### PR TITLE
Updated rules_bzlformat to 0.2.0

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -34,3 +34,44 @@ jobs:
       run: |
         bazelisk build //... 
 
+    - name: Ensure Bazel packages covered by bzlformat_pkg
+      shell: bash
+      run: |
+        bazelisk run //:bzlformat_missing_pkgs_test
+
+  ubuntu_build:
+
+    runs-on: ubuntu-20.04
+
+    env:
+      CC: clang
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Write local.bazelrc File
+      shell: bash
+      run: |
+        cat >local.bazelrc <<EOF
+        common --config=ci
+        EOF
+
+    - name: Output the Bazel Info
+      shell: bash
+      run: |
+        bazelisk info
+
+    - name: Execute Tests
+      shell: bash
+      run: |
+        bazelisk test //... 
+
+    - name: Build Anything Not Tested
+      shell: bash
+      run: |
+        bazelisk build //... 
+
+    - name: Ensure Bazel packages covered by bzlformat_pkg
+      shell: bash
+      run: |
+        bazelisk run //:bzlformat_missing_pkgs_test

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,8 @@
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load(
+    "@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl",
+    "bzlformat_missing_pkgs",
+    "bzlformat_pkg",
+)
 load(
     "@cgrindel_rules_updatesrc//updatesrc:updatesrc.bzl",
     "updatesrc_update_all",
@@ -6,9 +10,14 @@ load(
 
 bzlformat_pkg(name = "bzlformat")
 
+bzlformat_missing_pkgs(
+    name = "bzlformat_missing_pkgs",
+)
+
 updatesrc_update_all(
     name = "update_all",
     targets_to_run = [
         "//doc:update",
+        ":bzlformat_missing_pkgs_fix",
     ],
 )

--- a/deps.bzl
+++ b/deps.bzl
@@ -23,7 +23,7 @@ def bazel_starlib_dependencies():
     maybe(
         http_archive,
         name = "cgrindel_rules_bzlformat",
-        sha256 = "b45b392613092b42c4ee94051be104b990e3c8651dea17410dfd63b98957cd57",
-        strip_prefix = "rules_bzlformat-0.1.0",
-        urls = ["https://github.com/cgrindel/rules_bzlformat/archive/v0.1.0.tar.gz"],
+        sha256 = "df22d867e661de66a255a994caf814ff66426a43873194575bcaaaf9b9ad89ed",
+        strip_prefix = "rules_bzlformat-0.2.0",
+        urls = ["https://github.com/cgrindel/rules_bzlformat/archive/v0.2.0.tar.gz"],
     )


### PR DESCRIPTION
Closes #5.

- Updated rules_bzlformat to 0.2.0.
- Added Ubuntu CI runner.