### PR TITLE
Generate a changelog using Github API

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -36,8 +36,16 @@ jobs:
 
     - name: Execute Integration Tests
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         bazelisk test //:all_integration_tests
+
+    - name: DEBUG STOP
+      shell: bash
+      run: |
+        exit 1
+
 
     - name: Ensure Bazel packages covered by bzlformat_pkg
       shell: bash

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -41,12 +41,6 @@ jobs:
       run: |
         bazelisk test //:all_integration_tests
 
-    - name: DEBUG STOP
-      shell: bash
-      run: |
-        exit 1
-
-
     - name: Ensure Bazel packages covered by bzlformat_pkg
       shell: bash
       run: |
@@ -86,6 +80,8 @@ jobs:
 
     - name: Execute Integration Tests
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         bazelisk test //:all_integration_tests
 

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -34,6 +34,11 @@ jobs:
       run: |
         bazelisk build //... 
 
+    - name: Execute Integration Tests
+      shell: bash
+      run: |
+        bazelisk test //:all_integration_tests
+
     - name: Ensure Bazel packages covered by bzlformat_pkg
       shell: bash
       run: |
@@ -70,6 +75,11 @@ jobs:
       shell: bash
       run: |
         bazelisk build //... 
+
+    - name: Execute Integration Tests
+      shell: bash
+      run: |
+        bazelisk test //:all_integration_tests
 
     - name: Ensure Bazel packages covered by bzlformat_pkg
       shell: bash

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -33,6 +33,7 @@ test_suite(
         "manual",
     ],
     tests = [
+        "//tests/lib_tests/private_tests/github_tests:integration_tests",
         "//tests/tools_tests:integration_tests",
     ],
     visibility = ["//:__subpackages__"],

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -24,37 +24,16 @@ updatesrc_update_all(
     ],
 )
 
-# MARK: - Release Artifact
+# MARK: - Integration Tests
 
-filegroup(
-    name = "package_content",
-    srcs = [
-        "BUILD.bazel",
-        "WORKSPACE",
-        "LICENSE",
-        "README.md",
-        ".bazelrc",
-    ] + glob([
-        "*.bzl",
-        "*.bazelrc",
-    ]),
-)
-
-pkg_tar(
-    name = "bazel_starlib",
-    srcs = [
-        "//:package_content",
-        "//doc:package_content",
-        "//lib:package_content",
-        "//rules:package_content",
+test_suite(
+    name = "all_integration_tests",
+    tags = [
+        "exclusive",
+        "manual",
     ],
-    extension = "tar.gz",
-)
-
-workspace_snippet(
-    name = "bazel_starlib_workspace",
-    pkg = ":bazel_starlib",
-    url_templates = [
-        "http://github.com/cgrindel/bazel-starlib/releases/download/${STABLE_CURRENT_RELEASE_TAG}/bazel-starlib-${STABLE_CURRENT_RELEASE}.tar.gz",
+    tests = [
+        "//tests/tools_tests:integration_tests",
     ],
+    visibility = ["//:__subpackages__"],
 )

--- a/lib/private/BUILD.bazel
+++ b/lib/private/BUILD.bazel
@@ -21,3 +21,30 @@ sh_library(
         "//tools:__subpackages__",
     ],
 )
+
+sh_library(
+    name = "env",
+    srcs = ["env.sh"],
+    visibility = [
+        "//tests:__subpackages__",
+        "//tools:__subpackages__",
+    ],
+)
+
+sh_library(
+    name = "git",
+    srcs = ["git.sh"],
+    visibility = [
+        "//tests:__subpackages__",
+        "//tools:__subpackages__",
+    ],
+)
+
+sh_library(
+    name = "github",
+    srcs = ["github.sh"],
+    visibility = [
+        "//tests:__subpackages__",
+        "//tools:__subpackages__",
+    ],
+)

--- a/lib/private/env.sh
+++ b/lib/private/env.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Environment-related Functions
+
+# This is used to determine if the library has been loaded
+cgrindel_bazel_starlib_lib_private_env_loaded() { return; }
+
+# Succeeds if the specified executable is found in the path. Otherwise, it fails.
+is_installed() {
+  local name="${1}"
+  which "${name}" > /dev/null
+}
+

--- a/lib/private/git.sh
+++ b/lib/private/git.sh
@@ -14,7 +14,7 @@ get_git_remote_url() {
 }
 
 fetch_latest_from_git_remote() { 
-  git fetch
+  git fetch 2> /dev/null
 }
 
 get_latest_git_commit_hash() {

--- a/lib/private/git.sh
+++ b/lib/private/git.sh
@@ -13,3 +13,25 @@ get_git_remote_url() {
   git config --get remote.origin.url
 }
 
+fetch_latest_from_git_remote() { 
+  git fetch
+}
+
+get_latest_git_commit_hash() {
+  local branch="${1:-}"
+  git log -n 1 --pretty=format:'%H' "${branch:-}"
+}
+
+# Returns the list of release tags sorted by most recent to oldest.
+get_git_release_tags() {
+  git tag --sort=refname -l "v*"
+}
+
+git_tag_exists() {
+  local target_tag="${1}"
+  tags=( get_git_tags )
+  for tag in "${tags[@]}" ; do
+    [[ "${tag}" == "${target_tag}" ]] && return
+  done
+  return -1
+}

--- a/lib/private/git.sh
+++ b/lib/private/git.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Git-related Functions
+
+# This is used to determine if the library has been loaded
+cgrindel_bazel_starlib_lib_private_git_loaded() { return; }
+
+# Returns the URL for the git repository. It is typically in the form:
+#  git@github.com:cgrindel/bazel-starlib.git
+# OR 
+#  https://github.com/cgrindel/bazel-starlib.git
+get_git_remote_url() {
+  git config --get remote.origin.url
+}
+

--- a/lib/private/github.sh
+++ b/lib/private/github.sh
@@ -110,38 +110,9 @@ get_gh_changelog() {
     esac
   done
 
-  # [[ ${#args[@]} == 0 ]] && fail "Expected an api_base_url."
-  # local api_base_url="${args[0]}"
-  # [[ -z "${tag_name:-}" ]] && fail "Expected a tag_name."
-
+  [[ ${#args[@]} > 0 ]] && fail "Received positional args when none were expected. args: ${args[@]}"
   [[ ${#api_args[@]} == 0 ]] && fail "Expected one or more API args."
 
-  # DEBUG BEGIN
-  set -x
-  # DEBUG END
-
+  # Execute the API call
   gh api repos/{owner}/{repo}/releases/generate-notes "${api_args[@]}" --jq '.body'
-
-  # local request_data='{}'
-  # for (( i = 0; i < ${#api_args[@]}; i = i + 2 )); do
-  #   local arg_name="${api_args[$i]}"
-  #   local arg_value="${api_args[$i + 1]}"
-  #   request_data="$( 
-  #     echo "${request_data}" | \
-  #       jq \
-  #         --arg arg_name "${arg_name}" \
-  #         --arg arg_value "${arg_value}" \
-  #         '. + {($arg_name) : $arg_value}'
-  #   )"
-  # done
-
-  # # Execute the API
-  # local api_url="${api_base_url}/releases/generate-notes"
-  # curl \
-  #   --silent \
-  #   -u "cgrindel:${auth_token}" \
-  #   -X POST \
-  #   -H "Accept: application/vnd.github.v3+json" \
-  #   "${api_url}" \
-  #   -d "${request_data}"
 }

--- a/lib/private/github.sh
+++ b/lib/private/github.sh
@@ -98,18 +98,6 @@ get_gh_changelog() {
   local api_args=()
   while (("$#")); do
     case "${1}" in
-      # "--tag_name")
-      #   local tag_name="${2}"
-      #   shift 2
-      #   ;;
-      # "--target_commitish")
-      #   local target_commitish="${2}"
-      #   shift 2
-      #   ;;
-      # "--previous_tag_name")
-      #   local previous_tag_name="${2}"
-      #   shift 2
-      #   ;;
       --*)
         # Add the arg name and the value to the api args array
         api_args+=("${1:2}" "${2}")
@@ -126,16 +114,7 @@ get_gh_changelog() {
   local api_base_url="${args[0]}"
   [[ -z "${tag_name:-}" ]] && fail "Expected a tag_name."
 
-  local api_url="${api_base_url}/releases/generate-notes"
-
-  # local request_data="$(
-  #   jq -n \
-  #     --arg tag_name "${tag_name}" \
-  #     --arg target_commitish "${target_commit}" \
-  #     '{tag_name: $tag_name, target_commitish: $target_commitish}'
-  # )"
   local request_data='{}'
-  # local pairs_count=$(( ${#api_args[@]} / 2 ))
   for (( i = 0; i < ${#api_args[@]}; i = i + 2 )); do
     local arg_name="${api_args[$i]}"
     local arg_value="${api_args[$i + 1]}"
@@ -149,7 +128,9 @@ get_gh_changelog() {
   done
 
   # Execute the API
+  local api_url="${api_base_url}/releases/generate-notes"
   curl \
+    --silent \
     -u "cgrindel:${auth_token}" \
     -X POST \
     -H "Accept: application/vnd.github.v3+json" \

--- a/lib/private/github.sh
+++ b/lib/private/github.sh
@@ -8,6 +8,7 @@ cgrindel_bazel_starlib_lib_private_github_loaded() { return; }
 # MARK - Github Auth Status Functions
 
 # Returns the raw gh auth status displyaing the auth token.
+# Doc: https://cli.github.com/manual/gh_auth_status
 get_gh_auth_status() {
   gh auth status -t 2>&1
 }
@@ -94,7 +95,9 @@ get_gh_api_base_url() {
   echo "https://api.github.com/repos/${owner}/${name}"
 }
 
-# Generates a changelog markdown using the Github API
+# Generates a changelog markdown using the Github API.
+# Doc: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes
+# API: https://docs.github.com/en/rest/reference/repos#generate-release-notes-content-for-a-release
 get_gh_changelog() {
   local args=()
   local api_args=(--method POST)

--- a/lib/private/github.sh
+++ b/lib/private/github.sh
@@ -47,5 +47,5 @@ is_github_repo_url() {
 
 get_gh_repo_owner() {
   local repo_url="${1}"
-
+  echo ""
 }

--- a/lib/private/github.sh
+++ b/lib/private/github.sh
@@ -37,7 +37,7 @@ get_gh_auth_token() {
 _github_url_patterns=(git@github.com https://github.com)
 
 # Succeeds if the URL is a Github repo URL. Otherwise, it fails.
-is_git_repo_url() {
+is_github_repo_url() {
   local repo_url="${1}"
   for pattern in "${_github_url_patterns[@]}" ; do
     [[ "${repo_url}" =~ "${pattern}" ]] && return

--- a/lib/private/github.sh
+++ b/lib/private/github.sh
@@ -46,9 +46,12 @@ _github_url_patterns+=(git@github.com:)
 _github_url_owner_sed_cmds+=('s|git@[^:]+:([^/]+).*|\1|gp')
 
 # Example: https://github.com/cgrindel/bazel-starlib.git
-_github_url_patterns+=(https://github.com)
+_github_url_patterns+=(https://github.com/)
 _github_url_owner_sed_cmds+=('s|https://github.com/([^/]+)/.*|\1|gp')
 
+# Example: https://api.github.com/repos/cgrindel/bazel-starlib
+_github_url_patterns+=(https://api.github.com/repos/)
+_github_url_owner_sed_cmds+=('s|https://api.github.com/repos/([^/]+)/.*|\1|gp')
 
 # Returns the index for the Github URL pattern. This index can be used look up
 # owner and repo name.
@@ -79,4 +82,13 @@ get_gh_repo_owner() {
 get_gh_repo_name() {
   local repo_url="${1}"
   basename -s .git "${repo_url}"
+}
+
+# MARK - Github API Functions
+
+get_gh_api_base_url() {
+  local repo_url="${1}"
+  local owner="$( get_gh_repo_owner "${repo_url}" )"
+  local name="$( get_gh_repo_name "${repo_url}" )"
+  echo "https://api.github.com/repos/${owner}/${name}"
 }

--- a/lib/private/github.sh
+++ b/lib/private/github.sh
@@ -86,6 +86,7 @@ get_gh_repo_name() {
 
 # MARK - Github API Functions
 
+# Returns a base URL suitable for API calls.
 get_gh_api_base_url() {
   local repo_url="${1}"
   local owner="$( get_gh_repo_owner "${repo_url}" )"
@@ -93,6 +94,7 @@ get_gh_api_base_url() {
   echo "https://api.github.com/repos/${owner}/${name}"
 }
 
+# Generates a changelog markdown using the Github API
 get_gh_changelog() {
   local args=()
   local api_args=(--method POST)

--- a/lib/private/github.sh
+++ b/lib/private/github.sh
@@ -5,6 +5,8 @@
 # This is used to determine if the library has been loaded
 cgrindel_bazel_starlib_lib_private_github_loaded() { return; }
 
+# MARK - Github Auth Status Functions
+
 # Returns the raw gh auth status displyaing the auth token.
 get_gh_auth_status() {
   gh auth status -t
@@ -33,18 +35,20 @@ get_gh_auth_token() {
     sed -E -n 's/^.* Token:[[:space:]]+([^[:space:]]+).*/\1/gp'
 }
 
+# MARK - Github Repo URL Functions
+
 # List of valid Github URL patterns
 _github_url_patterns=()
 _github_url_owner_sed_cmds=()
 
-
-# git@github.com:cgrindel/bazel-starlib.git
+# Example: git@github.com:cgrindel/bazel-starlib.git
 _github_url_patterns+=(git@github.com:)
 _github_url_owner_sed_cmds+=('s|git@[^:]+:([^/]+).*|\1|gp')
 
-# https://github.com/cgrindel/bazel-starlib.git
+# Example: https://github.com/cgrindel/bazel-starlib.git
 _github_url_patterns+=(https://github.com)
 _github_url_owner_sed_cmds+=('s|https://github.com/([^/]+)/.*|\1|gp')
+
 
 # Returns the index for the Github URL pattern. This index can be used look up
 # owner and repo name.
@@ -69,4 +73,10 @@ get_gh_repo_owner() {
   local pattern_index=$( _get_github_repo_pattern_index "${repo_url}" )
   local sed_cmd="${_github_url_owner_sed_cmds[${pattern_index}]}"
   echo "${repo_url}" | sed -E -n "${sed_cmd}"
+}
+
+# Return the Github repository name from the repository URL.
+get_gh_repo_name() {
+  local repo_url="${1}"
+  basename -s .git "${repo_url}"
 }

--- a/lib/private/github.sh
+++ b/lib/private/github.sh
@@ -95,12 +95,12 @@ get_gh_api_base_url() {
 
 get_gh_changelog() {
   local args=()
-  local api_args=()
+  local api_args=(--method POST)
   while (("$#")); do
     case "${1}" in
       --*)
         # Add the arg name and the value to the api args array
-        api_args+=("${1:2}" "${2}")
+        api_args+=(-F "${1:2}=${2}")
         shift 2
         ;;
       *)
@@ -110,30 +110,38 @@ get_gh_changelog() {
     esac
   done
 
-  [[ ${#args[@]} == 0 ]] && fail "Expected an api_base_url."
-  local api_base_url="${args[0]}"
-  [[ -z "${tag_name:-}" ]] && fail "Expected a tag_name."
+  # [[ ${#args[@]} == 0 ]] && fail "Expected an api_base_url."
+  # local api_base_url="${args[0]}"
+  # [[ -z "${tag_name:-}" ]] && fail "Expected a tag_name."
 
-  local request_data='{}'
-  for (( i = 0; i < ${#api_args[@]}; i = i + 2 )); do
-    local arg_name="${api_args[$i]}"
-    local arg_value="${api_args[$i + 1]}"
-    request_data="$( 
-      echo "${request_data}" | \
-        jq \
-          --arg arg_name "${arg_name}" \
-          --arg arg_value "${arg_value}" \
-          '. + {($arg_name) : $arg_value}'
-    )"
-  done
+  [[ ${#api_args[@]} == 0 ]] && fail "Expected one or more API args."
 
-  # Execute the API
-  local api_url="${api_base_url}/releases/generate-notes"
-  curl \
-    --silent \
-    -u "cgrindel:${auth_token}" \
-    -X POST \
-    -H "Accept: application/vnd.github.v3+json" \
-    "${api_url}" \
-    -d "${request_data}"
+  # DEBUG BEGIN
+  set -x
+  # DEBUG END
+
+  gh api repos/{owner}/{repo}/releases/generate-notes "${api_args[@]}" --jq '.body'
+
+  # local request_data='{}'
+  # for (( i = 0; i < ${#api_args[@]}; i = i + 2 )); do
+  #   local arg_name="${api_args[$i]}"
+  #   local arg_value="${api_args[$i + 1]}"
+  #   request_data="$( 
+  #     echo "${request_data}" | \
+  #       jq \
+  #         --arg arg_name "${arg_name}" \
+  #         --arg arg_value "${arg_value}" \
+  #         '. + {($arg_name) : $arg_value}'
+  #   )"
+  # done
+
+  # # Execute the API
+  # local api_url="${api_base_url}/releases/generate-notes"
+  # curl \
+  #   --silent \
+  #   -u "cgrindel:${auth_token}" \
+  #   -X POST \
+  #   -H "Accept: application/vnd.github.v3+json" \
+  #   "${api_url}" \
+  #   -d "${request_data}"
 }

--- a/lib/private/github.sh
+++ b/lib/private/github.sh
@@ -34,18 +34,39 @@ get_gh_auth_token() {
 }
 
 # List of valid Github URL patterns
-_github_url_patterns=(git@github.com https://github.com)
+_github_url_patterns=()
+_github_url_owner_sed_cmds=()
 
-# Succeeds if the URL is a Github repo URL. Otherwise, it fails.
-is_github_repo_url() {
+
+# git@github.com:cgrindel/bazel-starlib.git
+_github_url_patterns+=(git@github.com:)
+_github_url_owner_sed_cmds+=('s|git@[^:]+:([^/]+).*|\1|gp')
+
+# https://github.com/cgrindel/bazel-starlib.git
+_github_url_patterns+=(https://github.com)
+_github_url_owner_sed_cmds+=('s|https://github.com/([^/]+)/.*|\1|gp')
+
+# Returns the index for the Github URL pattern. This index can be used look up
+# owner and repo name.
+_get_github_repo_pattern_index() {
   local repo_url="${1}"
-  for pattern in "${_github_url_patterns[@]}" ; do
-    [[ "${repo_url}" =~ "${pattern}" ]] && return
+  for (( i = 0; i < ${#_github_url_patterns[@]}; i++ )); do
+    pattern="${_github_url_patterns[$i]}"
+    [[ "${repo_url}" =~ "${pattern}" ]] && echo $i && return
   done
   return -1
 }
 
+# Succeeds if the URL is a Github repo URL. Otherwise, it fails.
+is_github_repo_url() {
+  local repo_url="${1}"
+  _get_github_repo_pattern_index "${repo_url}" > /dev/null
+}
+
+# Return the Github repository owner from the repository URL.
 get_gh_repo_owner() {
   local repo_url="${1}"
-  echo ""
+  local pattern_index=$( _get_github_repo_pattern_index "${repo_url}" )
+  local sed_cmd="${_github_url_owner_sed_cmds[${pattern_index}]}"
+  echo "${repo_url}" | sed -E -n "${sed_cmd}"
 }

--- a/lib/private/github.sh
+++ b/lib/private/github.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# Github-related Functions
+
+# This is used to determine if the library has been loaded
+cgrindel_bazel_starlib_lib_private_github_loaded() { return; }
+
+# Returns the raw gh auth status displyaing the auth token.
+get_gh_auth_status() {
+  gh auth status -t
+}
+
+# Example gh auth status:
+# $ gh auth status
+# github.com
+#   ✓ Logged in to github.com as cgrindel (/Users/chuck/.config/gh/hosts.yml)
+#   ✓ Git operations for github.com configured to use ssh protocol.
+#   ✓ Token: *******************
+
+# Returns the current user's username from the auth status.
+get_gh_username() {
+  local auth_status="${1:-}"
+  [[ -z "${auth_status}" ]] && auth_status="$( get_gh_auth_status )"
+  echo "${auth_status}" | \
+    sed -E -n 's/^.* Logged in to [^[:space:]]+ as ([^[:space:]]+).*/\1/gp'
+}
+
+# Returns the current user's auth token from the auth status.
+get_gh_auth_token() {
+  local auth_status="${1:-}"
+  [[ -z "${auth_status}" ]] && auth_status="$( get_gh_auth_status )"
+  echo "${auth_status}" | \
+    sed -E -n 's/^.* Token:[[:space:]]+([^[:space:]]+).*/\1/gp'
+}
+
+# List of valid Github URL patterns
+_github_url_patterns=(git@github.com https://github.com)
+
+# Succeeds if the URL is a Github repo URL. Otherwise, it fails.
+is_git_repo_url() {
+  local repo_url="${1}"
+  for pattern in "${_github_url_patterns[@]}" ; do
+    [[ "${repo_url}" =~ "${pattern}" ]] && return
+  done
+  return -1
+}
+
+get_gh_repo_owner() {
+  local repo_url="${1}"
+
+}

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
 load(":filter_srcs_tests.bzl", "filter_srcs_test_suite")
 load(":src_utils_tests.bzl", "src_utils_test_suite")
@@ -7,3 +8,8 @@ filter_srcs_test_suite()
 src_utils_test_suite()
 
 bzlformat_pkg(name = "bzlformat")
+
+bzl_library(
+    name = "integration_test_common",
+    srcs = ["integration_test_common.bzl"],
+)

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -13,3 +13,9 @@ bzl_library(
     name = "integration_test_common",
     srcs = ["integration_test_common.bzl"],
 )
+
+sh_library(
+    name = "setup_git_repo",
+    srcs = ["setup_git_repo.sh"],
+    visibility = ["//:__subpackages__"],
+)

--- a/tests/integration_test_common.bzl
+++ b/tests/integration_test_common.bzl
@@ -1,0 +1,12 @@
+INTEGRATION_TEST_TAGS = [
+    "exclusive",
+    "manual",
+]
+
+GH_ENV_INHERIT = [
+    # The HOME, GH_TOKEN, and GITHUB_TOKEN environment variables help the gh utility find
+    # its auth info.
+    "GITHUB_TOKEN",
+    "GH_TOKEN",
+    "HOME",
+]

--- a/tests/lib_tests/private_tests/github_tests/BUILD.bazel
+++ b/tests/lib_tests/private_tests/github_tests/BUILD.bazel
@@ -51,3 +51,13 @@ sh_test(
         "@bazel_tools//tools/bash/runfiles",
     ],
 )
+
+sh_test(
+    name = "get_gh_api_base_url_test",
+    srcs = ["get_gh_api_base_url_test.sh"],
+    deps = [
+        "//lib/private:fail",
+        "//lib/private:github",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)

--- a/tests/lib_tests/private_tests/github_tests/BUILD.bazel
+++ b/tests/lib_tests/private_tests/github_tests/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+
+bzlformat_pkg(name = "bzlformat")
+
+sh_test(
+    name = "get_gh_username_test",
+    srcs = ["get_gh_username_test.sh"],
+    deps = [
+        "//lib/private:fail",
+        "//lib/private:github",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)

--- a/tests/lib_tests/private_tests/github_tests/BUILD.bazel
+++ b/tests/lib_tests/private_tests/github_tests/BUILD.bazel
@@ -71,9 +71,9 @@ sh_test(
     env_inherit = GH_ENV_INHERIT,
     tags = INTEGRATION_TEST_TAGS,
     deps = [
+        "//lib/private:env",
         "//lib/private:fail",
         "//lib/private:github",
-        "//tests:setup_git_repo",
         "@bazel_tools//tools/bash/runfiles",
     ],
 )

--- a/tests/lib_tests/private_tests/github_tests/BUILD.bazel
+++ b/tests/lib_tests/private_tests/github_tests/BUILD.bazel
@@ -65,8 +65,6 @@ sh_test(
 
 # MARK: - Integration Tests
 
-# TODO: Add test for get_gh_changelog
-
 sh_test(
     name = "get_gh_auth_status_test",
     srcs = ["get_gh_auth_status_test.sh"],

--- a/tests/lib_tests/private_tests/github_tests/BUILD.bazel
+++ b/tests/lib_tests/private_tests/github_tests/BUILD.bazel
@@ -80,11 +80,26 @@ sh_test(
     ],
 )
 
+sh_test(
+    name = "get_gh_changelog_test",
+    srcs = ["get_gh_changelog_test.sh"],
+    env_inherit = GH_ENV_INHERIT,
+    tags = INTEGRATION_TEST_TAGS,
+    deps = [
+        "//lib/private:env",
+        "//lib/private:fail",
+        "//lib/private:github",
+        "//tests:setup_git_repo",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)
+
 test_suite(
     name = "integration_tests",
     tags = INTEGRATION_TEST_TAGS,
     tests = [
         ":get_gh_auth_status_test",
+        ":get_gh_changelog_test",
     ],
     visibility = ["//:__subpackages__"],
 )

--- a/tests/lib_tests/private_tests/github_tests/BUILD.bazel
+++ b/tests/lib_tests/private_tests/github_tests/BUILD.bazel
@@ -11,3 +11,13 @@ sh_test(
         "@bazel_tools//tools/bash/runfiles",
     ],
 )
+
+sh_test(
+    name = "get_gh_auth_token_test",
+    srcs = ["get_gh_auth_token_test.sh"],
+    deps = [
+        "//lib/private:fail",
+        "//lib/private:github",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)

--- a/tests/lib_tests/private_tests/github_tests/BUILD.bazel
+++ b/tests/lib_tests/private_tests/github_tests/BUILD.bazel
@@ -65,6 +65,8 @@ sh_test(
 
 # MARK: - Integration Tests
 
+# TODO: Add test for get_gh_changelog
+
 sh_test(
     name = "get_gh_auth_status_test",
     srcs = ["get_gh_auth_status_test.sh"],

--- a/tests/lib_tests/private_tests/github_tests/BUILD.bazel
+++ b/tests/lib_tests/private_tests/github_tests/BUILD.bazel
@@ -31,3 +31,13 @@ sh_test(
         "@bazel_tools//tools/bash/runfiles",
     ],
 )
+
+sh_test(
+    name = "get_gh_repo_owner_test",
+    srcs = ["get_gh_repo_owner_test.sh"],
+    deps = [
+        "//lib/private:fail",
+        "//lib/private:github",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)

--- a/tests/lib_tests/private_tests/github_tests/BUILD.bazel
+++ b/tests/lib_tests/private_tests/github_tests/BUILD.bazel
@@ -21,3 +21,13 @@ sh_test(
         "@bazel_tools//tools/bash/runfiles",
     ],
 )
+
+sh_test(
+    name = "is_github_repo_url_test",
+    srcs = ["is_github_repo_url_test.sh"],
+    deps = [
+        "//lib/private:fail",
+        "//lib/private:github",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)

--- a/tests/lib_tests/private_tests/github_tests/BUILD.bazel
+++ b/tests/lib_tests/private_tests/github_tests/BUILD.bazel
@@ -41,3 +41,13 @@ sh_test(
         "@bazel_tools//tools/bash/runfiles",
     ],
 )
+
+sh_test(
+    name = "get_gh_repo_name_test",
+    srcs = ["get_gh_repo_name_test.sh"],
+    deps = [
+        "//lib/private:fail",
+        "//lib/private:github",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)

--- a/tests/lib_tests/private_tests/github_tests/BUILD.bazel
+++ b/tests/lib_tests/private_tests/github_tests/BUILD.bazel
@@ -73,6 +73,7 @@ sh_test(
     deps = [
         "//lib/private:fail",
         "//lib/private:github",
+        "//tests:setup_git_repo",
         "@bazel_tools//tools/bash/runfiles",
     ],
 )

--- a/tests/lib_tests/private_tests/github_tests/BUILD.bazel
+++ b/tests/lib_tests/private_tests/github_tests/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("//tests:integration_test_common.bzl", "GH_ENV_INHERIT", "INTEGRATION_TEST_TAGS")
 
 bzlformat_pkg(name = "bzlformat")
 
@@ -60,4 +61,27 @@ sh_test(
         "//lib/private:github",
         "@bazel_tools//tools/bash/runfiles",
     ],
+)
+
+# MARK: - Integration Tests
+
+sh_test(
+    name = "get_gh_auth_status_test",
+    srcs = ["get_gh_auth_status_test.sh"],
+    env_inherit = GH_ENV_INHERIT,
+    tags = INTEGRATION_TEST_TAGS,
+    deps = [
+        "//lib/private:fail",
+        "//lib/private:github",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)
+
+test_suite(
+    name = "integration_tests",
+    tags = INTEGRATION_TEST_TAGS,
+    tests = [
+        ":get_gh_auth_status_test",
+    ],
+    visibility = ["//:__subpackages__"],
 )

--- a/tests/lib_tests/private_tests/github_tests/generate_gh_changelog_test.sh
+++ b/tests/lib_tests/private_tests/github_tests/generate_gh_changelog_test.sh
@@ -28,9 +28,17 @@ github_sh="$(rlocation "${github_sh_location}")" || \
   (echo >&2 "Failed to locate ${github_sh_location}" && exit 1)
 source "${github_sh}"
 
+setup_git_repo_sh_location=cgrindel_bazel_starlib/tests/setup_git_repo.sh
+setup_git_repo_sh="$(rlocation "${setup_git_repo_sh_location}")" || \
+  (echo >&2 "Failed to locate ${setup_git_repo_sh_location}" && exit 1)
+
 is_installed gh || fail "Could not find Github CLI (gh)."
+
+# MARK - Setup
+
+source "${setup_git_repo_sh}"
+cd "${repo_dir}"
 
 # MARK - Test
 
-result="$( get_gh_auth_status )"
-[[ "${result}" =~ "Logged in to " ]] || fail "Expected auth status to indicate a user is logged in."
+fail "IMPLEMENT ME!"

--- a/tests/lib_tests/private_tests/github_tests/get_gh_api_base_url_test.sh
+++ b/tests/lib_tests/private_tests/github_tests/get_gh_api_base_url_test.sh
@@ -29,14 +29,14 @@ source "${github_sh}"
 urls=()
 urls+=(git@github.com:cgrindel/bazel-starlib.git)
 urls+=(git@github.com:cgrindel/bazel-starlib)
-urls+=(https://github.com/foo_bar/bazel-starlib.git)
-urls+=(https://github.com/chicken-smidgen/bazel-starlib)
-urls+=(https://api.github.com/repos/chicken-smidgen/bazel-starlib)
+urls+=(https://github.com/cgrindel/bazel-starlib.git)
+urls+=(https://github.com/cgrindel/bazel-starlib)
+urls+=(https://api.github.com/repos/cgrindel/bazel-starlib)
 
-expected=bazel-starlib
-for (( i = 0; i < ${#urls[@]}; i++ )); do
-  url="${urls[$i]}"
-  actual="$( get_gh_repo_name "${url}" )"
+expected="https://api.github.com/repos/cgrindel/bazel-starlib"
+for url in "${urls[@]}" ; do
+  actual="$( get_gh_api_base_url "${url}" )"
   [[ "${actual}" == "${expected}" ]] || \
-    fail "Expected name not found. url: ${url}, expected: ${expected}, actual: ${actual}"
+    fail "Expected base API URL not found. url: ${url}, expected: ${expected}, actual: ${actual}"
 done
+

--- a/tests/lib_tests/private_tests/github_tests/get_gh_auth_status_test.sh
+++ b/tests/lib_tests/private_tests/github_tests/get_gh_auth_status_test.sh
@@ -18,21 +18,28 @@ fail_sh="$(rlocation "${fail_sh_location}")" || \
   (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
 source "${fail_sh}"
 
+env_sh_location=cgrindel_bazel_starlib/lib/private/env.sh
+env_sh="$(rlocation "${env_sh_location}")" || \
+  (echo >&2 "Failed to locate ${env_sh_location}" && exit 1)
+source "${env_sh}"
+
 github_sh_location=cgrindel_bazel_starlib/lib/private/github.sh
 github_sh="$(rlocation "${github_sh_location}")" || \
   (echo >&2 "Failed to locate ${github_sh_location}" && exit 1)
 source "${github_sh}"
 
-setup_git_repo_sh_location=cgrindel_bazel_starlib/tests/setup_git_repo.sh
-setup_git_repo_sh="$(rlocation "${setup_git_repo_sh_location}")" || \
-  (echo >&2 "Failed to locate ${setup_git_repo_sh_location}" && exit 1)
+# setup_git_repo_sh_location=cgrindel_bazel_starlib/tests/setup_git_repo.sh
+# setup_git_repo_sh="$(rlocation "${setup_git_repo_sh_location}")" || \
+#   (echo >&2 "Failed to locate ${setup_git_repo_sh_location}" && exit 1)
+
+is_installed gh || fail "Could not find Github CLI (gh)."
 
 # MARK - Setup
 
-source "${setup_git_repo_sh}"
-cd "${repo_dir}"
-
+# source "${setup_git_repo_sh}"
+# cd "${repo_dir}"
 
 # MARK - Test
 
-fail "IMPLEMENT ME!"
+result="$( get_gh_auth_status )"
+[[ "${result}" =~ "Logged in to " ]] || fail "Expected auth status to indicate a user is logged in."

--- a/tests/lib_tests/private_tests/github_tests/get_gh_auth_status_test.sh
+++ b/tests/lib_tests/private_tests/github_tests/get_gh_auth_status_test.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+# MARK - Locate Dependencies
+
+fail_sh_location=cgrindel_bazel_starlib/lib/private/fail.sh
+fail_sh="$(rlocation "${fail_sh_location}")" || \
+  (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
+source "${fail_sh}"
+
+github_sh_location=cgrindel_bazel_starlib/lib/private/github.sh
+github_sh="$(rlocation "${github_sh_location}")" || \
+  (echo >&2 "Failed to locate ${github_sh_location}" && exit 1)
+source "${github_sh}"
+
+
+# MARK - Test
+
+fail "IMPLEMENT ME!"

--- a/tests/lib_tests/private_tests/github_tests/get_gh_auth_status_test.sh
+++ b/tests/lib_tests/private_tests/github_tests/get_gh_auth_status_test.sh
@@ -23,6 +23,15 @@ github_sh="$(rlocation "${github_sh_location}")" || \
   (echo >&2 "Failed to locate ${github_sh_location}" && exit 1)
 source "${github_sh}"
 
+setup_git_repo_sh_location=cgrindel_bazel_starlib/tests/setup_git_repo.sh
+setup_git_repo_sh="$(rlocation "${setup_git_repo_sh_location}")" || \
+  (echo >&2 "Failed to locate ${setup_git_repo_sh_location}" && exit 1)
+
+# MARK - Setup
+
+source "${setup_git_repo_sh}"
+cd "${repo_dir}"
+
 
 # MARK - Test
 

--- a/tests/lib_tests/private_tests/github_tests/get_gh_auth_token_test.sh
+++ b/tests/lib_tests/private_tests/github_tests/get_gh_auth_token_test.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+fail_sh_location=cgrindel_bazel_starlib/lib/private/fail.sh
+fail_sh="$(rlocation "${fail_sh_location}")" || \
+  (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
+source "${fail_sh}"
+
+github_sh_location=cgrindel_bazel_starlib/lib/private/github.sh
+github_sh="$(rlocation "${github_sh_location}")" || \
+  (echo >&2 "Failed to locate ${github_sh_location}" && exit 1)
+source "${github_sh}"
+
+
+# MARK - Test
+
+auth_status="
+github.com
+  ✓ Logged in to github.com as cgrindel (/Users/chuck/.config/gh/hosts.yml)
+  ✓ Git operations for github.com configured to use ssh protocol.
+  ✓ Token: 1234567899b95cd24c3e91d210388a28bf560b73
+"
+
+expected="1234567899b95cd24c3e91d210388a28bf560b73"
+actual="$( get_gh_auth_token "${auth_status}" )"
+[[ "${actual}" == "${expected}" ]] || \
+  fail "Expected auth token not found. actual: ${actual}, expected: ${expected}"

--- a/tests/lib_tests/private_tests/github_tests/get_gh_changelog_test.sh
+++ b/tests/lib_tests/private_tests/github_tests/get_gh_changelog_test.sh
@@ -41,4 +41,9 @@ cd "${repo_dir}"
 
 # MARK - Test
 
-fail "IMPLEMENT ME!"
+tag_name="v0.1.1"
+prev_tag_name="v0.1.0"
+result="$( get_gh_changelog --tag_name  "${tag_name}" --previous_tag_name "${prev_tag_name}" )"
+[[ "${result}" =~ "**Full Changelog**: https://github.com/cgrindel/bazel-starlib/compare/v0.1.0...v0.1.1" ]] || \
+  fail "Expected to find changelog URL for v0.1.0...v0.1.1. result: ${result}"
+

--- a/tests/lib_tests/private_tests/github_tests/get_gh_repo_name_test.sh
+++ b/tests/lib_tests/private_tests/github_tests/get_gh_repo_name_test.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+# MARK - Locate Dependencies
+
+fail_sh_location=cgrindel_bazel_starlib/lib/private/fail.sh
+fail_sh="$(rlocation "${fail_sh_location}")" || \
+  (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
+source "${fail_sh}"
+
+github_sh_location=cgrindel_bazel_starlib/lib/private/github.sh
+github_sh="$(rlocation "${github_sh_location}")" || \
+  (echo >&2 "Failed to locate ${github_sh_location}" && exit 1)
+source "${github_sh}"
+
+
+# MARK - Test
+
+urls=()
+urls+=(git@github.com:cgrindel/bazel-starlib.git)
+urls+=(git@github.com:cgrindel/bazel-starlib)
+urls+=(https://github.com/foo_bar/bazel-starlib.git)
+urls+=(https://github.com/chicken-smidgen/bazel-starlib)
+
+expected=bazel-starlib
+for (( i = 0; i < ${#urls[@]}; i++ )); do
+  url="${urls[$i]}"
+  actual="$( get_gh_repo_name "${url}" )"
+  [[ "${actual}" == "${expected}" ]] || \
+    fail "Expected owner not found. url: ${url}, expected: ${expected}, actual: ${actual}"
+done

--- a/tests/lib_tests/private_tests/github_tests/get_gh_repo_owner_test.sh
+++ b/tests/lib_tests/private_tests/github_tests/get_gh_repo_owner_test.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+# MARK - Locate Dependencies
+
+fail_sh_location=cgrindel_bazel_starlib/lib/private/fail.sh
+fail_sh="$(rlocation "${fail_sh_location}")" || \
+  (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
+source "${fail_sh}"
+
+github_sh_location=cgrindel_bazel_starlib/lib/private/github.sh
+github_sh="$(rlocation "${github_sh_location}")" || \
+  (echo >&2 "Failed to locate ${github_sh_location}" && exit 1)
+source "${github_sh}"
+
+
+# MARK - Test
+
+urls=()
+urls+=(git@github.com:cgrindel/bazel-starlib.git)
+urls+=(https://github.com/foo_bar/bazel-starlib.git)
+urls+=(https://github.com/chicken-smidgen/bazel-starlib)
+
+expected_owners=()
+expected_owners+=(cgrindel)
+expected_owners+=(foo_bar)
+expected_owners+=(chicken-smidgen)
+
+for (( i = 0; i < ${#urls[@]}; i++ )); do
+  url="${urls[$i]}"
+  expected="${expected_owners[$i]}"
+  actual="$( get_gh_repo_owner "${url}" )"
+  [[ "${actual}" == "${expected}" ]] || fail "Expected owner not found. url: ${url}, expected: ${expected}, actual: ${actual}"
+done
+
+fail "IMPLEMENT ME!"

--- a/tests/lib_tests/private_tests/github_tests/get_gh_repo_owner_test.sh
+++ b/tests/lib_tests/private_tests/github_tests/get_gh_repo_owner_test.sh
@@ -40,7 +40,6 @@ for (( i = 0; i < ${#urls[@]}; i++ )); do
   url="${urls[$i]}"
   expected="${expected_owners[$i]}"
   actual="$( get_gh_repo_owner "${url}" )"
-  [[ "${actual}" == "${expected}" ]] || fail "Expected owner not found. url: ${url}, expected: ${expected}, actual: ${actual}"
+  [[ "${actual}" == "${expected}" ]] || \
+    fail "Expected owner not found. url: ${url}, expected: ${expected}, actual: ${actual}"
 done
-
-fail "IMPLEMENT ME!"

--- a/tests/lib_tests/private_tests/github_tests/get_gh_repo_owner_test.sh
+++ b/tests/lib_tests/private_tests/github_tests/get_gh_repo_owner_test.sh
@@ -30,10 +30,12 @@ urls=()
 urls+=(git@github.com:cgrindel/bazel-starlib.git)
 urls+=(https://github.com/foo_bar/bazel-starlib.git)
 urls+=(https://github.com/chicken-smidgen/bazel-starlib)
+urls+=(https://api.github.com/repos/chicken-smidgen/bazel-starlib)
 
 expected_owners=()
 expected_owners+=(cgrindel)
 expected_owners+=(foo_bar)
+expected_owners+=(chicken-smidgen)
 expected_owners+=(chicken-smidgen)
 
 for (( i = 0; i < ${#urls[@]}; i++ )); do

--- a/tests/lib_tests/private_tests/github_tests/get_gh_username_test.sh
+++ b/tests/lib_tests/private_tests/github_tests/get_gh_username_test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+fail_sh_location=cgrindel_bazel_starlib/lib/private/fail.sh
+fail_sh="$(rlocation "${fail_sh_location}")" || \
+  (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
+source "${fail_sh}"
+
+
+fail "IMPLEMENT ME!"

--- a/tests/lib_tests/private_tests/github_tests/get_gh_username_test.sh
+++ b/tests/lib_tests/private_tests/github_tests/get_gh_username_test.sh
@@ -16,5 +16,24 @@ fail_sh="$(rlocation "${fail_sh_location}")" || \
   (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
 source "${fail_sh}"
 
+github_sh_location=cgrindel_bazel_starlib/lib/private/github.sh
+github_sh="$(rlocation "${github_sh_location}")" || \
+  (echo >&2 "Failed to locate ${github_sh_location}" && exit 1)
+source "${github_sh}"
 
-fail "IMPLEMENT ME!"
+
+# MARK - Test
+
+auth_status="
+github.com
+  ✓ Logged in to github.com as cgrindel (/Users/chuck/.config/gh/hosts.yml)
+  ✓ Git operations for github.com configured to use ssh protocol.
+  ✓ Token: 1234567899b95cd24c3e91d210388a28bf560b73
+"
+
+expected="cgrindel"
+actual="$( get_gh_username "${auth_status}" )"
+[[ "${actual}" == "${expected}" ]] || \
+  fail "Expected username not found. actual: ${actual}, expected: ${expected}"
+# [[ "${actual}" == "${expected}" ]] || \
+#   fail "Expected token not found. actual: ${actual}, expected: ${expected}"

--- a/tests/lib_tests/private_tests/github_tests/get_gh_username_test.sh
+++ b/tests/lib_tests/private_tests/github_tests/get_gh_username_test.sh
@@ -37,5 +37,3 @@ expected="cgrindel"
 actual="$( get_gh_username "${auth_status}" )"
 [[ "${actual}" == "${expected}" ]] || \
   fail "Expected username not found. actual: ${actual}, expected: ${expected}"
-# [[ "${actual}" == "${expected}" ]] || \
-#   fail "Expected token not found. actual: ${actual}, expected: ${expected}"

--- a/tests/lib_tests/private_tests/github_tests/is_github_repo_url_test.sh
+++ b/tests/lib_tests/private_tests/github_tests/is_github_repo_url_test.sh
@@ -26,16 +26,23 @@ source "${github_sh}"
 
 # MARK - Test
 
-auth_status="
-github.com
-  ✓ Logged in to github.com as cgrindel (/Users/chuck/.config/gh/hosts.yml)
-  ✓ Git operations for github.com configured to use ssh protocol.
-  ✓ Token: 1234567899b95cd24c3e91d210388a28bf560b73
-"
+good_urls=()
+good_urls+=(git@github.com:cgrindel/bazel-starlib.git)
+good_urls+=(https://github.com/cgrindel/bazel-starlib.git)
+good_urls+=(https://github.com/cgrindel/bazel-starlib)
 
-expected="cgrindel"
-actual="$( get_gh_username "${auth_status}" )"
-[[ "${actual}" == "${expected}" ]] || \
-  fail "Expected username not found. actual: ${actual}, expected: ${expected}"
-# [[ "${actual}" == "${expected}" ]] || \
-#   fail "Expected token not found. actual: ${actual}, expected: ${expected}"
+for url in "${good_urls[@]}" ; do
+  is_github_repo_url "${url}" || fail "Expected '${url}' to be a Github URL."
+done
+
+bad_urls=()
+bad_urls+=(git@example.org:cgrindel/bazel-starlib.git)
+bad_urls+=(https://example.org/cgrindel/bazel-starlib.git)
+
+for url in "${bad_urls[@]}" ; do
+  is_github_repo_url "${url}" && fail "Expected '${url}' to not be a Github URL."
+done
+
+# Because the negative tests have failures when the test is working, we need to
+# end on a positive note.
+echo "ALL IS WELL"

--- a/tests/setup_git_repo.sh
+++ b/tests/setup_git_repo.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Clone this repo so that we have an actual git repository for the test
+repo_dir="${PWD}/repo"
+rm -rf "${repo_dir}"
+repo_url="https://github.com/cgrindel/bazel-starlib"
+git clone "${repo_url}" "${repo_dir}" 2>/dev/null
+
+# Any utilities under test need to know where the workspace directory is. In
+# this case, we are faking it out by setting it to our cloned repo directory.
+export "BUILD_WORKSPACE_DIRECTORY=${repo_dir}"

--- a/tests/tools_tests/BUILD.bazel
+++ b/tests/tools_tests/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("//tests:integration_test_common.bzl", "GH_ENV_INHERIT", "INTEGRATION_TEST_TAGS")
 
 bzlformat_pkg(name = "bzlformat")
 
@@ -46,17 +47,8 @@ sh_test(
     data = [
         "//tools:generate_gh_changelog",
     ],
-    env_inherit = [
-        # The HOME, GH_TOKEN, and GITHUB_TOKEN environment variables help the gh utility find
-        # its auth info.
-        "GITHUB_TOKEN",
-        "GH_TOKEN",
-        "HOME",
-    ],
-    tags = [
-        "exclusive",
-        "manual",
-    ],
+    env_inherit = GH_ENV_INHERIT,
+    tags = INTEGRATION_TEST_TAGS,
     deps = [
         "//lib/private:env",
         "@bazel_tools//tools/bash/runfiles",
@@ -65,10 +57,7 @@ sh_test(
 
 test_suite(
     name = "integration_tests",
-    tags = [
-        "exclusive",
-        "manual",
-    ],
+    tags = INTEGRATION_TEST_TAGS,
     tests = [
         ":generate_gh_changelog_test",
     ],

--- a/tests/tools_tests/BUILD.bazel
+++ b/tests/tools_tests/BUILD.bazel
@@ -37,3 +37,33 @@ sh_test(
         "@cgrindel_bazel_shlib//lib:assertions",
     ],
 )
+
+# MARK: - Integration Tests
+
+sh_test(
+    name = "generate_gh_changelog_test",
+    srcs = ["generate_gh_changelog_test.sh"],
+    data = [
+        "//tools:generate_gh_changelog",
+    ],
+    tags = [
+        "exclusive",
+        "manual",
+    ],
+    deps = [
+        "@bazel_tools//tools/bash/runfiles",
+        "@cgrindel_bazel_shlib//lib:assertions",
+    ],
+)
+
+test_suite(
+    name = "integration_tests",
+    tags = [
+        "exclusive",
+        "manual",
+    ],
+    tests = [
+        ":generate_gh_changelog_test",
+    ],
+    visibility = ["//:__subpackages__"],
+)

--- a/tests/tools_tests/BUILD.bazel
+++ b/tests/tools_tests/BUILD.bazel
@@ -47,8 +47,11 @@ sh_test(
         "//tools:generate_gh_changelog",
     ],
     env_inherit = [
+        # The HOME, GH_TOKEN, and GITHUB_TOKEN environment variables help the gh utility find
+        # its auth info.
         "GITHUB_TOKEN",
         "GH_TOKEN",
+        "HOME",
     ],
     tags = [
         "exclusive",

--- a/tests/tools_tests/BUILD.bazel
+++ b/tests/tools_tests/BUILD.bazel
@@ -51,6 +51,7 @@ sh_test(
     tags = INTEGRATION_TEST_TAGS,
     deps = [
         "//lib/private:env",
+        "//tests:setup_git_repo",
         "@bazel_tools//tools/bash/runfiles",
     ],
 )

--- a/tests/tools_tests/BUILD.bazel
+++ b/tests/tools_tests/BUILD.bazel
@@ -33,8 +33,8 @@ sh_test(
         "//tools:generate_sha256",
     ],
     deps = [
+        "//lib/private:fail",
         "@bazel_tools//tools/bash/runfiles",
-        "@cgrindel_bazel_shlib//lib:assertions",
     ],
 )
 
@@ -46,13 +46,17 @@ sh_test(
     data = [
         "//tools:generate_gh_changelog",
     ],
+    env_inherit = [
+        "GITHUB_TOKEN",
+        "GH_TOKEN",
+    ],
     tags = [
         "exclusive",
         "manual",
     ],
     deps = [
+        "//lib/private:env",
         "@bazel_tools//tools/bash/runfiles",
-        "@cgrindel_bazel_shlib//lib:assertions",
     ],
 )
 

--- a/tests/tools_tests/generate_gh_changelog_test.sh
+++ b/tests/tools_tests/generate_gh_changelog_test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+fail_sh_location=cgrindel_bazel_starlib/lib/private/fail.sh
+fail_sh="$(rlocation "${fail_sh_location}")" || \
+  (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
+source "${fail_sh}"
+
+
+fail "IMPLEMENT ME!"

--- a/tests/tools_tests/generate_gh_changelog_test.sh
+++ b/tests/tools_tests/generate_gh_changelog_test.sh
@@ -11,10 +11,46 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
+# MARK - Dependencies
+
 fail_sh_location=cgrindel_bazel_starlib/lib/private/fail.sh
 fail_sh="$(rlocation "${fail_sh_location}")" || \
   (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
 source "${fail_sh}"
 
+env_sh_location=cgrindel_bazel_starlib/lib/private/env.sh
+env_sh="$(rlocation "${env_sh_location}")" || \
+  (echo >&2 "Failed to locate ${env_sh_location}" && exit 1)
+source "${env_sh}"
+
+generate_gh_changelog_sh_location=cgrindel_bazel_starlib/tools/generate_gh_changelog.sh
+generate_gh_changelog_sh="$(rlocation "${generate_gh_changelog_sh_location}")" || \
+  (echo >&2 "Failed to locate ${generate_gh_changelog_sh_location}" && exit 1)
+
+is_installed git || fail "Could not find git."
+
+# MARK - Setup
+
+# Clone this repo so that we have an actual git repository for the test
+repo_dir="${PWD}/repo"
+rm -rf "${repo_dir}"
+repo_url="https://github.com/cgrindel/bazel-starlib"
+git clone "${repo_url}" "${repo_dir}"
+cd "${repo_dir}"
+export "BUILD_WORKSPACE_DIRECTORY=${repo_dir}"
+
+# DEBUG BEGIN
+echo >&2 "*** CHUCK  BUILD_WORKSPACE_DIRECTORY: ${BUILD_WORKSPACE_DIRECTORY}" 
+# DEBUG END
+
+# MARK - Test changelog between two known tags 
+
+tag_name="v0.1.1"
+prev_tag_name="v0.1.0"
+result="$( "${generate_gh_changelog_sh}" --previous_tag_name "${prev_tag_name}" "${tag_name}" )"
+
+# DEBUG BEGIN
+echo >&2 "*** CHUCK  result: ${result}" 
+# DEBUG END
 
 fail "IMPLEMENT ME!"

--- a/tests/tools_tests/generate_gh_changelog_test.sh
+++ b/tests/tools_tests/generate_gh_changelog_test.sh
@@ -27,20 +27,16 @@ generate_gh_changelog_sh_location=cgrindel_bazel_starlib/tools/generate_gh_chang
 generate_gh_changelog_sh="$(rlocation "${generate_gh_changelog_sh_location}")" || \
   (echo >&2 "Failed to locate ${generate_gh_changelog_sh_location}" && exit 1)
 
+setup_git_repo_sh_location=cgrindel_bazel_starlib/tests/setup_git_repo.sh
+setup_git_repo_sh="$(rlocation "${setup_git_repo_sh_location}")" || \
+  (echo >&2 "Failed to locate ${setup_git_repo_sh_location}" && exit 1)
+
 is_installed git || fail "Could not find git."
 
 # MARK - Setup
 
-# Clone this repo so that we have an actual git repository for the test
-repo_dir="${PWD}/repo"
-rm -rf "${repo_dir}"
-repo_url="https://github.com/cgrindel/bazel-starlib"
-git clone "${repo_url}" "${repo_dir}" 2>/dev/null
+source "${setup_git_repo_sh}"
 cd "${repo_dir}"
-
-# The utility needs to know where the workspace directory is. In this case, we are faking it out
-# by setting it to our cloned repo directory.
-export "BUILD_WORKSPACE_DIRECTORY=${repo_dir}"
 
 
 # MARK - Test changelog between two known tags 

--- a/tests/tools_tests/generate_gh_changelog_test.sh
+++ b/tests/tools_tests/generate_gh_changelog_test.sh
@@ -35,22 +35,26 @@ is_installed git || fail "Could not find git."
 repo_dir="${PWD}/repo"
 rm -rf "${repo_dir}"
 repo_url="https://github.com/cgrindel/bazel-starlib"
-git clone "${repo_url}" "${repo_dir}"
+git clone "${repo_url}" "${repo_dir}" 2>/dev/null
 cd "${repo_dir}"
+
+# The utility needs to know where the workspace directory is. In this case, we are faking it out
+# by setting it to our cloned repo directory.
 export "BUILD_WORKSPACE_DIRECTORY=${repo_dir}"
 
-# DEBUG BEGIN
-echo >&2 "*** CHUCK  BUILD_WORKSPACE_DIRECTORY: ${BUILD_WORKSPACE_DIRECTORY}" 
-# DEBUG END
 
 # MARK - Test changelog between two known tags 
 
 tag_name="v0.1.1"
 prev_tag_name="v0.1.0"
 result="$( "${generate_gh_changelog_sh}" --previous_tag_name "${prev_tag_name}" "${tag_name}" )"
+[[ "${result}" =~ "**Full Changelog**: https://github.com/cgrindel/bazel-starlib/compare/v0.1.0...v0.1.1" ]] || \
+  fail "Expected to find changelog URL for v0.1.0...v0.1.1. result: ${result}"
 
-# DEBUG BEGIN
-echo >&2 "*** CHUCK  result: ${result}" 
-# DEBUG END
 
-fail "IMPLEMENT ME!"
+# MARK - Test changelog to a new tag
+
+tag_name="v99999.0.0"
+result="$( "${generate_gh_changelog_sh}" "${tag_name}" )"
+match='[*][*]Full Changelog[*][*].*v9999'
+[[ "${result}" =~ $match ]] || fail "Expected to find changelog URL for ${tag_name}. result: ${result}"

--- a/tests/tools_tests/generate_sha256_test.sh
+++ b/tests/tools_tests/generate_sha256_test.sh
@@ -24,7 +24,7 @@ generate_sha256_sh="$(rlocation "${generate_sha256_sh_location}")" || \
 
 # MARK - Utilities Check
 
-utilities=(openssl sha256sum)
+utilities=(openssl shasum)
 utilities_to_test=()
 for utility in "${utilities[@]}" ; do
   which "${utility}" > /dev/null && utilities_to_test+=( "${utility}" )

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -47,12 +47,15 @@ sh_binary(
 sh_binary(
     name = "generate_gh_changelog",
     srcs = ["generate_gh_changelog.sh"],
-    data = [
-        ":get_gh_auth_token",
-    ],
+    # data = [
+    #     ":get_gh_auth_token",
+    # ],
     visibility = ["//visibility:public"],
     deps = [
+        "//lib/private:env",
         "//lib/private:fail",
+        "//lib/private:git",
+        "//lib/private:github",
         "@bazel_tools//tools/bash/runfiles",
     ],
 )

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -33,3 +33,13 @@ sh_binary(
         "@bazel_tools//tools/bash/runfiles",
     ],
 )
+
+sh_binary(
+    name = "get_gh_auth_token",
+    srcs = ["get_gh_auth_token.sh"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//lib/private:fail",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -43,3 +43,16 @@ sh_binary(
         "@bazel_tools//tools/bash/runfiles",
     ],
 )
+
+sh_binary(
+    name = "generate_gh_changelog",
+    srcs = ["generate_gh_changelog.sh"],
+    data = [
+        ":get_gh_auth_token",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//lib/private:fail",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)

--- a/tools/generate_gh_changelog.sh
+++ b/tools/generate_gh_changelog.sh
@@ -77,7 +77,6 @@ is_github_repo_url "${repo_url}" || \
 auth_status="$( get_gh_auth_status )"
 username="$( get_gh_username "${auth_status}" )"
 auth_token="$( get_gh_auth_token "${auth_status}")"
-# api_base_url="$( get_gh_api_base_url "${repo_url}" )"
 
 # Fetch the latest from origin
 fetch_latest_from_git_remote

--- a/tools/generate_gh_changelog.sh
+++ b/tools/generate_gh_changelog.sh
@@ -38,8 +38,8 @@ source "${github_sh}"
 
 is_installed gh || fail "Could not find Github CLI (gh)."
 is_installed git || fail "Could not find git."
-is_installed jq || fail "Could not find jq for JSON manipulation."
-is_installed curl || fail "Could not find curl for Github API execution."
+# is_installed jq || fail "Could not find jq for JSON manipulation."
+# is_installed curl || fail "Could not find curl for Github API execution."
 
 
 # MARK - Process Arguments
@@ -94,13 +94,14 @@ fi
 [[ -z "${previous_tag_name:-}" ]] || changelog_args+=(--previous_tag_name "${previous_tag_name}")
 
 # Generate the changelog
-response_json="$( get_gh_changelog "${changelog_args[@]}" )"
-changelog_md="$( echo "${response_json}" | jq '.body' )"
-# Evaluate the embedded newlines
-changelog_md="$( printf "%b\n" "${changelog_md}" )"
-# Remove the double quotes at beginning and end
-changelog_md="${changelog_md%\"}"
-changelog_md="${changelog_md#\"}"
+# response_json="$( get_gh_changelog "${changelog_args[@]}" )"
+# changelog_md="$( echo "${response_json}" | jq '.body' )"
+# # Evaluate the embedded newlines
+# changelog_md="$( printf "%b\n" "${changelog_md}" )"
+# # Remove the double quotes at beginning and end
+# changelog_md="${changelog_md%\"}"
+# changelog_md="${changelog_md#\"}"
+changelog_md="$( get_gh_changelog "${changelog_args[@]}" )"
 
 # Output the changelog
 if [[ -z "${output_path:-}" ]]; then

--- a/tools/generate_gh_changelog.sh
+++ b/tools/generate_gh_changelog.sh
@@ -38,8 +38,6 @@ source "${github_sh}"
 
 is_installed gh || fail "Could not find Github CLI (gh)."
 is_installed git || fail "Could not find git."
-# is_installed jq || fail "Could not find jq for JSON manipulation."
-# is_installed curl || fail "Could not find curl for Github API execution."
 
 
 # MARK - Process Arguments
@@ -79,13 +77,13 @@ is_github_repo_url "${repo_url}" || \
 auth_status="$( get_gh_auth_status )"
 username="$( get_gh_username "${auth_status}" )"
 auth_token="$( get_gh_auth_token "${auth_status}")"
-api_base_url="$( get_gh_api_base_url "${repo_url}" )"
+# api_base_url="$( get_gh_api_base_url "${repo_url}" )"
 
 # Fetch the latest from origin
 fetch_latest_from_git_remote
 
 # Construct the args for generating the changelog.
-changelog_args=( "${api_base_url}" )
+changelog_args=()
 changelog_args+=(--tag_name "${tag_name}")
 if ! git_tag_exists "${tag_name}"; then
   last_commit_on_main="$( get_latest_git_commit_hash "${remote_name}/${main_branch}" )"
@@ -94,13 +92,6 @@ fi
 [[ -z "${previous_tag_name:-}" ]] || changelog_args+=(--previous_tag_name "${previous_tag_name}")
 
 # Generate the changelog
-# response_json="$( get_gh_changelog "${changelog_args[@]}" )"
-# changelog_md="$( echo "${response_json}" | jq '.body' )"
-# # Evaluate the embedded newlines
-# changelog_md="$( printf "%b\n" "${changelog_md}" )"
-# # Remove the double quotes at beginning and end
-# changelog_md="${changelog_md%\"}"
-# changelog_md="${changelog_md#\"}"
 changelog_md="$( get_gh_changelog "${changelog_args[@]}" )"
 
 # Output the changelog

--- a/tools/generate_gh_changelog.sh
+++ b/tools/generate_gh_changelog.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+# MARK - Locate Depedencies
+
+fail_sh_location=cgrindel_bazel_starlib/lib/private/fail.sh
+fail_sh="$(rlocation "${fail_sh_location}")" || \
+  (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
+source "${fail_sh}"
+
+get_gh_auth_token_sh_location=cgrindel_bazel_starlib/tools/get_gh_auth_token.sh
+get_gh_auth_token_sh="$(rlocation "${get_gh_auth_token_sh_location}")" || \
+  (echo >&2 "Failed to locate ${get_gh_auth_token_sh_location}" && exit 1)
+
+# MARK - Functions
+
+is_installed() {
+  local name="${1}"
+  which "${name}" > /dev/null
+}
+
+
+# MARK - Check for Required Software
+
+is_installed jq || fail "Could not find jq for JSON manipulation."
+
+# MARK - Generate the changelog.
+
+starting_dir="${PWD}"
+cd "${BUILD_WORKSPACE_DIRECTORY}"
+
+auth_token="$( "${get_gh_auth_token_sh}" )"
+
+owner="cgrindel"
+repo="bazel-starlib"
+api_base_url="https://api.github.com/repos/${owner}/${repo}"
+
+api_url="${api_base_url}/releases/generate-notes"
+
+tag_name="v0.1.1"
+prev_tag_name="v0.1.0"
+
+# If tag_name does not exist, get the last commit on main at orgin
+
+# If tag_name does exist, get the commit hash for the tag.
+target_commit="$(git rev-list -n 1 "tags/${tag_name}")"
+
+
+# # Get the current commit
+# target_commit="$(git log --pretty=format:'%H' -n 1)"
+
+request_data="$(
+  jq -n \
+    --arg tag_name "${tag_name}" \
+    --arg prev_tag_name "${prev_tag_name}" \
+    --arg target_commitish "${target_commit}" \
+    '{tag_name: $tag_name, previous_tag_name: $prev_tag_name, target_commitish: $target_commitish}'
+)"
+
+# DEBUG BEGIN
+echo >&2 "*** CHUCK  api_url: ${api_url}" 
+echo >&2 "*** CHUCK  request_data: ${request_data}" 
+# DEBUG END
+
+curl \
+  -u "cgrindel:${auth_token}" \
+  -X POST \
+  -H "Accept: application/vnd.github.v3+json" \
+  "${api_url}" \
+  -d "${request_data}"

--- a/tools/generate_gh_changelog.sh
+++ b/tools/generate_gh_changelog.sh
@@ -39,6 +39,7 @@ source "${github_sh}"
 is_installed gh || fail "Could not find Github CLI (gh)."
 is_installed git || fail "Could not find git."
 is_installed jq || fail "Could not find jq for JSON manipulation."
+is_installed curl || fail "Could not find curl for Github API execution."
 
 
 # MARK - Process Arguments
@@ -65,17 +66,15 @@ tag_name="${args[0]}"
 starting_dir="${PWD}"
 cd "${BUILD_WORKSPACE_DIRECTORY}"
 
-auth_status="$( get_gh_auth_status )"
-username="$( get_gh_username "${auth_status}" )"
-auth_token="$( get_gh_auth_token "${auth_status}")"
-
 repo_url="$( get_git_remote_url )"
 is_git_repo_url "${repo_url}" || \
   fail "The git repository's remote URL does not appear to be a Github URL. ${repo_url}"
 
-owner="$( get_gh_repo_owner "${repo_url}" )"
-repo="$( get_gh_repo_name "${repo_url}" )"
-api_base_url="https://api.github.com/repos/${owner}/${repo}"
+auth_status="$( get_gh_auth_status )"
+username="$( get_gh_username "${auth_status}" )"
+auth_token="$( get_gh_auth_token "${auth_status}")"
+
+api_base_url="$( get_gh_api_base_url "${repo_url}" )"
 
 api_url="${api_base_url}/releases/generate-notes"
 

--- a/tools/generate_gh_changelog.sh
+++ b/tools/generate_gh_changelog.sh
@@ -73,8 +73,8 @@ repo_url="$( get_git_remote_url )"
 is_git_repo_url "${repo_url}" || \
   fail "The git repository's remote URL does not appear to be a Github URL. ${repo_url}"
 
-owner="cgrindel"
-repo="bazel-starlib"
+owner="$( get_gh_repo_owner "${repo_url}" )"
+repo="$( get_gh_repo_name "${repo_url}" )"
 api_base_url="https://api.github.com/repos/${owner}/${repo}"
 
 api_url="${api_base_url}/releases/generate-notes"

--- a/tools/generate_gh_changelog.sh
+++ b/tools/generate_gh_changelog.sh
@@ -74,10 +74,6 @@ repo_url="$( get_git_remote_url )"
 is_github_repo_url "${repo_url}" || \
   fail "The git repository's remote URL does not appear to be a Github URL. ${repo_url}"
 
-auth_status="$( get_gh_auth_status )"
-username="$( get_gh_username "${auth_status}" )"
-auth_token="$( get_gh_auth_token "${auth_status}")"
-
 # Fetch the latest from origin
 fetch_latest_from_git_remote
 

--- a/tools/generate_sha256.sh
+++ b/tools/generate_sha256.sh
@@ -59,10 +59,10 @@ fi
 
 # Select the utility to use
 if [[ -z "${utility:-}" ]]; then
-  if is_installed openssl; then
+  if is_installed shasum; then
+    utility=shasum
+  elif is_installed openssl; then
     utility=openssl
-  elif is_installed sha256sum; then
-    utility=sha256sum
   else
     fail "Could not find a supported utility to generate a SHA256 hash."
   fi
@@ -70,15 +70,15 @@ fi
 
 # Generate the hash
 case "${utility}" in
+  shasum)
+    output="$(
+    shasum -a 256 "${source_path}" |  sed -E -n 's/^([^[:space:]]+).*/\1/gp'
+    )"
+    ;;
   openssl)
     output="$(
     openssl dgst -sha256 "${source_path}" | \
       sed -E -n 's/^SHA256[^=]+= ([^[:space:]]+).*/\1/gp' 
-    )"
-    ;;
-  sha256sum)
-    output="$(
-    sha256sum "${source_path}" |  sed -E -n 's/^([^[:space:]]+).*/\1/gp'
     )"
     ;;
   *)

--- a/tools/get_gh_auth_token.sh
+++ b/tools/get_gh_auth_token.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+# MARK - Locate Depedencies
+
+fail_sh_location=cgrindel_bazel_starlib/lib/private/fail.sh
+fail_sh="$(rlocation "${fail_sh_location}")" || \
+  (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
+source "${fail_sh}"
+
+# MARK - Functions
+
+is_installed() {
+  local name="${1}"
+  which "${name}" > /dev/null
+}
+
+# MARK - Check for Required Software
+
+is_installed gh || fail "Could not find Github CLI (gh)."
+
+# MARK - Get the 
+
+gh auth status -t 2>&1 | \
+  sed -E -n 's/^.* Token:[[:space:]]+([^[:space:]]+).*/\1/gp'


### PR DESCRIPTION
Related to #4.

- Added `git.sh`, `github.sh`, and `env.sh` to house shell libraries used by the changelog generation.
- Implemented `@cgrindel_bazel_starlib//tools:generate_gh_changelog` to retrieve a changelog from the Github API.
- Added integration tests to test the changelog generation functionality.
- Updated the sha256 generation script to look for `shasum` instead of `sha256sum`.
