### PR TITLE
Added `assert_match` and `assert_no_match`.

### DIFF
--- a/lib/private/assertions.sh
+++ b/lib/private/assertions.sh
@@ -18,6 +18,15 @@ fail() {
   exit 1
 }
 
+make_err_msg() {
+  local err_msg="${1}"
+  local prefix="${2:-}"
+  [[ -z "${prefix}" ]] || \
+    local err_msg="${prefix} ${err_msg}"
+  echo "${err_msg}"
+}
+
+
 # Asserts that the actual value equals the expected value.
 #
 # Args:
@@ -31,11 +40,42 @@ fail() {
 assert_equal() {
   local expected="${1}"
   local actual="${2}"
-  local err_msg_prefix="${3:-}"
-  local err_msg="Expected to be equal. expected: ${expected}, actual: ${actual}"
-  if [[ ! -z "${err_msg_prefix}" ]]; then
-    local err_msg="${err_msg_prefix} ${err_msg}"
-  fi
+  local err_msg="$(make_err_msg "Expected to be equal. expected: ${expected}, actual: ${actual}" "${3:-}")"
   [[ "${expected}" == "${actual}" ]] || fail "${err_msg}"
 }
 
+# Asserts that the actual value contains the specified regex pattern.
+#
+# Args:
+#   pattern: The expected pattern.
+#   actual: The actual value.
+#   err_msg: Optional. The error message to print if the assertion fails.
+#
+# Outputs:
+#   stdout: None.
+#   stderr: None.
+assert_match() {
+  local pattern=${1}
+  local actual="${2}"
+  local err_msg="$(make_err_msg "Expected to match. pattern: ${pattern}, actual: ${actual}" "${3:-}")"
+  [[ "${actual}" =~ ${pattern} ]] || fail "${err_msg}"
+}
+
+# Asserts that the actual value does not contain the specified regex pattern.
+#
+# Args:
+#   pattern: The expected pattern.
+#   actual: The actual value.
+#   err_msg: Optional. The error message to print if the assertion fails.
+#
+# Outputs:
+#   stdout: None.
+#   stderr: None.
+assert_no_match() {
+  local pattern=${1}
+  local actual="${2}"
+  local err_msg="$(make_err_msg "Expected not to match. pattern: ${pattern}, actual: ${actual}" "${3:-}")"
+  [[ "${actual}" =~ ${pattern} ]] && fail "${err_msg}"
+  # Because this is a negative test, we need to end on a positive note if all is well.
+  echo ""
+}

--- a/tests/lib_tests/private_tests/assertions_tests/BUILD.bazel
+++ b/tests/lib_tests/private_tests/assertions_tests/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+
+bzlformat_pkg(name = "bzlformat")
+
+sh_test(
+    name = "assert_equal_test",
+    srcs = ["assert_equal_test.sh"],
+    deps = [
+        "//lib/private:assertions",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)
+
+sh_test(
+    name = "assert_match_test",
+    srcs = ["assert_match_test.sh"],
+    deps = [
+        "//lib/private:assertions",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)
+
+sh_test(
+    name = "assert_no_match_test",
+    srcs = ["assert_no_match_test.sh"],
+    deps = [
+        "//lib/private:assertions",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)

--- a/tests/lib_tests/private_tests/assertions_tests/BUILD.bazel
+++ b/tests/lib_tests/private_tests/assertions_tests/BUILD.bazel
@@ -22,6 +22,7 @@ sh_test(
     name = "assert_match_test",
     srcs = ["assert_match_test.sh"],
     deps = [
+        ":assert_fail",
         "//lib/private:assertions",
         "@bazel_tools//tools/bash/runfiles",
     ],
@@ -31,6 +32,7 @@ sh_test(
     name = "assert_no_match_test",
     srcs = ["assert_no_match_test.sh"],
     deps = [
+        ":assert_fail",
         "//lib/private:assertions",
         "@bazel_tools//tools/bash/runfiles",
     ],

--- a/tests/lib_tests/private_tests/assertions_tests/BUILD.bazel
+++ b/tests/lib_tests/private_tests/assertions_tests/BUILD.bazel
@@ -2,10 +2,17 @@ load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
 
 bzlformat_pkg(name = "bzlformat")
 
+sh_library(
+    name = "assert_fail",
+    testonly = True,
+    srcs = ["assert_fail.sh"],
+)
+
 sh_test(
     name = "assert_equal_test",
     srcs = ["assert_equal_test.sh"],
     deps = [
+        ":assert_fail",
         "//lib/private:assertions",
         "@bazel_tools//tools/bash/runfiles",
     ],

--- a/tests/lib_tests/private_tests/assertions_tests/assert_equal_test.sh
+++ b/tests/lib_tests/private_tests/assertions_tests/assert_equal_test.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+assertions_sh_location=cgrindel_bazel_starlib/lib/private/assertions.sh
+assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+  (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
+source "${assertions_sh}"
+
+fail "IMPLEMENT ME!"

--- a/tests/lib_tests/private_tests/assertions_tests/assert_equal_test.sh
+++ b/tests/lib_tests/private_tests/assertions_tests/assert_equal_test.sh
@@ -16,4 +16,50 @@ assertions_sh="$(rlocation "${assertions_sh_location}")" || \
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 source "${assertions_sh}"
 
+# MARK - Replace fail
+
+FAIL_ERR_MSGS=()
+
+fail() {
+  local err_msg="${1:-Unspecified error occurred.}"
+  FAIL_ERR_MSGS+=( "${err_msg}" )
+}
+
+reset_fail_err_msgs() {
+  FAIL_ERR_MSGS=()
+}
+
+new_fail(){
+  local err_msg="${1:-}"
+  [[ -n "${err_msg}" ]] || err_msg="Unspecified error occurred."
+  echo >&2 "${err_msg}"
+  exit 1
+}
+
+assert_fail() {
+  local pattern=${1}
+  [[ ${#FAIL_ERR_MSGS[@]} == 0 ]] && new_fail "Expected a failure. None found. pattern: ${pattern}"
+  [[ ${#FAIL_ERR_MSGS[@]} > 1 ]] && new_fail "Expected a single failure. Found ${#FAIL_ERR_MSGS[@]}. pattern: ${pattern}"
+  [[ "${FAIL_ERR_MSGS[0]}" =~ ${pattern} ]] || new_fail "Unexpected failure. Found ${FAIL_ERR_MSGS[0]}. pattern: ${pattern}"
+}
+
+assert_no_fail(){
+  [[ ${#FAIL_ERR_MSGS[@]} == 0 ]] || new_fail "Expected no failures. Found ${#FAIL_ERR_MSGS[@]}. ${FAIL_ERR_MSGS[@]}"
+}
+
+# MARK - Test assert_equal
+
+reset_fail_err_msgs
+assert_equal "hello" "goodbye"
+assert_fail "Expected to be equal."
+reset_fail_err_msgs
+
+# reset_fail_err_msgs
+# # DEBUG BEGIN
+# echo >&2 "*** CHUCK  #FAIL_ERR_MSGS[@]: ${#FAIL_ERR_MSGS[@]}" 
+# # DEBUG END
+# assert_equal "hello" "goodbye" "Custom prefix"
+# assert_fail "Custom prefix Expected to be equal."
+# reset_fail_err_msgs
+
 fail "IMPLEMENT ME!"

--- a/tests/lib_tests/private_tests/assertions_tests/assert_equal_test.sh
+++ b/tests/lib_tests/private_tests/assertions_tests/assert_equal_test.sh
@@ -21,8 +21,6 @@ assert_fail_sh="$(rlocation "${assert_fail_sh_location}")" || \
   (echo >&2 "Failed to locate ${assert_fail_sh_location}" && exit 1)
 source "${assert_fail_sh}"
 
-# MARK - Replace fail
-
 
 # MARK - Test assert_equal
 
@@ -31,12 +29,12 @@ assert_equal "hello" "goodbye"
 assert_fail "Expected to be equal."
 reset_fail_err_msgs
 
-# reset_fail_err_msgs
-# # DEBUG BEGIN
-# echo >&2 "*** CHUCK  #FAIL_ERR_MSGS[@]: ${#FAIL_ERR_MSGS[@]}" 
-# # DEBUG END
-# assert_equal "hello" "goodbye" "Custom prefix"
-# assert_fail "Custom prefix Expected to be equal."
-# reset_fail_err_msgs
+reset_fail_err_msgs
+assert_equal "hello" "goodbye" "Custom prefix."
+assert_fail "Custom prefix. Expected to be equal."
+reset_fail_err_msgs
 
-fail "IMPLEMENT ME!"
+reset_fail_err_msgs
+assert_equal "hello" "hello"
+assert_no_fail
+reset_fail_err_msgs

--- a/tests/lib_tests/private_tests/assertions_tests/assert_equal_test.sh
+++ b/tests/lib_tests/private_tests/assertions_tests/assert_equal_test.sh
@@ -16,36 +16,13 @@ assertions_sh="$(rlocation "${assertions_sh_location}")" || \
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 source "${assertions_sh}"
 
+assert_fail_sh_location=cgrindel_bazel_starlib/tests/lib_tests/private_tests/assertions_tests/assert_fail.sh
+assert_fail_sh="$(rlocation "${assert_fail_sh_location}")" || \
+  (echo >&2 "Failed to locate ${assert_fail_sh_location}" && exit 1)
+source "${assert_fail_sh}"
+
 # MARK - Replace fail
 
-FAIL_ERR_MSGS=()
-
-fail() {
-  local err_msg="${1:-Unspecified error occurred.}"
-  FAIL_ERR_MSGS+=( "${err_msg}" )
-}
-
-reset_fail_err_msgs() {
-  FAIL_ERR_MSGS=()
-}
-
-new_fail(){
-  local err_msg="${1:-}"
-  [[ -n "${err_msg}" ]] || err_msg="Unspecified error occurred."
-  echo >&2 "${err_msg}"
-  exit 1
-}
-
-assert_fail() {
-  local pattern=${1}
-  [[ ${#FAIL_ERR_MSGS[@]} == 0 ]] && new_fail "Expected a failure. None found. pattern: ${pattern}"
-  [[ ${#FAIL_ERR_MSGS[@]} > 1 ]] && new_fail "Expected a single failure. Found ${#FAIL_ERR_MSGS[@]}. pattern: ${pattern}"
-  [[ "${FAIL_ERR_MSGS[0]}" =~ ${pattern} ]] || new_fail "Unexpected failure. Found ${FAIL_ERR_MSGS[0]}. pattern: ${pattern}"
-}
-
-assert_no_fail(){
-  [[ ${#FAIL_ERR_MSGS[@]} == 0 ]] || new_fail "Expected no failures. Found ${#FAIL_ERR_MSGS[@]}. ${FAIL_ERR_MSGS[@]}"
-}
 
 # MARK - Test assert_equal
 

--- a/tests/lib_tests/private_tests/assertions_tests/assert_fail.sh
+++ b/tests/lib_tests/private_tests/assertions_tests/assert_fail.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+FAIL_ERR_MSGS=()
+
+fail() {
+  local err_msg="${1:-Unspecified error occurred.}"
+  FAIL_ERR_MSGS+=( "${err_msg}" )
+}
+
+reset_fail_err_msgs() {
+  FAIL_ERR_MSGS=()
+}
+
+new_fail(){
+  local err_msg="${1:-}"
+  [[ -n "${err_msg}" ]] || err_msg="Unspecified error occurred."
+  echo >&2 "${err_msg}"
+  exit 1
+}
+
+assert_fail() {
+  local pattern=${1}
+  [[ ${#FAIL_ERR_MSGS[@]} == 0 ]] && new_fail "Expected a failure. None found. pattern: ${pattern}"
+  [[ ${#FAIL_ERR_MSGS[@]} > 1 ]] && new_fail "Expected a single failure. Found ${#FAIL_ERR_MSGS[@]}. pattern: ${pattern}"
+  [[ "${FAIL_ERR_MSGS[0]}" =~ ${pattern} ]] || new_fail "Unexpected failure. Found ${FAIL_ERR_MSGS[0]}. pattern: ${pattern}"
+}
+
+assert_no_fail(){
+  [[ ${#FAIL_ERR_MSGS[@]} == 0 ]] || new_fail "Expected no failures. Found ${#FAIL_ERR_MSGS[@]}. ${FAIL_ERR_MSGS[@]}"
+}

--- a/tests/lib_tests/private_tests/assertions_tests/assert_fail.sh
+++ b/tests/lib_tests/private_tests/assertions_tests/assert_fail.sh
@@ -26,5 +26,5 @@ assert_fail() {
 }
 
 assert_no_fail(){
-  [[ ${#FAIL_ERR_MSGS[@]} == 0 ]] || new_fail "Expected no failures. Found ${#FAIL_ERR_MSGS[@]}. ${FAIL_ERR_MSGS[@]}"
+  [[ ${#FAIL_ERR_MSGS[@]} == 0 ]] || new_fail "Expected no failures. Found ${#FAIL_ERR_MSGS[@]}. '${FAIL_ERR_MSGS[@]}'"
 }

--- a/tests/lib_tests/private_tests/assertions_tests/assert_fail.sh
+++ b/tests/lib_tests/private_tests/assertions_tests/assert_fail.sh
@@ -22,7 +22,7 @@ assert_fail() {
   local pattern=${1}
   [[ ${#FAIL_ERR_MSGS[@]} == 0 ]] && new_fail "Expected a failure. None found. pattern: ${pattern}"
   [[ ${#FAIL_ERR_MSGS[@]} > 1 ]] && new_fail "Expected a single failure. Found ${#FAIL_ERR_MSGS[@]}. pattern: ${pattern}"
-  [[ "${FAIL_ERR_MSGS[0]}" =~ ${pattern} ]] || new_fail "Unexpected failure. Found ${FAIL_ERR_MSGS[0]}. pattern: ${pattern}"
+  [[ "${FAIL_ERR_MSGS[0]}" =~ ${pattern} ]] || new_fail "Unexpected failure. Found '${FAIL_ERR_MSGS[0]}'. pattern: ${pattern}"
 }
 
 assert_no_fail(){

--- a/tests/lib_tests/private_tests/assertions_tests/assert_match_test.sh
+++ b/tests/lib_tests/private_tests/assertions_tests/assert_match_test.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+assertions_sh_location=cgrindel_bazel_starlib/lib/private/assertions.sh
+assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+  (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
+source "${assertions_sh}"
+
+fail "IMPLEMENT ME!"

--- a/tests/lib_tests/private_tests/assertions_tests/assert_match_test.sh
+++ b/tests/lib_tests/private_tests/assertions_tests/assert_match_test.sh
@@ -16,4 +16,19 @@ assertions_sh="$(rlocation "${assertions_sh_location}")" || \
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 source "${assertions_sh}"
 
-fail "IMPLEMENT ME!"
+assert_fail_sh_location=cgrindel_bazel_starlib/tests/lib_tests/private_tests/assertions_tests/assert_fail.sh
+assert_fail_sh="$(rlocation "${assert_fail_sh_location}")" || \
+  (echo >&2 "Failed to locate ${assert_fail_sh_location}" && exit 1)
+source "${assert_fail_sh}"
+
+# MARK - Test assert_match
+
+reset_fail_err_msgs
+assert_match ^Begin "Begin with hello"
+assert_no_fail
+reset_fail_err_msgs
+
+reset_fail_err_msgs
+assert_match ^Begin "Not Begin with hello"
+assert_fail "Expected to match."
+reset_fail_err_msgs

--- a/tests/lib_tests/private_tests/assertions_tests/assert_no_match_test.sh
+++ b/tests/lib_tests/private_tests/assertions_tests/assert_no_match_test.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+assertions_sh_location=cgrindel_bazel_starlib/lib/private/assertions.sh
+assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+  (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
+source "${assertions_sh}"
+
+fail "IMPLEMENT ME!"

--- a/tests/lib_tests/private_tests/assertions_tests/assert_no_match_test.sh
+++ b/tests/lib_tests/private_tests/assertions_tests/assert_no_match_test.sh
@@ -16,4 +16,19 @@ assertions_sh="$(rlocation "${assertions_sh_location}")" || \
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 source "${assertions_sh}"
 
-fail "IMPLEMENT ME!"
+assert_fail_sh_location=cgrindel_bazel_starlib/tests/lib_tests/private_tests/assertions_tests/assert_fail.sh
+assert_fail_sh="$(rlocation "${assert_fail_sh_location}")" || \
+  (echo >&2 "Failed to locate ${assert_fail_sh_location}" && exit 1)
+source "${assert_fail_sh}"
+
+# MARK - Test assert_no_match
+
+reset_fail_err_msgs
+assert_no_match ^Begin "Begin with hello"
+assert_fail "Expected not to match."
+reset_fail_err_msgs
+
+reset_fail_err_msgs
+assert_no_match ^Begin "Not Begin with hello"
+assert_no_fail
+reset_fail_err_msgs


### PR DESCRIPTION
- Added `assert_match` and `assert_no_match`. They are used to test for patterns in strings.
- Refactored the error message logic into its own.
- Added tests for `assert_equal`, `assert_match`, and `assert_no_match`.