### PR TITLE
Added `generate_workspace_snippet` macro and updated `generate_release_notes`.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -54,8 +54,3 @@ generate_release_notes(
     name = "generate_release_notes",
     generate_workspace_snippet = ":generate_workspace_snippet",
 )
-
-# update_readme(
-#     name = "update_readme",
-#     generate_workspace_snippet = ":generate_workspace_snippet",
-# )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -9,6 +9,7 @@ load(
 )
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("//rules:generate_release_notes.bzl", "generate_release_notes")
+load("//rules:generate_workspace_snippet.bzl", "generate_workspace_snippet")
 
 bzlformat_pkg(name = "bzlformat")
 
@@ -43,7 +44,17 @@ test_suite(
 
 # MARK: - Release
 
+generate_workspace_snippet(
+    name = "generate_workspace_snippet",
+    template = "workspace_snippet.tmpl",
+)
+
 generate_release_notes(
     name = "generate_release_notes",
-    snippet_template = "workspace_snippet.tmpl",
+    generate_workspace_snippet = ":generate_workspace_snippet",
 )
+
+# update_readme(
+#     name = "update_readme",
+#     generate_workspace_snippet = ":generate_workspace_snippet",
+# )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -37,6 +37,7 @@ test_suite(
         "//tests/lib_tests/private_tests/git_tests:integration_tests",
         "//tests/lib_tests/private_tests/github_tests:integration_tests",
         "//tests/rules_tests/generate_release_notes_tests:integration_tests",
+        "//tests/rules_tests/generate_workspace_snippet_tests:integration_tests",
         "//tests/tools_tests:integration_tests",
     ],
     visibility = ["//:__subpackages__"],

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -16,6 +16,7 @@ _RULE_NAMES = [
     "execute_binary",
     "filter_srcs",
     "generate_release_notes",
+    "generate_workspace_snippet",
     "hash_sha256",
     "write_bazel_status_vars",
 ]

--- a/doc/generate_release_notes.md
+++ b/doc/generate_release_notes.md
@@ -10,6 +10,9 @@
 generate_release_notes(<a href="#generate_release_notes-name">name</a>, <a href="#generate_release_notes-generate_workspace_snippet">generate_workspace_snippet</a>)
 </pre>
 
+Defines an executable target that generates release notes as Github markdown.
+
+Typically, this macro is used in conjunction with the     `generate_workspace_snippet` macro. The `generate_workspace_snippet`     defines how to generate the workspace snippet. The resulting target     is then referenced by this macro.
 
 
 **PARAMETERS**
@@ -17,7 +20,7 @@ generate_release_notes(<a href="#generate_release_notes-name">name</a>, <a href=
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="generate_release_notes-name"></a>name |  <p align="center"> - </p>   |  <code>"generate_release_notes"</code> |
-| <a id="generate_release_notes-generate_workspace_snippet"></a>generate_workspace_snippet |  <p align="center"> - </p>   |  <code>None</code> |
+| <a id="generate_release_notes-name"></a>name |  The name of the executable target as a <code>string</code>.   |  none |
+| <a id="generate_release_notes-generate_workspace_snippet"></a>generate_workspace_snippet |  The label that should be executed to                                     generate the workspace snippet.   |  none |
 
 

--- a/doc/generate_release_notes.md
+++ b/doc/generate_release_notes.md
@@ -7,7 +7,7 @@
 ## generate_release_notes
 
 <pre>
-generate_release_notes(<a href="#generate_release_notes-name">name</a>, <a href="#generate_release_notes-snippet_template">snippet_template</a>)
+generate_release_notes(<a href="#generate_release_notes-name">name</a>, <a href="#generate_release_notes-generate_workspace_snippet">generate_workspace_snippet</a>)
 </pre>
 
 
@@ -18,6 +18,6 @@ generate_release_notes(<a href="#generate_release_notes-name">name</a>, <a href=
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="generate_release_notes-name"></a>name |  <p align="center"> - </p>   |  <code>"generate_release_notes"</code> |
-| <a id="generate_release_notes-snippet_template"></a>snippet_template |  <p align="center"> - </p>   |  <code>None</code> |
+| <a id="generate_release_notes-generate_workspace_snippet"></a>generate_workspace_snippet |  <p align="center"> - </p>   |  <code>None</code> |
 
 

--- a/doc/generate_workspace_snippet.md
+++ b/doc/generate_workspace_snippet.md
@@ -1,0 +1,23 @@
+<!-- Generated with Stardoc, Do Not Edit! -->
+# `generate_workspace_snippet` Rule
+
+
+<a id="#generate_workspace_snippet"></a>
+
+## generate_workspace_snippet
+
+<pre>
+generate_workspace_snippet(<a href="#generate_workspace_snippet-name">name</a>, <a href="#generate_workspace_snippet-template">template</a>)
+</pre>
+
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="generate_workspace_snippet-name"></a>name |  <p align="center"> - </p>   |  <code>"generate_workspace_snippet"</code> |
+| <a id="generate_workspace_snippet-template"></a>template |  <p align="center"> - </p>   |  <code>None</code> |
+
+

--- a/doc/generate_workspace_snippet.md
+++ b/doc/generate_workspace_snippet.md
@@ -10,6 +10,9 @@
 generate_workspace_snippet(<a href="#generate_workspace_snippet-name">name</a>, <a href="#generate_workspace_snippet-template">template</a>)
 </pre>
 
+Defines an executable target that generates a workspace snippet suitable     for inclusion in a markdown document.
+
+Without a template, the utility will output an `http_archive` declaration.     With a template, the utility will output the template replacing     `${http_archive_statement}` with the `http_archive` declaration.
 
 
 **PARAMETERS**
@@ -17,7 +20,7 @@ generate_workspace_snippet(<a href="#generate_workspace_snippet-name">name</a>, 
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="generate_workspace_snippet-name"></a>name |  <p align="center"> - </p>   |  <code>"generate_workspace_snippet"</code> |
-| <a id="generate_workspace_snippet-template"></a>template |  <p align="center"> - </p>   |  <code>None</code> |
+| <a id="generate_workspace_snippet-name"></a>name |  The name of the executable target as a <code>string</code>.   |  none |
+| <a id="generate_workspace_snippet-template"></a>template |  The path to a template file  as a <code>string</code>.   |  <code>None</code> |
 
 

--- a/doc/rules.md
+++ b/doc/rules.md
@@ -6,6 +6,7 @@ The rules listed below are available in this repository.
   * [execute_binary](/doc/execute_binary.md)
   * [filter_srcs](/doc/filter_srcs.md)
   * [generate_release_notes](/doc/generate_release_notes.md)
+  * [generate_workspace_snippet](/doc/generate_workspace_snippet.md)
   * [hash_sha256](/doc/hash_sha256.md)
   * [write_bazel_status_vars](/doc/write_bazel_status_vars.md)
 

--- a/lib/private/assertions.sh
+++ b/lib/private/assertions.sh
@@ -39,3 +39,24 @@ assert_equal() {
   [[ "${expected}" == "${actual}" ]] || fail "${err_msg}"
 }
 
+# Asserts that the actual value contains the specified regex pattern.
+#
+# Args:
+#   pattern: The expected pattern.
+#   actual: The actual value.
+#   err_msg: Optional. The error message to print if the assertion fails.
+#
+# Outputs:
+#   stdout: None.
+#   stderr: None.
+assert_match() {
+  local pattern=${1}
+  local actual="${2}"
+  local err_msg_prefix="${3:-}"
+  local err_msg="Expected to match. pattern: ${pattern}, actual: ${actual}"
+  if [[ ! -z "${err_msg_prefix}" ]]; then
+    local err_msg="${err_msg_prefix} ${err_msg}"
+  fi
+  [[ "${actual}" =~ ${pattern} ]] || fail "${err_msg}"
+}
+

--- a/lib/private/assertions.sh
+++ b/lib/private/assertions.sh
@@ -41,11 +41,6 @@ assert_equal() {
   local expected="${1}"
   local actual="${2}"
   local err_msg="$(make_err_msg "Expected to be equal. expected: ${expected}, actual: ${actual}" "${3:-}")"
-  # local err_msg_prefix="${3:-}"
-  # local err_msg="Expected to be equal. expected: ${expected}, actual: ${actual}"
-  # if [[ ! -z "${err_msg_prefix}" ]]; then
-  #   local err_msg="${err_msg_prefix} ${err_msg}"
-  # fi
   [[ "${expected}" == "${actual}" ]] || fail "${err_msg}"
 }
 
@@ -63,11 +58,6 @@ assert_match() {
   local pattern=${1}
   local actual="${2}"
   local err_msg="$(make_err_msg "Expected to match. pattern: ${pattern}, actual: ${actual}" "${3:-}")"
-  # local err_msg_prefix="${3:-}"
-  # local err_msg="Expected to match. pattern: ${pattern}, actual: ${actual}"
-  # if [[ ! -z "${err_msg_prefix}" ]]; then
-  #   local err_msg="${err_msg_prefix} ${err_msg}"
-  # fi
   [[ "${actual}" =~ ${pattern} ]] || fail "${err_msg}"
 }
 
@@ -85,10 +75,7 @@ assert_no_match() {
   local pattern=${1}
   local actual="${2}"
   local err_msg="$(make_err_msg "Expected not to match. pattern: ${pattern}, actual: ${actual}" "${3:-}")"
-  # local err_msg_prefix="${3:-}"
-  # local err_msg="Expected not to match. pattern: ${pattern}, actual: ${actual}"
-  # if [[ ! -z "${err_msg_prefix}" ]]; then
-  #   local err_msg="${err_msg_prefix} ${err_msg}"
-  # fi
   [[ "${actual}" =~ ${pattern} ]] && fail "${err_msg}"
+  # Because this is a negative test, we need to end on a positive note if all is well.
+  echo ""
 }

--- a/lib/private/assertions.sh
+++ b/lib/private/assertions.sh
@@ -18,6 +18,15 @@ fail() {
   exit 1
 }
 
+make_err_msg() {
+  local err_msg="${1}"
+  local prefix="${2:-}"
+  [[ -z "${prefix}" ]] || \
+    local err_msg="${prefix} ${err_msg}"
+  echo "${err_msg}"
+}
+
+
 # Asserts that the actual value equals the expected value.
 #
 # Args:
@@ -31,11 +40,12 @@ fail() {
 assert_equal() {
   local expected="${1}"
   local actual="${2}"
-  local err_msg_prefix="${3:-}"
-  local err_msg="Expected to be equal. expected: ${expected}, actual: ${actual}"
-  if [[ ! -z "${err_msg_prefix}" ]]; then
-    local err_msg="${err_msg_prefix} ${err_msg}"
-  fi
+  local err_msg="$(make_err_msg "Expected to be equal. expected: ${expected}, actual: ${actual}" "${3:-}")"
+  # local err_msg_prefix="${3:-}"
+  # local err_msg="Expected to be equal. expected: ${expected}, actual: ${actual}"
+  # if [[ ! -z "${err_msg_prefix}" ]]; then
+  #   local err_msg="${err_msg_prefix} ${err_msg}"
+  # fi
   [[ "${expected}" == "${actual}" ]] || fail "${err_msg}"
 }
 
@@ -52,11 +62,33 @@ assert_equal() {
 assert_match() {
   local pattern=${1}
   local actual="${2}"
-  local err_msg_prefix="${3:-}"
-  local err_msg="Expected to match. pattern: ${pattern}, actual: ${actual}"
-  if [[ ! -z "${err_msg_prefix}" ]]; then
-    local err_msg="${err_msg_prefix} ${err_msg}"
-  fi
+  local err_msg="$(make_err_msg "Expected to match. pattern: ${pattern}, actual: ${actual}" "${3:-}")"
+  # local err_msg_prefix="${3:-}"
+  # local err_msg="Expected to match. pattern: ${pattern}, actual: ${actual}"
+  # if [[ ! -z "${err_msg_prefix}" ]]; then
+  #   local err_msg="${err_msg_prefix} ${err_msg}"
+  # fi
   [[ "${actual}" =~ ${pattern} ]] || fail "${err_msg}"
 }
 
+# Asserts that the actual value does not contain the specified regex pattern.
+#
+# Args:
+#   pattern: The expected pattern.
+#   actual: The actual value.
+#   err_msg: Optional. The error message to print if the assertion fails.
+#
+# Outputs:
+#   stdout: None.
+#   stderr: None.
+assert_no_match() {
+  local pattern=${1}
+  local actual="${2}"
+  local err_msg="$(make_err_msg "Expected not to match. pattern: ${pattern}, actual: ${actual}" "${3:-}")"
+  # local err_msg_prefix="${3:-}"
+  # local err_msg="Expected not to match. pattern: ${pattern}, actual: ${actual}"
+  # if [[ ! -z "${err_msg_prefix}" ]]; then
+  #   local err_msg="${err_msg_prefix} ${err_msg}"
+  # fi
+  [[ "${actual}" =~ ${pattern} ]] && fail "${err_msg}"
+}

--- a/rules/BUILD.bazel
+++ b/rules/BUILD.bazel
@@ -39,12 +39,22 @@ bzl_library(
 )
 
 bzl_library(
+    name = "generate_workspace_snippet",
+    srcs = ["generate_workspace_snippet.bzl"],
+    deps = [
+        "//rules/private:generate_workspace_snippet",
+    ],
+)
+
+bzl_library(
     name = "generate_release_notes",
     srcs = ["generate_release_notes.bzl"],
     deps = [
         "//rules/private:generate_release_notes",
     ],
 )
+
+# TODO: Can I remove pkg_files and pkg_filegroup?
 
 pkg_files(
     name = "package_files",

--- a/rules/generate_workspace_snippet.bzl
+++ b/rules/generate_workspace_snippet.bzl
@@ -1,0 +1,6 @@
+load(
+    "//rules/private:generate_workspace_snippet.bzl",
+    _generate_workspace_snippet = "generate_workspace_snippet",
+)
+
+generate_workspace_snippet = _generate_workspace_snippet

--- a/rules/private/BUILD.bazel
+++ b/rules/private/BUILD.bazel
@@ -26,6 +26,14 @@ bzl_library(
 )
 
 bzl_library(
+    name = "generate_workspace_snippet",
+    srcs = ["generate_workspace_snippet.bzl"],
+    deps = [
+        ":execute_binary",
+    ],
+)
+
+bzl_library(
     name = "generate_release_notes",
     srcs = ["generate_release_notes.bzl"],
     deps = [

--- a/rules/private/BUILD.bazel
+++ b/rules/private/BUILD.bazel
@@ -25,6 +25,9 @@ bzl_library(
 bzl_library(
     name = "execute_binary",
     srcs = ["execute_binary.bzl"],
+    deps = [
+        "@bazel_skylib//lib:paths",
+    ],
 )
 
 bzl_library(

--- a/rules/private/execute_binary.bzl
+++ b/rules/private/execute_binary.bzl
@@ -51,6 +51,11 @@ set -euo pipefail
   [[ -f "${PWD}/../MANIFEST" ]] && \
   export RUNFILES_DIR="${PWD}/.."
 
+# DEBUG BEGIN
+echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") PWD: ${PWD}" 
+tree >&2
+# DEBUG END
+
 args=()
 """ + "\n".join([
             # Do not quote the {arg}. The values are already quoted. Adding the

--- a/rules/private/execute_binary.bzl
+++ b/rules/private/execute_binary.bzl
@@ -12,44 +12,21 @@ def file_placeholder(key):
 def _create_file_args_placeholder_dict(ctx):
     return {p: fa.files.to_list()[0] for fa, p in ctx.attr.file_args.items()}
 
-def _substitute_placehodlers(placeholder_dict, out_files_dict, value):
+def _substitute_placehodlers(placeholder_dict, value):
     new_value = value
     for key, file in placeholder_dict.items():
-        o_file = out_files_dict[file]
         p_str = file_placeholder(key)
-        new_value = new_value.replace(p_str, o_file.short_path)
+        new_value = new_value.replace(p_str, file.short_path)
     return new_value
 
 def _execute_binary_impl(ctx):
     bin_path = ctx.executable.binary.short_path
     out = ctx.actions.declare_file(ctx.label.name + ".sh")
 
-    # Copy any input files to the output. This is required when for example an
-    # execute_binary (#1) references another execute_binary (#2) and is tested
-    # by an sh_test. Any file args for #2 need to be present and have the correct
-    # permissions.
-    # Note: The file_args attribute shows up as a dict under ctx.attr.file_args and
-    # as a list under ctx.files.file_args
-    out_files_dict = {}
-    out_files_dir = ctx.label.name + "_eb_args"
-    for in_file in ctx.files.file_args:
-        out_file = ctx.actions.declare_file(out_files_dir + "/" + in_file.short_path)
-
-        # Copy any input files so that the argument files have the correct
-        # permissions if the execute_binary target is used by other
-        # execute_binary targets.
-        ctx.actions.run_shell(
-            outputs = [out_file],
-            inputs = [in_file],
-            arguments = [in_file.path, out_file.path],
-            command = "cp $1 $2",
-        )
-        out_files_dict[in_file] = out_file
-
     placeholder_dict = _create_file_args_placeholder_dict(ctx)
     quoted_args = []
     for arg in ctx.attr.args:
-        arg = _substitute_placehodlers(placeholder_dict, out_files_dict, arg)
+        arg = _substitute_placehodlers(placeholder_dict, arg)
         if arg.startswith("\"") and arg.endswith("\""):
             quoted_args.append(arg)
         else:
@@ -63,24 +40,11 @@ def _execute_binary_impl(ctx):
 
 set -euo pipefail
 
-# DEBUG BEGIN
-echo >&2 "*** CHUCK  $(basename ${BASH_SOURCE[0]}) before RUNFILES_DIR: ${RUNFILES_DIR:-}" 
-# DEBUG END
-
 # Set the RUNFILES_DIR. If an embedded binary is a sh_binary, it has trouble 
 # finding the runfiles directory. So, we help.
-[[ -f "${RUNFILES_DIR:-}" ]] && [[ -f "${PWD}/../MANIFEST" ]] && export RUNFILES_DIR="${PWD}/.."
+[[ -f "${PWD}/../MANIFEST" ]] && export RUNFILES_DIR="${PWD}/.."
 
 args=()
-""" + """\
-tmp_binary="{binary}"
-""".format(binary = bin_path) + """\
-
-# DEBUG BEGIN
-echo >&2 "*** CHUCK  $(basename ${BASH_SOURCE[0]}) PWD: ${PWD}" 
-echo >&2 "*** CHUCK  $(basename ${BASH_SOURCE[0]}) RUNFILES_DIR: ${RUNFILES_DIR:-}" 
-# DEBUG END
-
 """ + "\n".join([
             # Do not quote the {arg}. The values are already quoted. Adding the
             # quotes here will ruin the Bash substitution.
@@ -97,18 +61,11 @@ fi
 """.format(binary = bin_path),
     )
 
-    out_files = out_files_dict.values()
-    runfiles = ctx.runfiles(files = ctx.files.data + out_files)
+    # The file_args attribute shows up as a dict under ctx.attr.file_args and
+    # as a list under ctx.files.file_args
+    runfiles = ctx.runfiles(files = ctx.files.data + ctx.files.file_args)
     runfiles = runfiles.merge(ctx.attr.binary[DefaultInfo].default_runfiles)
-
-    # DEBUG BEGIN
-    print("*** CHUCK ctx.label: ", ctx.label)
-    print("*** CHUCK runfiles.files.to_list(): ")
-    for idx, item in enumerate(runfiles.files.to_list()):
-        print("*** CHUCK", idx, ":", item)
-
-    # DEBUG END
-    return DefaultInfo(executable = out, files = depset(out_files), runfiles = runfiles)
+    return DefaultInfo(executable = out, runfiles = runfiles)
 
 execute_binary = rule(
     implementation = _execute_binary_impl,

--- a/rules/private/execute_binary.bzl
+++ b/rules/private/execute_binary.bzl
@@ -52,25 +52,32 @@ set -euo pipefail
   export RUNFILES_DIR="${PWD}/.."
 
 # DEBUG BEGIN
-echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") PWD: ${PWD}" 
-tree >&2
+# echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") PWD: ${PWD}" 
+# tree >&2
 # DEBUG END
 
-args=()
+""" + """\
+binary="{binary}"
+""".format(binary = bin_path) + """\
+
+# Construct the command (binary plus args).
+cmd=( "${binary}" )
 """ + "\n".join([
             # Do not quote the {arg}. The values are already quoted. Adding the
             # quotes here will ruin the Bash substitution.
-            """args+=( {arg} )""".format(arg = arg)
+            """cmd+=( {arg} )""".format(arg = arg)
             for arg in quoted_args
         ]) + """
-[[ $# > 0 ]] && args+=( "${@}" )
-if [[ ${#args[@]} > 0 ]]; then
-""" + """\
-  "{binary}" "${{args[@]}}"
-else
-  "{binary}"
-fi
-""".format(binary = bin_path),
+
+# Add any args that were passed to this invocation
+[[ $# > 0 ]] && cmd+=( "${@}" )
+
+# Execute the binary with its args
+# DEBUG BEGIN
+set -x
+# DEBUG END
+"${cmd[@]}"
+""",
     )
 
     # The file_arguments attribute shows up as a dict under ctx.attr.file_arguments and

--- a/rules/private/execute_binary.bzl
+++ b/rules/private/execute_binary.bzl
@@ -28,6 +28,8 @@ def _execute_binary_impl(ctx):
     # execute_binary (#1) references another execute_binary (#2) and is tested
     # by an sh_test. Any file args for #2 need to be present and have the correct
     # permissions.
+    # Note: The file_args attribute shows up as a dict under ctx.attr.file_args and
+    # as a list under ctx.files.file_args
     out_files_dict = {}
     out_files_dir = ctx.label.name + "_eb_args"
     for in_file in ctx.files.file_args:
@@ -95,8 +97,6 @@ fi
 """.format(binary = bin_path),
     )
 
-    # The file_args attribute shows up as a dict under ctx.attr.file_args and
-    # as a list under ctx.files.file_args
     out_files = out_files_dict.values()
     runfiles = ctx.runfiles(files = ctx.files.data + out_files)
     runfiles = runfiles.merge(ctx.attr.binary[DefaultInfo].default_runfiles)
@@ -109,7 +109,6 @@ fi
 
     # DEBUG END
     return DefaultInfo(executable = out, files = depset(out_files), runfiles = runfiles)
-    # return DefaultInfo(executable = out, files = runfiles.files, runfiles = runfiles)
 
 execute_binary = rule(
     implementation = _execute_binary_impl,

--- a/rules/private/generate_release_notes.bzl
+++ b/rules/private/generate_release_notes.bzl
@@ -1,12 +1,24 @@
 load("//rules/private:execute_binary.bzl", "execute_binary", "file_placeholder")
 
-def generate_release_notes(name = "generate_release_notes", generate_workspace_snippet = None):
+def generate_release_notes(name, generate_workspace_snippet):
+    """Defines an executable target that generates release notes as Github markdown.
+
+    Typically, this macro is used in conjunction with the \
+    `generate_workspace_snippet` macro. The `generate_workspace_snippet` \
+    defines how to generate the workspace snippet. The resulting target \
+    is then referenced by this macro.
+
+    Args:
+        name: The name of the executable target as a `string`.
+        generate_workspace_snippet: The label that should be executed to \
+                                    generate the workspace snippet.
+    """
     file_arguments = {}
     arguments = []
-    if generate_workspace_snippet != None:
-        file_key = "generate_workspace_snippet"
-        arguments.extend(["--generate_workspace_snippet", file_placeholder(file_key)])
-        file_arguments[generate_workspace_snippet] = file_key
+
+    file_key = "generate_workspace_snippet"
+    arguments.extend(["--generate_workspace_snippet", file_placeholder(file_key)])
+    file_arguments[generate_workspace_snippet] = file_key
 
     execute_binary(
         name = name,

--- a/rules/private/generate_release_notes.bzl
+++ b/rules/private/generate_release_notes.bzl
@@ -1,12 +1,12 @@
 load("//rules/private:execute_binary.bzl", "execute_binary", "file_placeholder")
 
-def generate_release_notes(name = "generate_release_notes", snippet_template = None):
+def generate_release_notes(name = "generate_release_notes", generate_workspace_snippet = None):
     file_args = {}
     args = []
-    if snippet_template != None:
-        file_key = "snippet_template"
-        args.extend(["--snippet_template", file_placeholder(file_key)])
-        file_args[snippet_template] = file_key
+    if generate_workspace_snippet != None:
+        file_key = "generate_workspace_snippet"
+        args.extend(["--generate_workspace_snippet", file_placeholder(file_key)])
+        file_args[generate_workspace_snippet] = file_key
 
     execute_binary(
         name = name,

--- a/rules/private/generate_workspace_snippet.bzl
+++ b/rules/private/generate_workspace_snippet.bzl
@@ -1,8 +1,17 @@
 load("//rules/private:execute_binary.bzl", "execute_binary", "file_placeholder")
 
-# TODO: Add doc.
+def generate_workspace_snippet(name, template = None):
+    """Defines an executable target that generates a workspace snippet suitable \
+    for inclusion in a markdown document.
 
-def generate_workspace_snippet(name = "generate_workspace_snippet", template = None):
+    Without a template, the utility will output an `http_archive` declaration. \
+    With a template, the utility will output the template replacing \
+    `${http_archive_statement}` with the `http_archive` declaration.
+
+    Args:
+        name: The name of the executable target as a `string`.
+        template: The path to a template file  as a `string`.
+    """
     file_arguments = {}
     arguments = []
     if template != None:

--- a/rules/private/generate_workspace_snippet.bzl
+++ b/rules/private/generate_workspace_snippet.bzl
@@ -1,0 +1,18 @@
+load("//rules/private:execute_binary.bzl", "execute_binary", "file_placeholder")
+
+# TODO: Add doc.
+
+def generate_workspace_snippet(name = "generate_workspace_snippet", template = None):
+    file_args = {}
+    args = []
+    if template != None:
+        file_key = "template"
+        args.extend(["--template", file_placeholder(file_key)])
+        file_args[template] = file_key
+
+    execute_binary(
+        name = name,
+        args = args,
+        file_args = file_args,
+        binary = "@cgrindel_bazel_starlib//tools:generate_workspace_snippet",
+    )

--- a/tests/rules_tests/generate_release_notes_tests/BUILD.bazel
+++ b/tests/rules_tests/generate_release_notes_tests/BUILD.bazel
@@ -4,36 +4,39 @@ load("//tests:integration_test_common.bzl", "GH_ENV_INHERIT", "INTEGRATION_TEST_
 
 bzlformat_pkg(name = "bzlformat")
 
-generate_release_notes(
-    name = "without_template",
-)
+# TODO: Reimplement me!
 
-generate_release_notes(
-    name = "with_template",
-    snippet_template = "workspace_snippet.tmpl",
-)
+# generate_release_notes(
+#     name = "without_template",
+# )
 
-sh_test(
-    name = "generate_release_notes_test",
-    srcs = ["generate_release_notes_test.sh"],
-    data = [
-        ":with_template",
-        ":without_template",
-    ],
-    env_inherit = GH_ENV_INHERIT,
-    tags = INTEGRATION_TEST_TAGS,
-    deps = [
-        "//tests:setup_git_repo",
-        "@bazel_tools//tools/bash/runfiles",
-        "@cgrindel_bazel_starlib//lib/private:assertions",
-    ],
-)
+# generate_release_notes(
+#     name = "with_template",
+#     snippet_template = "workspace_snippet.tmpl",
+# )
+
+# sh_test(
+#     name = "generate_release_notes_test",
+#     srcs = ["generate_release_notes_test.sh"],
+#     data = [
+#         ":with_template",
+#         ":without_template",
+#     ],
+#     env_inherit = GH_ENV_INHERIT,
+#     tags = INTEGRATION_TEST_TAGS,
+#     deps = [
+#         "//tests:setup_git_repo",
+#         "@bazel_tools//tools/bash/runfiles",
+#         "@cgrindel_bazel_starlib//lib/private:assertions",
+#     ],
+# )
 
 test_suite(
     name = "integration_tests",
     tags = INTEGRATION_TEST_TAGS,
     tests = [
-        ":generate_release_notes_test",
+        # TODO: Enable me!
+        # ":generate_release_notes_test",
     ],
     visibility = ["//:__subpackages__"],
 )

--- a/tests/rules_tests/generate_release_notes_tests/BUILD.bazel
+++ b/tests/rules_tests/generate_release_notes_tests/BUILD.bazel
@@ -1,42 +1,40 @@
 load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
 load("//rules:generate_release_notes.bzl", "generate_release_notes")
+load("//rules:generate_workspace_snippet.bzl", "generate_workspace_snippet")
 load("//tests:integration_test_common.bzl", "GH_ENV_INHERIT", "INTEGRATION_TEST_TAGS")
 
 bzlformat_pkg(name = "bzlformat")
 
-# TODO: Reimplement me!
+generate_workspace_snippet(
+    name = "generate_workspace_snippet",
+    template = "workspace_snippet.tmpl",
+)
 
-# generate_release_notes(
-#     name = "without_template",
-# )
+generate_release_notes(
+    name = "generate_release_notes",
+    generate_workspace_snippet = ":generate_workspace_snippet",
+)
 
-# generate_release_notes(
-#     name = "with_template",
-#     snippet_template = "workspace_snippet.tmpl",
-# )
-
-# sh_test(
-#     name = "generate_release_notes_test",
-#     srcs = ["generate_release_notes_test.sh"],
-#     data = [
-#         ":with_template",
-#         ":without_template",
-#     ],
-#     env_inherit = GH_ENV_INHERIT,
-#     tags = INTEGRATION_TEST_TAGS,
-#     deps = [
-#         "//tests:setup_git_repo",
-#         "@bazel_tools//tools/bash/runfiles",
-#         "@cgrindel_bazel_starlib//lib/private:assertions",
-#     ],
-# )
+sh_test(
+    name = "generate_release_notes_test",
+    srcs = ["generate_release_notes_test.sh"],
+    data = [
+        ":generate_release_notes",
+    ],
+    env_inherit = GH_ENV_INHERIT,
+    tags = INTEGRATION_TEST_TAGS,
+    deps = [
+        "//tests:setup_git_repo",
+        "@bazel_tools//tools/bash/runfiles",
+        "@cgrindel_bazel_starlib//lib/private:assertions",
+    ],
+)
 
 test_suite(
     name = "integration_tests",
     tags = INTEGRATION_TEST_TAGS,
     tests = [
-        # TODO: Enable me!
-        # ":generate_release_notes_test",
+        ":generate_release_notes_test",
     ],
     visibility = ["//:__subpackages__"],
 )

--- a/tests/rules_tests/generate_release_notes_tests/generate_release_notes_test.sh
+++ b/tests/rules_tests/generate_release_notes_tests/generate_release_notes_test.sh
@@ -19,13 +19,17 @@ setup_git_repo_sh="$(rlocation "${setup_git_repo_sh_location}")" || \
   (echo >&2 "Failed to locate ${setup_git_repo_sh_location}" && exit 1)
 
 
-without_template_sh_location=cgrindel_bazel_starlib/tests/rules_tests/generate_release_notes_tests/without_template.sh
-without_template_sh="$(rlocation "${without_template_sh_location}")" || \
-  (echo >&2 "Failed to locate ${without_template_sh_location}" && exit 1)
+# without_template_sh_location=cgrindel_bazel_starlib/tests/rules_tests/generate_release_notes_tests/without_template.sh
+# without_template_sh="$(rlocation "${without_template_sh_location}")" || \
+#   (echo >&2 "Failed to locate ${without_template_sh_location}" && exit 1)
 
-with_template_sh_location=cgrindel_bazel_starlib/tests/rules_tests/generate_release_notes_tests/with_template.sh
-with_template_sh="$(rlocation "${with_template_sh_location}")" || \
-  (echo >&2 "Failed to locate ${with_template_sh_location}" && exit 1)
+# with_template_sh_location=cgrindel_bazel_starlib/tests/rules_tests/generate_release_notes_tests/with_template.sh
+# with_template_sh="$(rlocation "${with_template_sh_location}")" || \
+#   (echo >&2 "Failed to locate ${with_template_sh_location}" && exit 1)
+
+generate_release_notes_sh_location=cgrindel_bazel_starlib/tests/rules_tests/generate_release_notes_tests/generate_release_notes.sh
+generate_release_notes_sh="$(rlocation "${generate_release_notes_sh_location}")" || \
+  (echo >&2 "Failed to locate ${generate_release_notes_sh_location}" && exit 1)
 
 
 # MARK - Setup
@@ -37,17 +41,12 @@ source "${setup_git_repo_sh}"
 
 tag="v999.0.0"
 
-actual="$( "${without_template_sh}" "${tag}" )"
-[[ "${actual}" =~ "## What's Changed" ]] || \
-  fail "Without Template: Did not find release notes header."
-[[ ! "${actual}" =~ "bazel_starlib_dependencies()" ]] || \
-  fail "Without Template: Found content from the template."
+actual="$( "${generate_release_notes_sh}" "${tag}" )"
+assert_match "## What's Changed" "${actual}" "Did not find release notes header."
+assert_match "bazel_starlib_dependencies()" "${actual}" "Did not find template content."
+# assert_no_match "bazel_starlib_dependencies()" "${actual}" "Did not find template content."
 
-
-actual="$( "${with_template_sh}" "${tag}" )"
-[[ "${actual}" =~ "## What's Changed" ]] || \
-  fail "With Template: Did not find release notes header."
-[[ "${actual}" =~ "bazel_starlib_dependencies()" ]] || \
-  fail "With Template: Did not find content from the template."
-
-
+# # DEBUG BEGIN
+# echo >&2 "*** CHUCK  actual:"$'\n'"${actual}" 
+# fail "STOP"
+# # DEBUG END

--- a/tests/rules_tests/generate_release_notes_tests/generate_release_notes_test.sh
+++ b/tests/rules_tests/generate_release_notes_tests/generate_release_notes_test.sh
@@ -18,15 +18,6 @@ setup_git_repo_sh_location=cgrindel_bazel_starlib/tests/setup_git_repo.sh
 setup_git_repo_sh="$(rlocation "${setup_git_repo_sh_location}")" || \
   (echo >&2 "Failed to locate ${setup_git_repo_sh_location}" && exit 1)
 
-
-# without_template_sh_location=cgrindel_bazel_starlib/tests/rules_tests/generate_release_notes_tests/without_template.sh
-# without_template_sh="$(rlocation "${without_template_sh_location}")" || \
-#   (echo >&2 "Failed to locate ${without_template_sh_location}" && exit 1)
-
-# with_template_sh_location=cgrindel_bazel_starlib/tests/rules_tests/generate_release_notes_tests/with_template.sh
-# with_template_sh="$(rlocation "${with_template_sh_location}")" || \
-#   (echo >&2 "Failed to locate ${with_template_sh_location}" && exit 1)
-
 generate_release_notes_sh_location=cgrindel_bazel_starlib/tests/rules_tests/generate_release_notes_tests/generate_release_notes.sh
 generate_release_notes_sh="$(rlocation "${generate_release_notes_sh_location}")" || \
   (echo >&2 "Failed to locate ${generate_release_notes_sh_location}" && exit 1)
@@ -44,13 +35,3 @@ tag="v999.0.0"
 actual="$( "${generate_release_notes_sh}" "${tag}" )"
 assert_match "## What's Changed" "${actual}" "Did not find release notes header."
 assert_match "bazel_starlib_dependencies()" "${actual}" "Did not find template content."
-# assert_no_match "bazel_starlib_dependencies()" "${actual}" "Did not find template content."
-
-# # DEBUG BEGIN
-# echo >&2 "*** CHUCK  actual:"$'\n'"${actual}" 
-# fail "STOP"
-# # DEBUG END
-
-# DEBUG BEGIN
-echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") PWD: ${PWD}" 
-# DEBUG END

--- a/tests/rules_tests/generate_release_notes_tests/generate_release_notes_test.sh
+++ b/tests/rules_tests/generate_release_notes_tests/generate_release_notes_test.sh
@@ -50,3 +50,7 @@ assert_match "bazel_starlib_dependencies()" "${actual}" "Did not find template c
 # echo >&2 "*** CHUCK  actual:"$'\n'"${actual}" 
 # fail "STOP"
 # # DEBUG END
+
+# DEBUG BEGIN
+echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") PWD: ${PWD}" 
+# DEBUG END

--- a/tests/rules_tests/generate_workspace_snippet_tests/BUILD.bazel
+++ b/tests/rules_tests/generate_workspace_snippet_tests/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
 load("//rules:generate_workspace_snippet.bzl", "generate_workspace_snippet")
+load("//tests:integration_test_common.bzl", "GH_ENV_INHERIT", "INTEGRATION_TEST_TAGS")
 
 bzlformat_pkg(name = "bzlformat")
 
@@ -10,4 +11,29 @@ generate_workspace_snippet(
 generate_workspace_snippet(
     name = "with_template",
     template = "workspace_snippet.tmpl",
+)
+
+sh_test(
+    name = "generate_workspace_snippet_test",
+    srcs = ["generate_workspace_snippet_test.sh"],
+    data = [
+        ":with_template",
+        ":without_template",
+    ],
+    env_inherit = GH_ENV_INHERIT,
+    tags = INTEGRATION_TEST_TAGS,
+    deps = [
+        "//tests:setup_git_repo",
+        "@bazel_tools//tools/bash/runfiles",
+        "@cgrindel_bazel_starlib//lib/private:assertions",
+    ],
+)
+
+test_suite(
+    name = "integration_tests",
+    tags = INTEGRATION_TEST_TAGS,
+    tests = [
+        ":generate_workspace_snippet_test",
+    ],
+    visibility = ["//:__subpackages__"],
 )

--- a/tests/rules_tests/generate_workspace_snippet_tests/BUILD.bazel
+++ b/tests/rules_tests/generate_workspace_snippet_tests/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("//rules:generate_workspace_snippet.bzl", "generate_workspace_snippet")
+
+bzlformat_pkg(name = "bzlformat")
+
+generate_workspace_snippet(
+    name = "without_template",
+)
+
+generate_workspace_snippet(
+    name = "with_template",
+    template = "workspace_snippet.tmpl",
+)

--- a/tests/rules_tests/generate_workspace_snippet_tests/generate_workspace_snippet_test.sh
+++ b/tests/rules_tests/generate_workspace_snippet_tests/generate_workspace_snippet_test.sh
@@ -16,4 +16,22 @@ assertions_sh="$(rlocation "${assertions_sh_location}")" || \
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 source "${assertions_sh}"
 
+setup_git_repo_sh_location=cgrindel_bazel_starlib/tests/setup_git_repo.sh
+setup_git_repo_sh="$(rlocation "${setup_git_repo_sh_location}")" || \
+  (echo >&2 "Failed to locate ${setup_git_repo_sh_location}" && exit 1)
+
+without_template_sh_location=cgrindel_bazel_starlib/tests/rules_tests/generate_workspace_snippet_tests/without_template.sh
+without_template_sh="$(rlocation "${without_template_sh_location}")" || \
+  (echo >&2 "Failed to locate ${without_template_sh_location}" && exit 1)
+
+with_template_sh_location=cgrindel_bazel_starlib/tests/rules_tests/generate_workspace_snippet_tests/with_template.sh
+with_template_sh="$(rlocation "${with_template_sh_location}")" || \
+  (echo >&2 "Failed to locate ${with_template_sh_location}" && exit 1)
+
+# MARK - Setup
+
+source "${setup_git_repo_sh}"
+
+# MARK - Test
+
 fail "IMPLEMENT ME!"

--- a/tests/rules_tests/generate_workspace_snippet_tests/generate_workspace_snippet_test.sh
+++ b/tests/rules_tests/generate_workspace_snippet_tests/generate_workspace_snippet_test.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+assertions_sh_location=cgrindel_bazel_starlib/lib/private/assertions.sh
+assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+  (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
+source "${assertions_sh}"
+
+fail "IMPLEMENT ME!"

--- a/tests/rules_tests/generate_workspace_snippet_tests/generate_workspace_snippet_test.sh
+++ b/tests/rules_tests/generate_workspace_snippet_tests/generate_workspace_snippet_test.sh
@@ -38,8 +38,9 @@ tag="v999.0.0"
 
 actual="$( "${without_template_sh}" --tag "${tag}" )"
 assert_match 'http_archive\(' "${actual}" "Without Template http_archive"
+assert_match 'name = "cgrindel_bazel_starlib"' "${actual}" "Without Template name attribute"
 
-
-# DEBUG BEGIN
-fail "IMPLEMENT ME!"
-# DEBUG END
+actual="$( "${with_template_sh}" --tag "${tag}" )"
+assert_match 'http_archive\(' "${actual}" "With Template http_archive"
+assert_match 'name = "cgrindel_bazel_starlib"' "${actual}" "With Template name attribute"
+assert_match bazel_starlib_dependencies "${actual}" "With Template bazel_starlib_dependencies"

--- a/tests/rules_tests/generate_workspace_snippet_tests/generate_workspace_snippet_test.sh
+++ b/tests/rules_tests/generate_workspace_snippet_tests/generate_workspace_snippet_test.sh
@@ -39,6 +39,7 @@ tag="v999.0.0"
 actual="$( "${without_template_sh}" --tag "${tag}" )"
 assert_match 'http_archive\(' "${actual}" "Without Template http_archive"
 assert_match 'name = "cgrindel_bazel_starlib"' "${actual}" "Without Template name attribute"
+assert_no_match bazel_starlib_dependencies "${actual}" "Without Template bazel_starlib_dependencies"
 
 actual="$( "${with_template_sh}" --tag "${tag}" )"
 assert_match 'http_archive\(' "${actual}" "With Template http_archive"

--- a/tests/rules_tests/generate_workspace_snippet_tests/generate_workspace_snippet_test.sh
+++ b/tests/rules_tests/generate_workspace_snippet_tests/generate_workspace_snippet_test.sh
@@ -34,4 +34,12 @@ source "${setup_git_repo_sh}"
 
 # MARK - Test
 
+tag="v999.0.0"
+
+actual="$( "${without_template_sh}" --tag "${tag}" )"
+assert_match 'http_archive\(' "${actual}" "Without Template http_archive"
+
+
+# DEBUG BEGIN
 fail "IMPLEMENT ME!"
+# DEBUG END

--- a/tests/rules_tests/generate_workspace_snippet_tests/workspace_snippet.tmpl
+++ b/tests/rules_tests/generate_workspace_snippet_tests/workspace_snippet.tmpl
@@ -1,0 +1,19 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+${http_archive_statement}
+
+load("@cgrindel_bazel_starlib//:deps.bzl", "bazel_starlib_dependencies")
+
+bazel_starlib_dependencies()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
+load("@cgrindel_bazel_doc//bazeldoc:deps.bzl", "bazeldoc_dependencies")
+
+bazeldoc_dependencies()
+
+load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
+
+stardoc_repositories()

--- a/tests/tools_tests/BUILD.bazel
+++ b/tests/tools_tests/BUILD.bazel
@@ -80,8 +80,8 @@ sh_test(
     name = "generate_release_notes_test",
     srcs = ["generate_release_notes_test.sh"],
     data = [
-        "workspace_snippet.tmpl",
         "//tools:generate_release_notes",
+        "//tools:generate_workspace_snippet",
     ],
     env_inherit = GH_ENV_INHERIT,
     tags = INTEGRATION_TEST_TAGS,

--- a/tests/tools_tests/generate_release_notes_test.sh
+++ b/tests/tools_tests/generate_release_notes_test.sh
@@ -35,10 +35,6 @@ generate_release_notes_sh_location=cgrindel_bazel_starlib/tools/generate_release
 generate_release_notes_sh="$(rlocation "${generate_release_notes_sh_location}")" || \
   (echo >&2 "Failed to locate ${generate_release_notes_sh_location}" && exit 1)
 
-# workspace_snippet_tmpl_location=cgrindel_bazel_starlib/tests/tools_tests/workspace_snippet.tmpl
-# workspace_snippet_tmpl="$(rlocation "${workspace_snippet_tmpl_location}")" || \
-#   (echo >&2 "Failed to locate ${workspace_snippet_tmpl_location}" && exit 1)
-
 is_installed git || fail "Could not find git."
 
 # MARK - Setup

--- a/tests/tools_tests/generate_release_notes_test.sh
+++ b/tests/tools_tests/generate_release_notes_test.sh
@@ -27,13 +27,17 @@ setup_git_repo_sh_location=cgrindel_bazel_starlib/tests/setup_git_repo.sh
 setup_git_repo_sh="$(rlocation "${setup_git_repo_sh_location}")" || \
   (echo >&2 "Failed to locate ${setup_git_repo_sh_location}" && exit 1)
 
+generate_workspace_snippet_sh_location=cgrindel_bazel_starlib/tools/generate_workspace_snippet.sh
+generate_workspace_snippet_sh="$(rlocation "${generate_workspace_snippet_sh_location}")" || \
+  (echo >&2 "Failed to locate ${generate_workspace_snippet_sh_location}" && exit 1)
+
 generate_release_notes_sh_location=cgrindel_bazel_starlib/tools/generate_release_notes.sh
 generate_release_notes_sh="$(rlocation "${generate_release_notes_sh_location}")" || \
   (echo >&2 "Failed to locate ${generate_release_notes_sh_location}" && exit 1)
 
-workspace_snippet_tmpl_location=cgrindel_bazel_starlib/tests/tools_tests/workspace_snippet.tmpl
-workspace_snippet_tmpl="$(rlocation "${workspace_snippet_tmpl_location}")" || \
-  (echo >&2 "Failed to locate ${workspace_snippet_tmpl_location}" && exit 1)
+# workspace_snippet_tmpl_location=cgrindel_bazel_starlib/tests/tools_tests/workspace_snippet.tmpl
+# workspace_snippet_tmpl="$(rlocation "${workspace_snippet_tmpl_location}")" || \
+#   (echo >&2 "Failed to locate ${workspace_snippet_tmpl_location}" && exit 1)
 
 is_installed git || fail "Could not find git."
 
@@ -48,17 +52,12 @@ cd "${repo_dir}"
 
 tag="v0.1.1"
 
-# Test without template
-actual="$( "${generate_release_notes_sh}" "${tag}" )"
-[[ "${actual}" =~ "## What's Changed" ]]
-[[ "${actual}" =~ "## Workspace Snippet" ]]
-[[ "${actual}" =~ "http_archive(" ]]
-
-# Test with template
+# Test
 actual="$( 
-  "${generate_release_notes_sh}" --snippet_template "${workspace_snippet_tmpl}" "${tag}" 
+  "${generate_release_notes_sh}" \
+    --generate_workspace_snippet "${generate_workspace_snippet_sh}" \
+    "${tag}" 
 )"
 [[ "${actual}" =~ "## What's Changed" ]]
 [[ "${actual}" =~ "## Workspace Snippet" ]]
 [[ "${actual}" =~ "http_archive(" ]]
-[[ "${actual}" =~ "bazel_starlib_dependencies()" ]]

--- a/tests/tools_tests/generate_sha256_test.sh
+++ b/tests/tools_tests/generate_sha256_test.sh
@@ -11,7 +11,7 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
-# MARK - Locate Depedencies
+# MARK - Locate Dependencies
 
 fail_sh_location=cgrindel_bazel_starlib/lib/private/fail.sh
 fail_sh="$(rlocation "${fail_sh_location}")" || \

--- a/tests/tools_tests/generate_workspace_snippet_test.sh
+++ b/tests/tools_tests/generate_workspace_snippet_test.sh
@@ -136,13 +136,6 @@ err_output="$(
 err_output="$(
 "${generate_workspace_snippet_sh}" \
   --tag "${tag}" \
-  2>&1 || true
-)"
-[[ "${err_output}" =~ "Expected a SHA256 value." ]] || fail "Missing SHA256 failure."
-
-err_output="$(
-"${generate_workspace_snippet_sh}" \
-  --tag "${tag}" \
   --sha256 "${sha256}" \
   --no_github_archive_url \
   2>&1 || true

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -79,7 +79,6 @@ sh_binary(
         ":generate_gh_changelog",
         ":generate_git_archive",
         ":generate_sha256",
-        ":generate_workspace_snippet",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -5,6 +5,10 @@ bzlformat_pkg(name = "bzlformat")
 sh_binary(
     name = "generate_workspace_snippet",
     srcs = ["generate_workspace_snippet.sh"],
+    data = [
+        ":generate_git_archive",
+        ":generate_sha256",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         "//lib/private:fail",
@@ -77,8 +81,6 @@ sh_binary(
     srcs = ["generate_release_notes.sh"],
     data = [
         ":generate_gh_changelog",
-        ":generate_git_archive",
-        ":generate_sha256",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/tools/create_release.sh
+++ b/tools/create_release.sh
@@ -11,7 +11,7 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
-# MARK - Locate Depedencies
+# MARK - Locate Dependencies
 
 fail_sh_location=cgrindel_bazel_starlib/lib/private/fail.sh
 fail_sh="$(rlocation "${fail_sh_location}")" || \

--- a/tools/generate_gh_changelog.sh
+++ b/tools/generate_gh_changelog.sh
@@ -11,7 +11,7 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
-# MARK - Locate Depedencies
+# MARK - Locate Dependencies
 
 fail_sh_location=cgrindel_bazel_starlib/lib/private/fail.sh
 fail_sh="$(rlocation "${fail_sh_location}")" || \

--- a/tools/generate_git_archive.sh
+++ b/tools/generate_git_archive.sh
@@ -18,7 +18,7 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
-# MARK - Locate Depedencies
+# MARK - Locate Dependencies
 
 fail_sh_location=cgrindel_bazel_starlib/lib/private/fail.sh
 fail_sh="$(rlocation "${fail_sh_location}")" || \

--- a/tools/generate_release_notes.sh
+++ b/tools/generate_release_notes.sh
@@ -30,9 +30,9 @@ generate_sha256_sh_location=cgrindel_bazel_starlib/tools/generate_sha256.sh
 generate_sha256_sh="$(rlocation "${generate_sha256_sh_location}")" || \
   (echo >&2 "Failed to locate ${generate_sha256_sh_location}" && exit 1)
 
-generate_workspace_snippet_sh_location=cgrindel_bazel_starlib/tools/generate_workspace_snippet.sh
-generate_workspace_snippet_sh="$(rlocation "${generate_workspace_snippet_sh_location}")" || \
-  (echo >&2 "Failed to locate ${generate_workspace_snippet_sh_location}" && exit 1)
+# generate_workspace_snippet_sh_location=cgrindel_bazel_starlib/tools/generate_workspace_snippet.sh
+# generate_workspace_snippet_sh="$(rlocation "${generate_workspace_snippet_sh_location}")" || \
+#   (echo >&2 "Failed to locate ${generate_workspace_snippet_sh_location}" && exit 1)
 
 # MARK - Process Arguments
 
@@ -45,12 +45,13 @@ while (("$#")); do
       output_path="${2}"
       shift 2
       ;;
-    "--snippet_template")
+    "--generate_workspace_snippet")
       # If the input path is not absolute, then resolve it to be relative to
       # the starting directory. We do this before we starting changing
       # directories.
-      snippet_template="${2}"
-      [[ "${snippet_template}" =~ ^/ ]] || snippet_template="${starting_dir}/${2}"
+      generate_workspace_snippet="${2}"
+      [[ "${generate_workspace_snippet}" =~ ^/ ]] || \
+        generate_workspace_snippet="${starting_dir}/${generate_workspace_snippet}"
       shift 2
       ;;
     --*)
@@ -65,6 +66,9 @@ done
 
 [[ ${#args[@]} == 0 ]] && fail "A tag name for the release must be specified."
 tag_name="${args[0]}"
+
+[[ -z "${generate_workspace_snippet:-}" ]] && \
+  fail "Expected a value for --generate_workspace_snippet."
 
 
 # MARK - Generate the changelog.
@@ -81,8 +85,7 @@ changelog_md="$( "${generate_gh_changelog_sh}" "${tag_name}" )"
 archive_sha256="$( "${generate_git_archive_sh}" --tag_name "${tag_name}" | "${generate_sha256_sh}" )"
 
 workspace_snippet_args=(--sha256 "${archive_sha256}" --tag "${tag_name}")
-[[ -z "${snippet_template:-}" ]] || workspace_snippet_args+=(--template "${snippet_template}")
-workspace_snippet="$( "${generate_workspace_snippet_sh}" "${workspace_snippet_args[@]}" )"
+workspace_snippet="$( "${generate_workspace_snippet}" "${workspace_snippet_args[@]}" )"
 
 release_notes_md="$(cat <<-EOF
 ${changelog_md}

--- a/tools/generate_release_notes.sh
+++ b/tools/generate_release_notes.sh
@@ -22,13 +22,13 @@ generate_gh_changelog_sh_location=cgrindel_bazel_starlib/tools/generate_gh_chang
 generate_gh_changelog_sh="$(rlocation "${generate_gh_changelog_sh_location}")" || \
   (echo >&2 "Failed to locate ${generate_gh_changelog_sh_location}" && exit 1)
 
-generate_git_archive_sh_location=cgrindel_bazel_starlib/tools/generate_git_archive.sh
-generate_git_archive_sh="$(rlocation "${generate_git_archive_sh_location}")" || \
-  (echo >&2 "Failed to locate ${generate_git_archive_sh_location}" && exit 1)
+# generate_git_archive_sh_location=cgrindel_bazel_starlib/tools/generate_git_archive.sh
+# generate_git_archive_sh="$(rlocation "${generate_git_archive_sh_location}")" || \
+#   (echo >&2 "Failed to locate ${generate_git_archive_sh_location}" && exit 1)
 
-generate_sha256_sh_location=cgrindel_bazel_starlib/tools/generate_sha256.sh
-generate_sha256_sh="$(rlocation "${generate_sha256_sh_location}")" || \
-  (echo >&2 "Failed to locate ${generate_sha256_sh_location}" && exit 1)
+# generate_sha256_sh_location=cgrindel_bazel_starlib/tools/generate_sha256.sh
+# generate_sha256_sh="$(rlocation "${generate_sha256_sh_location}")" || \
+#   (echo >&2 "Failed to locate ${generate_sha256_sh_location}" && exit 1)
 
 # generate_workspace_snippet_sh_location=cgrindel_bazel_starlib/tools/generate_workspace_snippet.sh
 # generate_workspace_snippet_sh="$(rlocation "${generate_workspace_snippet_sh_location}")" || \
@@ -82,10 +82,11 @@ cd "${BUILD_WORKSPACE_DIRECTORY}"
   "generating release notes on this OS may result in an incompatible SHA256 value."
 
 changelog_md="$( "${generate_gh_changelog_sh}" "${tag_name}" )"
-archive_sha256="$( "${generate_git_archive_sh}" --tag_name "${tag_name}" | "${generate_sha256_sh}" )"
 
-workspace_snippet_args=(--sha256 "${archive_sha256}" --tag "${tag_name}")
-workspace_snippet="$( "${generate_workspace_snippet}" "${workspace_snippet_args[@]}" )"
+# archive_sha256="$( "${generate_git_archive_sh}" --tag_name "${tag_name}" | "${generate_sha256_sh}" )"
+# workspace_snippet_args=(--sha256 "${archive_sha256}" --tag "${tag_name}")
+# workspace_snippet="$( "${generate_workspace_snippet}" "${workspace_snippet_args[@]}" )"
+workspace_snippet="$( "${generate_workspace_snippet}" --tag "${tag_name}" )"
 
 release_notes_md="$(cat <<-EOF
 ${changelog_md}

--- a/tools/generate_release_notes.sh
+++ b/tools/generate_release_notes.sh
@@ -83,10 +83,15 @@ cd "${BUILD_WORKSPACE_DIRECTORY}"
 
 changelog_md="$( "${generate_gh_changelog_sh}" "${tag_name}" )"
 
+# # Go back to the starting directory so that embedded binary for generate_workspace_snippet can be found.
+# cd "${starting_dir}"
+
 # archive_sha256="$( "${generate_git_archive_sh}" --tag_name "${tag_name}" | "${generate_sha256_sh}" )"
 # workspace_snippet_args=(--sha256 "${archive_sha256}" --tag "${tag_name}")
 # workspace_snippet="$( "${generate_workspace_snippet}" "${workspace_snippet_args[@]}" )"
+
 workspace_snippet="$( "${generate_workspace_snippet}" --tag "${tag_name}" )"
+
 
 release_notes_md="$(cat <<-EOF
 ${changelog_md}

--- a/tools/generate_release_notes.sh
+++ b/tools/generate_release_notes.sh
@@ -11,7 +11,7 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
-# MARK - Locate Depedencies
+# MARK - Locate Dependencies
 
 fail_sh_location=cgrindel_bazel_starlib/lib/private/fail.sh
 fail_sh="$(rlocation "${fail_sh_location}")" || \

--- a/tools/generate_release_notes.sh
+++ b/tools/generate_release_notes.sh
@@ -22,18 +22,6 @@ generate_gh_changelog_sh_location=cgrindel_bazel_starlib/tools/generate_gh_chang
 generate_gh_changelog_sh="$(rlocation "${generate_gh_changelog_sh_location}")" || \
   (echo >&2 "Failed to locate ${generate_gh_changelog_sh_location}" && exit 1)
 
-# generate_git_archive_sh_location=cgrindel_bazel_starlib/tools/generate_git_archive.sh
-# generate_git_archive_sh="$(rlocation "${generate_git_archive_sh_location}")" || \
-#   (echo >&2 "Failed to locate ${generate_git_archive_sh_location}" && exit 1)
-
-# generate_sha256_sh_location=cgrindel_bazel_starlib/tools/generate_sha256.sh
-# generate_sha256_sh="$(rlocation "${generate_sha256_sh_location}")" || \
-#   (echo >&2 "Failed to locate ${generate_sha256_sh_location}" && exit 1)
-
-# generate_workspace_snippet_sh_location=cgrindel_bazel_starlib/tools/generate_workspace_snippet.sh
-# generate_workspace_snippet_sh="$(rlocation "${generate_workspace_snippet_sh_location}")" || \
-#   (echo >&2 "Failed to locate ${generate_workspace_snippet_sh_location}" && exit 1)
-
 # MARK - Process Arguments
 
 starting_dir="${PWD}"

--- a/tools/generate_release_notes.sh
+++ b/tools/generate_release_notes.sh
@@ -71,15 +71,7 @@ cd "${BUILD_WORKSPACE_DIRECTORY}"
 
 changelog_md="$( "${generate_gh_changelog_sh}" "${tag_name}" )"
 
-# # Go back to the starting directory so that embedded binary for generate_workspace_snippet can be found.
-# cd "${starting_dir}"
-
-# archive_sha256="$( "${generate_git_archive_sh}" --tag_name "${tag_name}" | "${generate_sha256_sh}" )"
-# workspace_snippet_args=(--sha256 "${archive_sha256}" --tag "${tag_name}")
-# workspace_snippet="$( "${generate_workspace_snippet}" "${workspace_snippet_args[@]}" )"
-
 workspace_snippet="$( "${generate_workspace_snippet}" --tag "${tag_name}" )"
-
 
 release_notes_md="$(cat <<-EOF
 ${changelog_md}

--- a/tools/generate_sha256.sh
+++ b/tools/generate_sha256.sh
@@ -11,7 +11,7 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
-# MARK - Locate Depedencies
+# MARK - Locate Dependencies
 
 fail_sh_location=cgrindel_bazel_starlib/lib/private/fail.sh
 fail_sh="$(rlocation "${fail_sh_location}")" || \

--- a/tools/generate_workspace_snippet.sh
+++ b/tools/generate_workspace_snippet.sh
@@ -21,7 +21,7 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
-# MARK - Locate Depedencies
+# MARK - Locate Dependencies
 
 fail_sh_location=cgrindel_bazel_starlib/lib/private/fail.sh
 fail_sh="$(rlocation "${fail_sh_location}")" || \

--- a/tools/generate_workspace_snippet.sh
+++ b/tools/generate_workspace_snippet.sh
@@ -104,6 +104,8 @@ while (("$#")); do
   esac
 done
 
+[[ ${#args[@]} > 0 ]] && fail "Received unexpected arguments: ${args[@]}"
+
 [[ -z "${tag:-}" ]] && fail "Expected a tag value."
 
 [[ "${add_github_archive_url}" == true ]] && \

--- a/tools/generate_workspace_snippet.sh
+++ b/tools/generate_workspace_snippet.sh
@@ -52,10 +52,6 @@ starting_dir="${PWD}"
 
 # MARK - Process Args
 
-# DEBUG BEGIN
-echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") @: ${@}" 
-# DEBUG END
-
 add_github_archive_url=true
 url_templates=()
 args=()

--- a/tools/generate_workspace_snippet.sh
+++ b/tools/generate_workspace_snippet.sh
@@ -52,6 +52,10 @@ starting_dir="${PWD}"
 
 # MARK - Process Args
 
+# DEBUG BEGIN
+echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") @: ${@}" 
+# DEBUG END
+
 add_github_archive_url=true
 url_templates=()
 args=()

--- a/tools/generate_workspace_snippet.sh
+++ b/tools/generate_workspace_snippet.sh
@@ -38,6 +38,14 @@ github_sh="$(rlocation "${github_sh_location}")" || \
   (echo >&2 "Failed to locate ${github_sh_location}" && exit 1)
 source "${github_sh}"
 
+generate_git_archive_sh_location=cgrindel_bazel_starlib/tools/generate_git_archive.sh
+generate_git_archive_sh="$(rlocation "${generate_git_archive_sh_location}")" || \
+  (echo >&2 "Failed to locate ${generate_git_archive_sh_location}" && exit 1)
+
+generate_sha256_sh_location=cgrindel_bazel_starlib/tools/generate_sha256.sh
+generate_sha256_sh="$(rlocation "${generate_sha256_sh_location}")" || \
+  (echo >&2 "Failed to locate ${generate_sha256_sh_location}" && exit 1)
+
 # MARK - Keep Track of the starting directory
 
 starting_dir="${PWD}"
@@ -96,13 +104,17 @@ while (("$#")); do
   esac
 done
 
-[[ -z "${sha256:-}" ]] && fail "Expected a SHA256 value."
 [[ -z "${tag:-}" ]] && fail "Expected a tag value."
 
 [[ "${add_github_archive_url}" == true ]] && \
   url_templates+=( 'http://github.com/${owner}/${repo}/archive/${tag}.tar.gz' )
 [[ ${#url_templates[@]} > 0 ]] || fail "Expected one ore more url templates."
 
+# MARK - Ensure that we have a SHA256 value
+
+if [[ -z "${sha256:-}" ]]; then
+  sha256="$( "${generate_git_archive_sh}" --tag_name "${tag}" | "${generate_sha256_sh}" )"
+fi
 
 # MARK - Generate the snippet
 

--- a/tools/get_gh_auth_token.sh
+++ b/tools/get_gh_auth_token.sh
@@ -11,7 +11,7 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
-# MARK - Locate Depedencies
+# MARK - Locate Dependencies
 
 fail_sh_location=cgrindel_bazel_starlib/lib/private/fail.sh
 fail_sh="$(rlocation "${fail_sh_location}")" || \

--- a/tools/update_readme.sh
+++ b/tools/update_readme.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+# MARK - Locate Depedencies
+
+fail_sh_location=cgrindel_bazel_starlib/lib/private/fail.sh
+fail_sh="$(rlocation "${fail_sh_location}")" || \
+  (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
+source "${fail_sh}"
+
+

--- a/tools/update_readme.sh
+++ b/tools/update_readme.sh
@@ -11,7 +11,7 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
-# MARK - Locate Depedencies
+# MARK - Locate Dependencies
 
 fail_sh_location=cgrindel_bazel_starlib/lib/private/fail.sh
 fail_sh="$(rlocation "${fail_sh_location}")" || \

--- a/tools/write_bazel_status_vars.sh
+++ b/tools/write_bazel_status_vars.sh
@@ -11,7 +11,7 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
-# MARK - Locate Depedencies
+# MARK - Locate Dependencies
 
 fail_sh_location=cgrindel_bazel_starlib/lib/private/fail.sh
 fail_sh="$(rlocation "${fail_sh_location}")" || \


### PR DESCRIPTION
Related to #4.

- Introduced `generate_workspace_snippet` macro to allow rule maintainers to define how to build their workspace snippet.
- Updated `generate_release_notes` to reference the target defined by `generate_workspace_snippet`.
- Refactored `execute_binary` rule to streamline the code generation and fix an issue with locating the binary.