### PR TITLE
Implemented `update_readme.sh` and `update_readme` macro

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -39,6 +39,7 @@ test_suite(
         "//tests/lib_tests/private_tests/github_tests:integration_tests",
         "//tests/rules_tests/generate_release_notes_tests:integration_tests",
         "//tests/rules_tests/generate_workspace_snippet_tests:integration_tests",
+        "//tests/rules_tests/update_readme_tests:integration_tests",
         "//tests/tools_tests:integration_tests",
     ],
     visibility = ["//:__subpackages__"],

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -10,6 +10,7 @@ load(
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("//rules:generate_release_notes.bzl", "generate_release_notes")
 load("//rules:generate_workspace_snippet.bzl", "generate_workspace_snippet")
+load("//rules:update_readme.bzl", "update_readme")
 
 bzlformat_pkg(name = "bzlformat")
 
@@ -55,7 +56,7 @@ generate_release_notes(
     generate_workspace_snippet = ":generate_workspace_snippet",
 )
 
-# update_readme(
-#     name = "update_readme",
-#     generate_workspace_snippet = ":generate_workspace_snippet",
-# )
+update_readme(
+    name = "update_readme",
+    generate_workspace_snippet = ":generate_workspace_snippet",
+)

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -54,3 +54,8 @@ generate_release_notes(
     name = "generate_release_notes",
     generate_workspace_snippet = ":generate_workspace_snippet",
 )
+
+# update_readme(
+#     name = "update_readme",
+#     generate_workspace_snippet = ":generate_workspace_snippet",
+# )

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ repository. Check out [the documentation](/doc/) for more information.
 
 ### Workspace Configuration
 
+<!-- BEGIN WORKSPACE SNIPPET -->
 ```python
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
@@ -36,4 +37,4 @@ load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
 
 stardoc_repositories()
 ```
-
+<!-- END WORKSPACE SNIPPET -->

--- a/README.md
+++ b/README.md
@@ -38,3 +38,5 @@ load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
 stardoc_repositories()
 ```
 <!-- END WORKSPACE SNIPPET -->
+
+AFTER SNIPPET

--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "cgrindel_bazel_starlib",
-    sha256 = "99ea556c74c1c7e5584452848ca32459e8a1d2ba63ea3a64847423db54504bed",
-    strip_prefix = "bazel-starlib-0.1.1",
-    urls = ["https://github.com/cgrindel/bazel-starlib/archive/v0.1.1.tar.gz"],
+    sha256 = "0903b4a7a6c625b26cd76a657582cea3693fdb4373a68e580486d887f7fdf4f2",
+    urls = [
+        "http://github.com/cgrindel/bazel-starlib/archive/v9999.tar.gz",
+    ],
 )
 
 load("@cgrindel_bazel_starlib//:deps.bzl", "bazel_starlib_dependencies")

--- a/README.md
+++ b/README.md
@@ -16,10 +16,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "cgrindel_bazel_starlib",
-    sha256 = "0903b4a7a6c625b26cd76a657582cea3693fdb4373a68e580486d887f7fdf4f2",
-    urls = [
-        "http://github.com/cgrindel/bazel-starlib/archive/v9999.tar.gz",
-    ],
+    sha256 = "99ea556c74c1c7e5584452848ca32459e8a1d2ba63ea3a64847423db54504bed",
+    strip_prefix = "bazel-starlib-0.1.1",
+    urls = ["https://github.com/cgrindel/bazel-starlib/archive/v0.1.1.tar.gz"],
 )
 
 load("@cgrindel_bazel_starlib//:deps.bzl", "bazel_starlib_dependencies")
@@ -39,5 +38,3 @@ load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
 stardoc_repositories()
 ```
 <!-- END WORKSPACE SNIPPET -->
-
-AFTER SNIPPET

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -19,6 +19,7 @@ _RULE_NAMES = [
     "generate_release_notes",
     "generate_workspace_snippet",
     "hash_sha256",
+    "update_readme",
     "write_bazel_status_vars",
 ]
 

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -6,7 +6,6 @@ load(
     "write_header",
     doc_providers = "providers",
 )
-load("@rules_pkg//:mappings.bzl", "pkg_filegroup", "pkg_files")
 
 bzlformat_pkg(name = "bzlformat")
 
@@ -121,20 +120,3 @@ write_file_list(
 # MARK: - Generate Documentation from Providers
 
 doc_for_provs(doc_provs = _ALL_DOC_PROVIDERS)
-
-pkg_files(
-    name = "package_files",
-    srcs = glob(
-        [
-            "*.bazel",
-            "*.md",
-        ],
-    ),
-)
-
-pkg_filegroup(
-    name = "package_content",
-    srcs = [":package_files"],
-    prefix = "doc",
-    visibility = ["//:__pkg__"],
-)

--- a/doc/generate_release_notes.md
+++ b/doc/generate_release_notes.md
@@ -21,6 +21,6 @@ Typically, this macro is used in conjunction with the     `generate_workspace_sn
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="generate_release_notes-name"></a>name |  The name of the executable target as a <code>string</code>.   |  none |
-| <a id="generate_release_notes-generate_workspace_snippet"></a>generate_workspace_snippet |  The label that should be executed to                                     generate the workspace snippet.   |  none |
+| <a id="generate_release_notes-generate_workspace_snippet"></a>generate_workspace_snippet |  The label that should be executed to generate the workspace snippet.   |  none |
 
 

--- a/doc/rules.md
+++ b/doc/rules.md
@@ -9,5 +9,6 @@ The rules listed below are available in this repository.
   * [generate_release_notes](/doc/generate_release_notes.md)
   * [generate_workspace_snippet](/doc/generate_workspace_snippet.md)
   * [hash_sha256](/doc/hash_sha256.md)
+  * [update_readme](/doc/update_readme.md)
   * [write_bazel_status_vars](/doc/write_bazel_status_vars.md)
 

--- a/doc/update_readme.md
+++ b/doc/update_readme.md
@@ -10,6 +10,9 @@
 update_readme(<a href="#update_readme-name">name</a>, <a href="#update_readme-generate_workspace_snippet">generate_workspace_snippet</a>, <a href="#update_readme-readme">readme</a>)
 </pre>
 
+Declares an executable target that updates a README.md with an updated workspace snippet.
+
+The utility will replace the lines between `<!-- BEGIN WORKSPACE SNIPPET -->` and     `<!-- END WORKSPACE SNIPPET -->` with the workspace snippet provided by the     `generate_workspace_snippet` utility that is provided.
 
 
 **PARAMETERS**
@@ -17,8 +20,8 @@ update_readme(<a href="#update_readme-name">name</a>, <a href="#update_readme-ge
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="update_readme-name"></a>name |  <p align="center"> - </p>   |  none |
-| <a id="update_readme-generate_workspace_snippet"></a>generate_workspace_snippet |  <p align="center"> - </p>   |  none |
-| <a id="update_readme-readme"></a>readme |  <p align="center"> - </p>   |  <code>None</code> |
+| <a id="update_readme-name"></a>name |  The name of the executable target as a <code>string</code>.   |  none |
+| <a id="update_readme-generate_workspace_snippet"></a>generate_workspace_snippet |  The label that should be executed to generate the workspace snippet.   |  none |
+| <a id="update_readme-readme"></a>readme |  A <code>string</code> representing the relative path to the README.md file from the root of the workspace.   |  <code>None</code> |
 
 

--- a/doc/update_readme.md
+++ b/doc/update_readme.md
@@ -1,0 +1,24 @@
+<!-- Generated with Stardoc, Do Not Edit! -->
+# `update_readme` Rule
+
+
+<a id="#update_readme"></a>
+
+## update_readme
+
+<pre>
+update_readme(<a href="#update_readme-name">name</a>, <a href="#update_readme-generate_workspace_snippet">generate_workspace_snippet</a>, <a href="#update_readme-readme">readme</a>)
+</pre>
+
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="update_readme-name"></a>name |  <p align="center"> - </p>   |  none |
+| <a id="update_readme-generate_workspace_snippet"></a>generate_workspace_snippet |  <p align="center"> - </p>   |  none |
+| <a id="update_readme-readme"></a>readme |  <p align="center"> - </p>   |  <code>None</code> |
+
+

--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@rules_pkg//:mappings.bzl", "pkg_filegroup", "pkg_files")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -10,18 +9,3 @@ bzl_library(
 )
 
 bzlformat_pkg(name = "bzlformat")
-
-pkg_files(
-    name = "package_files",
-    srcs = glob([
-        "*.bazel",
-        "*.bzl",
-    ]),
-)
-
-pkg_filegroup(
-    name = "package_content",
-    srcs = [":package_files"],
-    prefix = "lib",
-    visibility = ["//:__pkg__"],
-)

--- a/rules/BUILD.bazel
+++ b/rules/BUILD.bazel
@@ -62,6 +62,14 @@ bzl_library(
     ],
 )
 
+bzl_library(
+    name = "update_readme",
+    srcs = ["update_readme.bzl"],
+    deps = [
+        "//rules/private:update_readme",
+    ],
+)
+
 # TODO: Can I remove pkg_files and pkg_filegroup?
 
 pkg_files(

--- a/rules/BUILD.bazel
+++ b/rules/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@rules_pkg//:mappings.bzl", "pkg_filegroup", "pkg_files")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -68,21 +67,4 @@ bzl_library(
     deps = [
         "//rules/private:update_readme",
     ],
-)
-
-# TODO: Can I remove pkg_files and pkg_filegroup?
-
-pkg_files(
-    name = "package_files",
-    srcs = glob([
-        "*.bazel",
-        "*.bzl",
-    ]),
-)
-
-pkg_filegroup(
-    name = "package_content",
-    srcs = [":package_files"],
-    prefix = "rules",
-    visibility = ["//:__pkg__"],
 )

--- a/rules/private/BUILD.bazel
+++ b/rules/private/BUILD.bazel
@@ -53,3 +53,11 @@ bzl_library(
         ":execute_binary",
     ],
 )
+
+bzl_library(
+    name = "update_readme",
+    srcs = ["update_readme.bzl"],
+    deps = [
+        ":execute_binary",
+    ],
+)

--- a/rules/private/execute_binary.bzl
+++ b/rules/private/execute_binary.bzl
@@ -14,11 +14,13 @@ def file_placeholder(key):
 def _create_file_args_placeholder_dict(ctx):
     return {p: fa.files.to_list()[0] for fa, p in ctx.attr.file_arguments.items()}
 
-def _substitute_placehodlers(placeholder_dict, value):
+def _substitute_placehodlers(ctx, placeholder_dict, value):
     new_value = value
     for key, file in placeholder_dict.items():
         p_str = file_placeholder(key)
-        new_value = new_value.replace(p_str, file.short_path)
+
+        path = paths.join("${RUNFILES_DIR}", ctx.workspace_name, file.short_path)
+        new_value = new_value.replace(p_str, path)
     return new_value
 
 def _execute_binary_impl(ctx):
@@ -33,7 +35,7 @@ The args attribute is not supported for execute_binary. Use the arguments instea
     placeholder_dict = _create_file_args_placeholder_dict(ctx)
     quoted_args = []
     for arg in ctx.attr.arguments:
-        arg = _substitute_placehodlers(placeholder_dict, arg)
+        arg = _substitute_placehodlers(ctx, placeholder_dict, arg)
         if arg.startswith("\"") and arg.endswith("\""):
             quoted_args.append(arg)
         else:

--- a/rules/private/execute_binary.bzl
+++ b/rules/private/execute_binary.bzl
@@ -39,6 +39,9 @@ The args attribute is not supported for execute_binary. Use the arguments instea
         else:
             quoted_args.append("\"%s\"" % (arg))
 
+    # TODO: Update the file args to be <workspace_name>/<short_path> if path is not external.
+    # and use rlocation to resolve the location when injecting into the bash script.
+
     ctx.actions.write(
         output = out,
         is_executable = True,

--- a/rules/private/execute_binary.bzl
+++ b/rules/private/execute_binary.bzl
@@ -41,9 +41,6 @@ The args attribute is not supported for execute_binary. Use the arguments instea
         else:
             quoted_args.append("\"%s\"" % (arg))
 
-    # TODO: Update the file args to be <workspace_name>/<short_path> if path is not external.
-    # and use rlocation to resolve the location when injecting into the bash script.
-
     ctx.actions.write(
         output = out,
         is_executable = True,

--- a/rules/private/generate_release_notes.bzl
+++ b/rules/private/generate_release_notes.bzl
@@ -10,7 +10,7 @@ def generate_release_notes(name, generate_workspace_snippet):
 
     Args:
         name: The name of the executable target as a `string`.
-        generate_workspace_snippet: The label that should be executed to \
+        generate_workspace_snippet: The label that should be executed to
                                     generate the workspace snippet.
     """
     file_arguments = {}

--- a/rules/private/update_readme.bzl
+++ b/rules/private/update_readme.bzl
@@ -1,0 +1,19 @@
+load("//rules/private:execute_binary.bzl", "execute_binary", "file_placeholder")
+
+def update_readme(name, generate_workspace_snippet, readme = None):
+    file_arguments = {}
+    arguments = []
+
+    file_key = "generate_workspace_snippet"
+    arguments.extend(["--generate_workspace_snippet", file_placeholder(file_key)])
+    file_arguments[generate_workspace_snippet] = file_key
+
+    if readme != None:
+        arguments.extend(["--readme", readme])
+
+    execute_binary(
+        name = name,
+        arguments = arguments,
+        file_arguments = file_arguments,
+        binary = "@cgrindel_bazel_starlib//tools:update_readme",
+    )

--- a/rules/private/update_readme.bzl
+++ b/rules/private/update_readme.bzl
@@ -1,6 +1,19 @@
 load("//rules/private:execute_binary.bzl", "execute_binary", "file_placeholder")
 
 def update_readme(name, generate_workspace_snippet, readme = None):
+    """Declares an executable target that updates a README.md with an updated workspace snippet.
+
+    The utility will replace the lines between `<!-- BEGIN WORKSPACE SNIPPET -->` and \
+    `<!-- END WORKSPACE SNIPPET -->` with the workspace snippet provided by the \
+    `generate_workspace_snippet` utility that is provided.
+
+    Args:
+        name: The name of the executable target as a `string`.
+        generate_workspace_snippet: The label that should be executed to
+                                    generate the workspace snippet.
+        readme: A `string` representing the relative path to the README.md
+                file from the root of the workspace.
+    """
     file_arguments = {}
     arguments = []
 

--- a/rules/update_readme.bzl
+++ b/rules/update_readme.bzl
@@ -1,0 +1,6 @@
+load(
+    "//rules/private:update_readme.bzl",
+    _update_readme = "update_readme",
+)
+
+update_readme = _update_readme

--- a/tests/rules_tests/update_readme_tests/BUILD.bazel
+++ b/tests/rules_tests/update_readme_tests/BUILD.bazel
@@ -1,0 +1,40 @@
+load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("//rules:generate_workspace_snippet.bzl", "generate_workspace_snippet")
+load("//rules:update_readme.bzl", "update_readme")
+load("//tests:integration_test_common.bzl", "GH_ENV_INHERIT", "INTEGRATION_TEST_TAGS")
+
+bzlformat_pkg(name = "bzlformat")
+
+generate_workspace_snippet(
+    name = "generate_workspace_snippet",
+    template = "workspace_snippet.tmpl",
+)
+
+update_readme(
+    name = "update_readme",
+    generate_workspace_snippet = ":generate_workspace_snippet",
+)
+
+sh_test(
+    name = "update_readme_test",
+    srcs = ["update_readme_test.sh"],
+    data = [
+        ":update_readme",
+    ],
+    env_inherit = GH_ENV_INHERIT,
+    tags = INTEGRATION_TEST_TAGS,
+    deps = [
+        "//tests:setup_git_repo",
+        "@bazel_tools//tools/bash/runfiles",
+        "@cgrindel_bazel_starlib//lib/private:assertions",
+    ],
+)
+
+test_suite(
+    name = "integration_tests",
+    tags = INTEGRATION_TEST_TAGS,
+    tests = [
+        ":update_readme_test",
+    ],
+    visibility = ["//:__subpackages__"],
+)

--- a/tests/rules_tests/update_readme_tests/BUILD.bazel
+++ b/tests/rules_tests/update_readme_tests/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
-load("//rules:generate_workspace_snippet.bzl", "generate_workspace_snippet")
 load("//rules:update_readme.bzl", "update_readme")
+load("//rules:generate_workspace_snippet.bzl", "generate_workspace_snippet")
 load("//tests:integration_test_common.bzl", "GH_ENV_INHERIT", "INTEGRATION_TEST_TAGS")
 
 bzlformat_pkg(name = "bzlformat")

--- a/tests/rules_tests/update_readme_tests/update_readme_test.sh
+++ b/tests/rules_tests/update_readme_tests/update_readme_test.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+assertions_sh_location=cgrindel_bazel_starlib/lib/private/assertions.sh
+assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+  (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
+source "${assertions_sh}"
+
+fail "IMPLEMENT ME!"

--- a/tests/rules_tests/update_readme_tests/update_readme_test.sh
+++ b/tests/rules_tests/update_readme_tests/update_readme_test.sh
@@ -56,6 +56,7 @@ assert_match "Text before snippet" "${actual}" "Find README.md"
 assert_match "Text after snippet" "${actual}" "Find README.md"
 assert_no_match "Text should be replaced" "${actual}" "Find README.md"
 assert_match "http_archive" "${actual}" "Find README.md"
+assert_match "${tag_name}" "${actual}" "Find README.md"
 
 
 # MARK - Test Find README.md
@@ -70,3 +71,4 @@ assert_match "Text before snippet" "${actual}" "Find README.md"
 assert_match "Text after snippet" "${actual}" "Find README.md"
 assert_no_match "Text should be replaced" "${actual}" "Find README.md"
 assert_match "http_archive" "${actual}" "Find README.md"
+assert_match "${tag_name}" "${actual}" "Find README.md"

--- a/tests/rules_tests/update_readme_tests/update_readme_test.sh
+++ b/tests/rules_tests/update_readme_tests/update_readme_test.sh
@@ -47,17 +47,12 @@ echo "${readme_content}" > "${readme_path}"
 tag_name="v99999.0.0"
 
 
-# MARK - Test
-
-# DEBUG BEGIN
-set -x
-# DEBUG END
+# MARK - Test Specify README path
 
 "${update_readme_sh}" --readme "${readme_path}" "${tag_name}"
 
 actual="$(< "${readme_path}")"
-
-# DEBUG BEGIN
-echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") actual:"$'\n'"${actual}" 
-fail "STOP"
-# DEBUG END
+assert_match "Text before snippet" "${actual}" "Find README.md"
+assert_match "Text after snippet" "${actual}" "Find README.md"
+assert_no_match "Text should be replaced" "${actual}" "Find README.md"
+assert_match "http_archive" "${actual}" "Find README.md"

--- a/tests/rules_tests/update_readme_tests/update_readme_test.sh
+++ b/tests/rules_tests/update_readme_tests/update_readme_test.sh
@@ -11,9 +11,53 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
+# MARK - Locate Deps
+
 assertions_sh_location=cgrindel_bazel_starlib/lib/private/assertions.sh
 assertions_sh="$(rlocation "${assertions_sh_location}")" || \
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 source "${assertions_sh}"
 
-fail "IMPLEMENT ME!"
+setup_git_repo_sh_location=cgrindel_bazel_starlib/tests/setup_git_repo.sh
+setup_git_repo_sh="$(rlocation "${setup_git_repo_sh_location}")" || \
+  (echo >&2 "Failed to locate ${setup_git_repo_sh_location}" && exit 1)
+
+update_readme_sh_location=cgrindel_bazel_starlib/tests/rules_tests/update_readme_tests/update_readme.sh
+update_readme_sh="$(rlocation "${update_readme_sh_location}")" || \
+  (echo >&2 "Failed to locate ${update_readme_sh_location}" && exit 1)
+
+
+# MARK - Setup
+
+source "${setup_git_repo_sh}"
+
+readme_content="$(cat <<-EOF
+Text before snippet
+<!-- BEGIN WORKSPACE SNIPPET -->
+Text should be replaced
+<!-- END WORKSPACE SNIPPET -->
+Text after snippet
+EOF
+)"
+
+readme_path="${BUILD_WORKSPACE_DIRECTORY}/foo/README.md"
+mkdir -p "$(dirname "${readme_path}")"
+echo "${readme_content}" > "${readme_path}"
+
+tag_name="v99999.0.0"
+
+
+# MARK - Test
+
+# DEBUG BEGIN
+set -x
+# DEBUG END
+
+"${update_readme_sh}" --readme "${readme_path}" "${tag_name}"
+
+actual="$(< "${readme_path}")"
+
+# DEBUG BEGIN
+echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") actual:"$'\n'"${actual}" 
+fail "STOP"
+# DEBUG END

--- a/tests/rules_tests/update_readme_tests/update_readme_test.sh
+++ b/tests/rules_tests/update_readme_tests/update_readme_test.sh
@@ -40,16 +40,30 @@ Text after snippet
 EOF
 )"
 
-readme_path="${BUILD_WORKSPACE_DIRECTORY}/foo/README.md"
-mkdir -p "$(dirname "${readme_path}")"
-echo "${readme_content}" > "${readme_path}"
-
 tag_name="v99999.0.0"
 
 
 # MARK - Test Specify README path
 
+readme_path="${BUILD_WORKSPACE_DIRECTORY}/foo/README.md"
+mkdir -p "$(dirname "${readme_path}")"
+echo "${readme_content}" > "${readme_path}"
+
 "${update_readme_sh}" --readme "${readme_path}" "${tag_name}"
+
+actual="$(< "${readme_path}")"
+assert_match "Text before snippet" "${actual}" "Find README.md"
+assert_match "Text after snippet" "${actual}" "Find README.md"
+assert_no_match "Text should be replaced" "${actual}" "Find README.md"
+assert_match "http_archive" "${actual}" "Find README.md"
+
+
+# MARK - Test Find README.md
+
+readme_path="${BUILD_WORKSPACE_DIRECTORY}/README.md"
+echo "${readme_content}" > "${readme_path}"
+
+"${update_readme_sh}" "${tag_name}"
 
 actual="$(< "${readme_path}")"
 assert_match "Text before snippet" "${actual}" "Find README.md"

--- a/tests/rules_tests/update_readme_tests/workspace_snippet.tmpl
+++ b/tests/rules_tests/update_readme_tests/workspace_snippet.tmpl
@@ -1,0 +1,19 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+${http_archive_statement}
+
+load("@cgrindel_bazel_starlib//:deps.bzl", "bazel_starlib_dependencies")
+
+bazel_starlib_dependencies()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
+load("@cgrindel_bazel_doc//bazeldoc:deps.bzl", "bazeldoc_dependencies")
+
+bazeldoc_dependencies()
+
+load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
+
+stardoc_repositories()

--- a/tests/tools_tests/BUILD.bazel
+++ b/tests/tools_tests/BUILD.bazel
@@ -27,6 +27,18 @@ sh_test(
     ],
 )
 
+sh_test(
+    name = "update_readme_test",
+    srcs = ["update_readme_test.sh"],
+    data = [
+        "//tools:update_readme",
+    ],
+    deps = [
+        "//lib/private:assertions",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)
+
 # MARK: - Integration Tests
 
 sh_test(

--- a/tests/tools_tests/BUILD.bazel
+++ b/tests/tools_tests/BUILD.bazel
@@ -27,10 +27,20 @@ sh_test(
     ],
 )
 
+sh_binary(
+    name = "generate_fake_snippet",
+    srcs = ["generate_fake_snippet.sh"],
+    deps = [
+        "//lib/private:fail",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)
+
 sh_test(
     name = "update_readme_test",
     srcs = ["update_readme_test.sh"],
     data = [
+        ":generate_fake_snippet",
         "//tools:update_readme",
     ],
     deps = [

--- a/tests/tools_tests/generate_fake_snippet.sh
+++ b/tests/tools_tests/generate_fake_snippet.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+fail_sh_location=cgrindel_bazel_starlib/lib/private/fail.sh
+fail_sh="$(rlocation "${fail_sh_location}")" || \
+  (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
+source "${fail_sh}"
+
+args=()
+while (("$#")); do
+  case "${1}" in
+    "--output")
+      output_path="${2}"
+      shift 2
+      ;;
+    *)
+      args+=("${1}")
+      shift 1
+      ;;
+  esac
+done
+
+[[ -z "${output_path:-}" ]] && fail "Expected an output path."
+
+echo "
+This is the beginning of the fake snippet.
+
+
+This is the end of the fake snippet.
+" > "${output_path}"

--- a/tests/tools_tests/update_readme_test.sh
+++ b/tests/tools_tests/update_readme_test.sh
@@ -11,9 +11,53 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
+# MARK - Locate Deps
+
 assertions_sh_location=cgrindel_bazel_starlib/lib/private/assertions.sh
 assertions_sh="$(rlocation "${assertions_sh_location}")" || \
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 source "${assertions_sh}"
 
-fail "IMPLEMENT ME!"
+generate_fake_snippet_sh_location=cgrindel_bazel_starlib/tests/tools_tests/generate_fake_snippet.sh
+generate_fake_snippet_sh="$(rlocation "${generate_fake_snippet_sh_location}")" || \
+  (echo >&2 "Failed to locate ${generate_fake_snippet_sh_location}" && exit 1)
+
+update_readme_sh_location=cgrindel_bazel_starlib/tools/update_readme.sh
+update_readme_sh="$(rlocation "${update_readme_sh_location}")" || \
+  (echo >&2 "Failed to locate ${update_readme_sh_location}" && exit 1)
+
+
+# MARK - Set up
+
+export BUILD_WORKSPACE_DIRECTORY="${PWD}"
+
+tag_name="v99999.0.0"
+
+readme_content="$(cat <<-EOF
+Text before snippet
+<!-- BEGIN WORKSPACE SNIPPET -->
+Text should be replaced
+<!-- END WORKSPACE SNIPPET -->
+Text after snippet
+EOF
+)"
+
+
+# MARK - Test Find README.md
+
+readme_path="${BUILD_WORKSPACE_DIRECTORY}/README.md"
+
+# Write README.md
+echo "${readme_content}" > "${readme_path}"
+
+"${update_readme_sh}" \
+  --generate_workspace_snippet "${generate_fake_snippet_sh}" \
+  "${tag_name}"
+
+actual="$(< "${readme_path}")"
+assert_match "Text before snippet" "${actual}" "Find README.md"
+assert_match "Text after snippet" "${actual}" "Find README.md"
+assert_no_match "Text should be replaced" "${actual}" "Find README.md"
+
+
+assert_match "fake snippet" "${actual}" "Find README.md"

--- a/tests/tools_tests/update_readme_test.sh
+++ b/tests/tools_tests/update_readme_test.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+assertions_sh_location=cgrindel_bazel_starlib/lib/private/assertions.sh
+assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+  (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
+source "${assertions_sh}"
+
+fail "IMPLEMENT ME!"

--- a/tests/tools_tests/update_readme_test.sh
+++ b/tests/tools_tests/update_readme_test.sh
@@ -58,6 +58,4 @@ actual="$(< "${readme_path}")"
 assert_match "Text before snippet" "${actual}" "Find README.md"
 assert_match "Text after snippet" "${actual}" "Find README.md"
 assert_no_match "Text should be replaced" "${actual}" "Find README.md"
-
-
 assert_match "fake snippet" "${actual}" "Find README.md"

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -101,3 +101,13 @@ sh_binary(
         "@bazel_tools//tools/bash/runfiles",
     ],
 )
+
+sh_binary(
+    name = "update_readme",
+    srcs = ["update_readme.sh"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//lib/private:fail",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)

--- a/tools/generate_workspace_snippet.sh
+++ b/tools/generate_workspace_snippet.sh
@@ -159,9 +159,6 @@ EOF
 if [[ -z "${template:-}" ]]; then
   snippet="${http_archive_statement}"
 else
-  # DEBUG BEGIN
-  echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") template: ${template}" 
-  # DEBUG END
   # Evaluate the template
   snippet="$(
     # Write the multline http_archive statement to a temp file. Be sure to

--- a/tools/generate_workspace_snippet.sh
+++ b/tools/generate_workspace_snippet.sh
@@ -159,6 +159,9 @@ EOF
 if [[ -z "${template:-}" ]]; then
   snippet="${http_archive_statement}"
 else
+  # DEBUG BEGIN
+  echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") template: ${template}" 
+  # DEBUG END
   # Evaluate the template
   snippet="$(
     # Write the multline http_archive statement to a temp file. Be sure to

--- a/tools/update_readme.sh
+++ b/tools/update_readme.sh
@@ -19,3 +19,58 @@ fail_sh="$(rlocation "${fail_sh_location}")" || \
 source "${fail_sh}"
 
 
+# MARK - Process Arguments
+
+starting_dir="${PWD}"
+
+args=()
+while (("$#")); do
+  case "${1}" in
+    "--output")
+      output_path="${2}"
+      shift 2
+      ;;
+    "--generate_workspace_snippet")
+      # If the input path is not absolute, then resolve it to be relative to
+      # the starting directory. We do this before we starting changing
+      # directories.
+      generate_workspace_snippet="${2}"
+      [[ "${generate_workspace_snippet}" =~ ^/ ]] || \
+        generate_workspace_snippet="${starting_dir}/${generate_workspace_snippet}"
+      shift 2
+      ;;
+    "--readme")
+      # This is a relative path from the root of the workspace.
+      readme_path="${2}"
+      shift 2
+      ;;
+    --*)
+      fail "Unrecognized flag ${1}."
+      ;;
+    *)
+      args+=("${1}")
+      shift 1
+      ;;
+  esac
+done
+
+[[ ${#args[@]} == 0 ]] && fail "A tag name for the release must be specified."
+tag_name="${args[0]}"
+
+[[ -z "${generate_workspace_snippet:-}" ]] && \
+  fail "Expected a value for --generate_workspace_snippet."
+
+
+# MARK - Update README.md
+
+cd "${BUILD_WORKSPACE_DIRECTORY}"
+
+[[ -z "${readme_path:-}" ]] && readme_path="README.md"
+[[ -f "${readme_path}" ]] || fail "Could not find the README.md file. ${readme_path}"
+
+
+snippet_path="$(mktemp)"
+"${generate_workspace_snippet}" --tag "${tag_name}" --output "${snippet_path}"
+
+
+

--- a/tools/update_readme.sh
+++ b/tools/update_readme.sh
@@ -84,6 +84,17 @@ trap 'cleanup $?' EXIT
 "${generate_workspace_snippet}" --tag "${tag_name}" --output "${snippet_path}"
 
 # Update the README.md inserting the workspace snippet
+# 
+# sed script explanation
+#
+# /BEGIN WORKSPACE SNIPPET/{      # Find the begin marker
+#   p                             # Print the begin marker
+#   r '"${snippet_path}"'         # Read in the snippet
+#   :a                            # Declare label 'a'
+#   n                             # Read the next line
+#   /END WORKSPACE SNIPPET/!b a   # If not the end marker, loop to 'a'
+# }
+# /BEGIN WORKSPACE SNIPPET/!p     # Print any line that is not begin marker
 sed -n -i.bak \
   -e '
 /BEGIN WORKSPACE SNIPPET/{

--- a/tools/update_readme.sh
+++ b/tools/update_readme.sh
@@ -117,12 +117,50 @@ trap 'cleanup $?' EXIT
 # ' \
 #   "${readme_path}"
 
-# DELETES LINES BETWEEN COMMENTS
-sed -i.bak \
+# # DELETES LINES BETWEEN COMMENTS
+# sed -i.bak \
+#   -e '
+# /BEGIN WORKSPACE SNIPPET/,/END WORKSPACE SNIPPET/{
+#   /BEGIN WORKSPACE SNIPPET/n
+#   /END WORKSPACE SNIPPET/!d
+# }
+# ' \
+#   "${readme_path}"
+
+# # CLEARS THE LINES BETWEEN MARKERS
+# sed -n -i.bak \
+#   -e '
+# /BEGIN WORKSPACE SNIPPET/{
+#   p
+#   :a
+#   n
+#   /END WORKSPACE SNIPPET/!b a
+# }
+# /BEGIN WORKSPACE SNIPPET/!p
+# ' \
+#   "${readme_path}"
+
+# Describe sed 
+# /BEGIN WORKSPACE SNIPPET/{      # Find the begin marker
+#   p                             # Print the begin marker
+#   r '"${snippet_path}"'         # Insert the snippet
+#   :a                            # Declare the label 'a'
+#   n                             # Read the next line
+#   /END WORKSPACE SNIPPET/!b a   # If not the end marker, loop to 'a'
+# }
+# /BEGIN WORKSPACE SNIPPET/!p     # Print all the other lines
+
+
+# WORKS
+sed -n -i.bak \
   -e '
-/BEGIN WORKSPACE SNIPPET/,/END WORKSPACE SNIPPET/{
-  /BEGIN WORKSPACE SNIPPET/n
-  /END WORKSPACE SNIPPET/!d
+/BEGIN WORKSPACE SNIPPET/{
+  p
+  r '"${snippet_path}"'
+  :a
+  n
+  /END WORKSPACE SNIPPET/!b a
 }
+/BEGIN WORKSPACE SNIPPET/!p
 ' \
   "${readme_path}"

--- a/tools/update_readme.sh
+++ b/tools/update_readme.sh
@@ -80,6 +80,11 @@ cleanup() {
 }
 trap 'cleanup $?' EXIT
 
+# DEBUG BEGIN
+echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") snippet_path: ${snippet_path}" 
+echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") readme_path: ${readme_path}" 
+# DEBUG END
+
 # Generate the snippet
 "${generate_workspace_snippet}" --tag "${tag_name}" --output "${snippet_path}"
 

--- a/tools/update_readme.sh
+++ b/tools/update_readme.sh
@@ -80,11 +80,6 @@ cleanup() {
 }
 trap 'cleanup $?' EXIT
 
-# DEBUG BEGIN
-echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") snippet_path: ${snippet_path}" 
-echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") readme_path: ${readme_path}" 
-# DEBUG END
-
 # Generate the snippet
 "${generate_workspace_snippet}" --tag "${tag_name}" --output "${snippet_path}"
 

--- a/tools/update_readme.sh
+++ b/tools/update_readme.sh
@@ -68,6 +68,7 @@ cd "${BUILD_WORKSPACE_DIRECTORY}"
 [[ -z "${readme_path:-}" ]] && readme_path="README.md"
 [[ -f "${readme_path}" ]] || fail "Could not find the README.md file. ${readme_path}"
 
+# Set up the cleanup
 readme_backup="${readme_path}.bak"
 snippet_path="$(mktemp)"
 cleanup() {
@@ -82,76 +83,7 @@ trap 'cleanup $?' EXIT
 # Generate the snippet
 "${generate_workspace_snippet}" --tag "${tag_name}" --output "${snippet_path}"
 
-# # DEBUG BEGIN
-# echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") snippet:"$'\n'"$(< "${snippet_path}")" 
-# # DEBUG END
-
-# Update the snippet
-# sed_script="$(cat <<-EOF
-# /^<!-- BEGIN WORKSPACE SNIPPET/{:a;N;/^<!-- END WORKSPACE SNIPPET/!ba;N;r ${snippet_path}};p
-# EOF
-# )"
-# sed -E -i.bak -e "${sed_script}" "${readme_path}"
-  # -e '/^<!-- BEGIN WORKSPACE SNIPPET/{:a;N;/^<!-- END WORKSPACE SNIPPET/!ba;N;r '"${snippet_path}"'};p' \
-  # -e '/BEGIN WORKSPACE SNIPPET/{:a;N;/END WORKSPACE SNIPPET/!ba;N;r '"${snippet_path}"'};p' \
-  # -e '/BEGIN WORKSPACE SNIPPET/\{:a;N;/END WORKSPACE SNIPPET/!ba;N;s/.*\n/REPLACEMENT\n/\};p' \
-  # -e '/BEGIN WORKSPACE SNIPPET/{:a;N;/END WORKSPACE SNIPPET/!ba;N;s/.*\n/REPLACEMENT\n/};p' \
-# /BEGIN WORKSPACE SNIPPET/{
-#   :a
-#   N
-#   /END WORKSPACE SNIPPET/!ba
-#   N
-#   s/.*\n/REPLACEMENT\n/
-# }
-# p
-
-# sed -i.bak -e '
-# /BEGIN WORKSPACE SNIPPET/{
-#   :a
-#   N
-#   /END WORKSPACE SNIPPET/!ba
-#   N
-#   s/.*\n/REPLACEMENT\n/
-# }
-# p
-# ' \
-#   "${readme_path}"
-
-# # DELETES LINES BETWEEN COMMENTS
-# sed -i.bak \
-#   -e '
-# /BEGIN WORKSPACE SNIPPET/,/END WORKSPACE SNIPPET/{
-#   /BEGIN WORKSPACE SNIPPET/n
-#   /END WORKSPACE SNIPPET/!d
-# }
-# ' \
-#   "${readme_path}"
-
-# # CLEARS THE LINES BETWEEN MARKERS
-# sed -n -i.bak \
-#   -e '
-# /BEGIN WORKSPACE SNIPPET/{
-#   p
-#   :a
-#   n
-#   /END WORKSPACE SNIPPET/!b a
-# }
-# /BEGIN WORKSPACE SNIPPET/!p
-# ' \
-#   "${readme_path}"
-
-# Describe sed 
-# /BEGIN WORKSPACE SNIPPET/{      # Find the begin marker
-#   p                             # Print the begin marker
-#   r '"${snippet_path}"'         # Insert the snippet
-#   :a                            # Declare the label 'a'
-#   n                             # Read the next line
-#   /END WORKSPACE SNIPPET/!b a   # If not the end marker, loop to 'a'
-# }
-# /BEGIN WORKSPACE SNIPPET/!p     # Print all the other lines
-
-
-# WORKS
+# Update the README.md inserting the workspace snippet
 sed -n -i.bak \
   -e '
 /BEGIN WORKSPACE SNIPPET/{


### PR DESCRIPTION
Related to #4.

- Implemented `update_readme.sh` and `update_readme` macro. They are used to update a `README.md` file with an updated workspace snippet.
- Fixed file args resolution for `execute_binary`. Now, they resolve from the `RUNFILES_DIR`.
- Removed obsolete `rules_pkg` declarations.