### PR TITLE
Added update_readme.yml Github Actions workflow

### DIFF
--- a/.github/actions/update_readme/action.yml
+++ b/.github/actions/update_readme/action.yml
@@ -1,0 +1,37 @@
+name: Build and Test
+
+inputs:
+  release_tag:
+    required: true
+    type: string
+  readme_path:
+    required: true
+    type: string
+    default: README.md
+  update_readme_target:
+    required: true
+    type: string
+    default: "//:update_readme"
+
+runs:
+  using: composite
+  steps:
+
+    - name: Update README.md
+      shell: bash
+      env:
+        UPDATE_README_TARGET: ${{ inputs.update_readme_target }}
+        RELEASE_TAG: ${{ inputs.release_tag }}
+        README_PATH: ${{ inputs.readme_path }}
+      run: |
+        bazelisk run "${UPDATE_README_TARGET}" -- \
+          --readme "${README_PATH}"
+          "${RELEASE_TAG}"
+
+    - name: Commit Changes
+      uses: EndBug/add-and-commit@v7
+      with:
+        default_author: github_actions
+        message: Update README.md for ${{ inputs.release_tag }}
+        add: ${{ inputs.readme_path }}
+        branch: main

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,4 +1,4 @@
-name: Create Release Workflow
+name: Create Release
 
 on:
   workflow_dispatch:
@@ -21,20 +21,11 @@ jobs:
       CC: clang
 
     steps:
-
     - uses: actions/checkout@v2
-
-    - name: Write local.bazelrc File
-      shell: bash
-      run: |
-        cat >local.bazelrc <<EOF
-        common --config=ci
-        EOF
-
-    - name: Output the Bazel Info
-      shell: bash
-      run: |
-        bazelisk info
+    - uses: ./.github/actions/setup_bazel_cache
+      with:
+        name: bazel_starlib
+    - uses: ./.github/actions/setup_bazel
 
     - name: Generate Release Notes
       shell: bash

--- a/.github/workflows/update_readme.yml
+++ b/.github/workflows/update_readme.yml
@@ -1,0 +1,29 @@
+name: Update README.md
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      release_tag:
+        required: true
+        type: string
+
+jobs:
+  update_readme:
+    runs-on: ubuntu-latest
+    env:
+      CC: clang
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./.github/actions/setup_bazel_cache
+      with:
+        name: bazel_starlib
+    - uses: ./.github/actions/setup_bazel
+    - uses: ./.github/actions/update_readme
+      with:
+        release_tag: ${{ github.ref_name }}


### PR DESCRIPTION
Related to #4.

- Initial, untested version of the workflow. (Need to add it before it can be seen and tested on another branch.
- Update the create_release.yml to use setup_bazel_cache and setup_bazel actions.