### PR TITLE
Added PR creation and automerge when updating README.md

### DIFF
--- a/.github/actions/update_readme/action.yml
+++ b/.github/actions/update_readme/action.yml
@@ -56,12 +56,3 @@ runs:
         token: ${{ inputs.github_token }}
         pull-request-number: ${{ steps.create_pr.outputs.pull-request-number }}
         merge-method: squash
-
-    # - name: Commit Changes
-    #   uses: EndBug/add-and-commit@v7
-    #   with:
-    #     default_author: github_actions
-    #     message: Update README.md for ${{ inputs.release_tag }}
-    #     add: ${{ inputs.readme_path }}
-    #     branch: auto_update_readme_for_${{ inputs.release_tag }}
-    #     branch_mode: create

--- a/.github/actions/update_readme/action.yml
+++ b/.github/actions/update_readme/action.yml
@@ -4,6 +4,9 @@ inputs:
   release_tag:
     required: true
     type: string
+  github_token:
+    description: The Github token to authenticate PR operations.
+    required: true
   readme_path:
     required: true
     type: string
@@ -32,7 +35,7 @@ runs:
       id: create_pr
       uses: peter-evans/create-pull-request@v3
       with:
-        token: ${{ secrets.PAT }}
+        token: ${{ inputs.github_token }}
         add-paths: |
           ${{ inputs.readme_path }}
         branch: auto_update_readme_for_${{ inputs.release_tag }}
@@ -44,7 +47,7 @@ runs:
       if: steps.create_pr.outputs.pull-request-operation == 'created'
       uses: peter-evans/enable-pull-request-automerge@v1
       with:
-        token: ${{ secrets.PAT }}
+        token: ${{ inputs.github_token }}
         pull-request-number: ${{ steps.create_pr.outputs.pull-request-number }}
         merge-method: squash
 

--- a/.github/actions/update_readme/action.yml
+++ b/.github/actions/update_readme/action.yml
@@ -15,6 +15,11 @@ inputs:
     required: true
     type: string
     default: "//:update_readme"
+  base_branch:
+    description: The branch being merged to.
+    required: true
+    type: string
+    default: main
 
 runs:
   using: composite
@@ -39,7 +44,7 @@ runs:
         add-paths: |
           ${{ inputs.readme_path }}
         branch: auto_update_readme_for_${{ inputs.release_tag }}
-        base: main
+        base: ${{ inputs.base_branch }}
         delete-branch: true
         title: Update REAMDE.md for ${{ inputs.release_tag }}
         body: Automated update of `${{ inputs.readme_path }}` for release ${{ inputs.release_tag }}

--- a/.github/actions/update_readme/action.yml
+++ b/.github/actions/update_readme/action.yml
@@ -28,11 +28,31 @@ runs:
           --readme "${README_PATH}" \
           "${RELEASE_TAG}"
 
-    - name: Commit Changes
-      uses: EndBug/add-and-commit@v7
+    - name: Create PR for README.md Update
+      id: create_pr
+      uses: peter-evans/create-pull-request@v3
       with:
-        default_author: github_actions
-        message: Update README.md for ${{ inputs.release_tag }}
-        add: ${{ inputs.readme_path }}
+        token: ${{ secrets.PAT }}
+        add-paths: |
+          ${{ inputs.readme_path }}
         branch: auto_update_readme_for_${{ inputs.release_tag }}
-        branch_mode: create
+        delete-branch: true
+        title: Update REAMDE.md for ${{ inputs.release_tag }}
+        body: Automated update of `${{ inputs.readme_path }}` for release ${{ inputs.release_tag }}
+
+    - name: Enable PR Automerge
+      if: steps.create_pr.outputs.pull-request-operation == 'created'
+      uses: peter-evans/enable-pull-request-automerge@v1
+      with:
+        token: ${{ secrets.PAT }}
+        pull-request-number: ${{ steps.create_pr.outputs.pull-request-number }}
+        merge-method: squash
+
+    # - name: Commit Changes
+    #   uses: EndBug/add-and-commit@v7
+    #   with:
+    #     default_author: github_actions
+    #     message: Update README.md for ${{ inputs.release_tag }}
+    #     add: ${{ inputs.readme_path }}
+    #     branch: auto_update_readme_for_${{ inputs.release_tag }}
+    #     branch_mode: create

--- a/.github/actions/update_readme/action.yml
+++ b/.github/actions/update_readme/action.yml
@@ -39,6 +39,7 @@ runs:
         add-paths: |
           ${{ inputs.readme_path }}
         branch: auto_update_readme_for_${{ inputs.release_tag }}
+        base: main
         delete-branch: true
         title: Update REAMDE.md for ${{ inputs.release_tag }}
         body: Automated update of `${{ inputs.readme_path }}` for release ${{ inputs.release_tag }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: CI for PR Merge
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, test_main ]
 
 jobs:
   build_and_test:

--- a/.github/workflows/update_readme.yml
+++ b/.github/workflows/update_readme.yml
@@ -27,3 +27,4 @@ jobs:
     - uses: ./.github/actions/update_readme
       with:
         release_tag: ${{  github.event.inputs.release_tag }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update_readme.yml
+++ b/.github/workflows/update_readme.yml
@@ -6,11 +6,21 @@ on:
       release_tag:
         required: true
         type: string
+      base_branch:
+        description: The branch being merged to.
+        required: true
+        type: string
+        default: main
   workflow_call:
     inputs:
       release_tag:
         required: true
         type: string
+      base_branch:
+        description: The branch being merged to.
+        required: true
+        type: string
+        default: main
 
 jobs:
   update_readme:
@@ -27,4 +37,5 @@ jobs:
     - uses: ./.github/actions/update_readme
       with:
         release_tag: ${{  github.event.inputs.release_tag }}
+        base_branch: ${{ github.event.inputs.base_branch }}
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Related to #4.

- Added steps to create a PR and auto-merge the PR.
- Added input parameter `base_branch` to update README.md workflow and action.
- Updated CI to build and test for `test_main` branch as well as `main`.