### PR TITLE
Updated update_readme workflow to use app-generated token

### DIFF
--- a/.github/workflows/update_readme.yml
+++ b/.github/workflows/update_readme.yml
@@ -34,8 +34,13 @@ jobs:
       with:
         name: bazel_starlib
     - uses: ./.github/actions/setup_bazel
+    - uses: tibdex/github-app-token@v1
+      id: generate_token
+      with:
+        app_id: ${{ secrets.APP_ID }}
+        private_key: ${{ secrets.APP_PRIVATE_KEY }}
     - uses: ./.github/actions/update_readme
       with:
         release_tag: ${{  github.event.inputs.release_tag }}
         base_branch: ${{ github.event.inputs.base_branch }}
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
Closes #4.

Using the app-generated token allows the auto-created PRs to trigger the CI workflow.