### PR TITLE
Add `create_release.sh` utility that launches the `create_release.yml` GA workflow.

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -7,20 +7,16 @@ on:
         required: true
         type: string
       reset_tag:
-        required: true
         type: boolean
         default: false
       release_notes_target:
-        required: true
         type: string
         default: "//:generate_release_notes"
       update_readme_target:
-        required: true
         type: string
         default: "//:update_readme"
       base_branch:
         description: The branch being merged to.
-        required: true
         type: string
         default: main
   workflow_call:
@@ -29,20 +25,16 @@ on:
         required: true
         type: string
       reset_tag:
-        required: true
         type: boolean
         default: false
       release_notes_target:
-        required: true
         type: string
         default: "//:generate_release_notes"
       update_readme_target:
-        required: true
         type: string
         default: "//:update_readme"
       base_branch:
         description: The branch being merged to.
-        required: true
         type: string
         default: main
 

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -119,6 +119,7 @@ sh_binary(
     deps = [
         "//lib/private:env",
         "//lib/private:fail",
+        "//lib/private:git",
         "//lib/private:github",
         "@bazel_tools//tools/bash/runfiles",
     ],

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -111,3 +111,15 @@ sh_binary(
         "@bazel_tools//tools/bash/runfiles",
     ],
 )
+
+sh_binary(
+    name = "create_release",
+    srcs = ["create_release.sh"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//lib/private:env",
+        "//lib/private:fail",
+        "//lib/private:github",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)

--- a/tools/create_release.sh
+++ b/tools/create_release.sh
@@ -23,6 +23,11 @@ env_sh="$(rlocation "${env_sh_location}")" || \
   (echo >&2 "Failed to locate ${env_sh_location}" && exit 1)
 source "${env_sh}"
 
+git_sh_location=cgrindel_bazel_starlib/lib/private/git.sh
+git_sh="$(rlocation "${git_sh_location}")" || \
+  (echo >&2 "Failed to locate ${git_sh_location}" && exit 1)
+source "${git_sh}"
+
 github_sh_location=cgrindel_bazel_starlib/lib/private/github.sh
 github_sh="$(rlocation "${github_sh_location}")" || \
   (echo >&2 "Failed to locate ${github_sh_location}" && exit 1)
@@ -68,7 +73,6 @@ done
 
 [[ ${#args[@]} == 0 ]] && usage_error "Expected a version tag for the release. (e.g v.1.2.3)"
 tag="${args[0]}"
-
 is_valid_release_tag "${tag}" || fail "Invalid version tag. Expected it to start with 'v'."
 
 

--- a/tools/create_release.sh
+++ b/tools/create_release.sh
@@ -57,6 +57,10 @@ reset_tag=false
 args=()
 while (("$#")); do
   case "${1}" in
+    --ref)
+      ref="${2}"
+      shift 2
+      ;;
     --reset_tag)
       reset_tag=true
       shift 1
@@ -81,7 +85,9 @@ is_valid_release_tag "${tag}" || fail "Invalid version tag. Expected it to start
 cd "${BUILD_WORKSPACE_DIRECTORY}"
 
 # Launch the workflow
-gh_cmd=(gh workflow run 'Create Release' -f "release_tag=${tag}")
+gh_cmd=(gh workflow run 'Create Release')
+[[ -z "${ref:-}" ]] || gh_cmd+=(--ref "${ref}")
+gh_cmd+=(-f "release_tag=${tag}")
 [[ "${reset_tag}" == true ]] && gh_cmd+=(-f "reset_tag=true")
 "${gh_cmd[@]}"
 

--- a/tools/create_release.sh
+++ b/tools/create_release.sh
@@ -88,6 +88,5 @@ cd "${BUILD_WORKSPACE_DIRECTORY}"
 gh_cmd=(gh workflow run 'Create Release')
 [[ -z "${ref:-}" ]] || gh_cmd+=(--ref "${ref}")
 gh_cmd+=(-f "release_tag=${tag}")
-[[ "${reset_tag}" == true ]] && gh_cmd+=(-f "reset_tag=true")
+gh_cmd+=(-f "reset_tag=${reset_tag}")
 "${gh_cmd[@]}"
-

--- a/tools/create_release.sh
+++ b/tools/create_release.sh
@@ -47,9 +47,15 @@ EOF
   )"
 }
 
+reset_tag=false
+
 args=()
 while (("$#")); do
   case "${1}" in
+    --reset_tag)
+      reset_tag=true
+      shift 1
+      ;;
     --*)
       fail "Unrecognized flag. ${1}"
       ;;
@@ -65,4 +71,13 @@ tag="${args[0]}"
 
 is_valid_release_tag "${tag}" || fail "Invalid version tag. Expected it to start with 'v'."
 
+
+# MARK - Run the workflow
+
+cd "${BUILD_WORKSPACE_DIRECTORY}"
+
+# Launch the workflow
+gh_cmd=(gh workflow run 'Create Release' -f "release_tag=${tag}")
+[[ "${reset_tag}" == true ]] && gh_cmd+=(-f "reset_tag=true")
+"${gh_cmd[@]}"
 

--- a/tools/create_release.sh
+++ b/tools/create_release.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+# MARK - Locate Dependencies
+
+fail_sh_location=cgrindel_bazel_starlib/lib/private/fail.sh
+fail_sh="$(rlocation "${fail_sh_location}")" || \
+  (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
+source "${fail_sh}"
+
+env_sh_location=cgrindel_bazel_starlib/lib/private/env.sh
+env_sh="$(rlocation "${env_sh_location}")" || \
+  (echo >&2 "Failed to locate ${env_sh_location}" && exit 1)
+source "${env_sh}"
+
+github_sh_location=cgrindel_bazel_starlib/lib/private/github.sh
+github_sh="$(rlocation "${github_sh_location}")" || \
+  (echo >&2 "Failed to locate ${github_sh_location}" && exit 1)
+source "${github_sh}"
+
+
+# MARK - Check for Required Software
+
+is_installed gh || fail "Could not find Github CLI (gh)."
+
+
+# MARK - Process Arguments
+
+get_usage() {
+  local utility="$(basename "${BASH_SOURCE[0]}")"
+  echo "$(cat <<-EOF
+Execute a Github Action workflow to create a relase with the specified tag.
+
+Usage:
+${utility} <tag>
+EOF
+  )"
+}
+
+args=()
+while (("$#")); do
+  case "${1}" in
+    --*)
+      fail "Unrecognized flag. ${1}"
+      ;;
+    *)
+      args+=("${1}")
+      shift 1
+      ;;
+  esac
+done
+
+[[ ${#args[@]} == 0 ]] && usage_error "Expected a version tag for the release. (e.g v.1.2.3)"
+tag="${args[0]}"
+
+is_valid_release_tag "${tag}" || fail "Invalid version tag. Expected it to start with 'v'."
+
+

--- a/tools/create_release_tag.sh
+++ b/tools/create_release_tag.sh
@@ -87,6 +87,7 @@ tag="${args[0]}"
 
 is_valid_release_tag "${tag}" || fail "Invalid version tag. Expected it to start with 'v'."
 
+
 # MARK - Create the release
 
 cd "${BUILD_WORKSPACE_DIRECTORY}"


### PR DESCRIPTION
Related to #4.

- Add `create_release.sh` utility that launches the `create_release.yml` GA workflow.
- Removed `required` designation for inputs.