### PR TITLE
Update `bazeldoc` to use `updatesrc_update`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -16,13 +16,6 @@ bzlformat_missing_pkgs(
 updatesrc_update_all(
     name = "update_all",
     targets_to_run = [
-        "//doc/bazeldoc:update",
-        "//doc/bzlformat:update",
-        "//doc/bzllib:update",
-        "//doc/bzlrelease:update",
-        "//doc/shlib:update",
-        "//doc/updatesrc:update",
-        "//doc:update",
         ":bzlformat_missing_pkgs_fix",
     ],
 )

--- a/bazeldoc/private/BUILD.bazel
+++ b/bazeldoc/private/BUILD.bazel
@@ -46,7 +46,6 @@ bzl_library(
     srcs = ["update_doc.bzl"],
     deps = [
         "//updatesrc:defs",
-        "@bazel_skylib//lib:paths",
         "@bazel_skylib//rules:write_file",
     ],
 )

--- a/bazeldoc/private/BUILD.bazel
+++ b/bazeldoc/private/BUILD.bazel
@@ -45,6 +45,8 @@ bzl_library(
     name = "update_doc",
     srcs = ["update_doc.bzl"],
     deps = [
+        "//updatesrc:defs",
+        "@bazel_skylib//lib:paths",
         "@bazel_skylib//rules:write_file",
     ],
 )

--- a/bazeldoc/private/doc_for_provs.bzl
+++ b/bazeldoc/private/doc_for_provs.bzl
@@ -2,7 +2,7 @@ load(":stardoc_for_prov.bzl", "stardoc_for_provs")
 load(":diff_test_for_provs.bzl", "diff_test_for_provs")
 load(":update_doc.bzl", "update_doc")
 
-def doc_for_provs(doc_provs, doc_path = "doc"):
+def doc_for_provs(doc_provs):
     """Defines targets for generating documentation, testing that the generated doc matches the workspace directory, and copying the generated doc to the workspace directory.
 
     Args:
@@ -14,4 +14,4 @@ def doc_for_provs(doc_provs, doc_path = "doc"):
     """
     stardoc_for_provs(doc_provs = doc_provs)
     diff_test_for_provs(doc_provs = doc_provs)
-    update_doc(doc_provs = doc_provs, doc_path = doc_path)
+    update_doc(doc_provs = doc_provs)

--- a/bazeldoc/private/update_doc.bzl
+++ b/bazeldoc/private/update_doc.bzl
@@ -1,12 +1,13 @@
 load("//updatesrc:defs.bzl", "updatesrc_update")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 
-def update_doc(doc_provs, name = "update"):
+def update_doc(doc_provs, name = "update", chicken = None):
     """Defines an executable target that copies the documentation from the output directory to the workspace directory.
 
     Args:
         doc_provs: A `list` of document provider `struct` values as returned
                    from `providers.create()`.
+        chicken: This is not real.
     """
     srcs = []
     outs = []

--- a/bazeldoc/private/update_doc.bzl
+++ b/bazeldoc/private/update_doc.bzl
@@ -1,6 +1,8 @@
+load("//updatesrc:defs.bzl", "updatesrc_update")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@bazel_skylib//lib:paths.bzl", "paths")
 
-def update_doc(doc_provs, doc_path = "doc"):
+def update_doc(doc_provs, name = "update", doc_path = "doc"):
     """Defines an executable target that copies the documentation from the output directory to the workspace directory.
 
     Args:
@@ -12,27 +14,41 @@ def update_doc(doc_provs, doc_path = "doc"):
     Returns:
         None.
     """
-    write_file(
-        name = "gen_update",
-        out = "update.sh",
-        content = [
-            "#!/usr/bin/env bash",
-            "cd $BUILD_WORKSPACE_DIRECTORY",
-        ] + [
-            "cp -fv bazel-bin/{doc_path}/{gen_doc} {doc_path}/{src_doc}".format(
-                doc_path = doc_path,
-                gen_doc = doc_prov.out_basename,
-                src_doc = doc_prov.doc_basename,
-            )
-            for doc_prov in doc_provs
-        ],
+    srcs = []
+    outs = []
+    for doc_prov in doc_provs:
+        # srcs.append(paths.join(doc_path, doc_prov.doc_basename))
+        # outs.append(paths.join(doc_path, doc_prov.out_basename))
+        srcs.append(doc_prov.doc_basename)
+        outs.append(doc_prov.out_basename)
+
+    updatesrc_update(
+        name = name,
+        srcs = srcs,
+        outs = outs,
     )
 
-    native.sh_binary(
-        name = "update",
-        srcs = ["update.sh"],
-        data = [doc_prov.out_basename for doc_prov in doc_provs],
-        # The '@' in the following visibility is important. It makes the
-        # target visible relative to the repository where it is being used.
-        visibility = ["@//visibility:public"],
-    )
+    # write_file(
+    #     name = "gen_update",
+    #     out = "update.sh",
+    #     content = [
+    #         "#!/usr/bin/env bash",
+    #         "cd $BUILD_WORKSPACE_DIRECTORY",
+    #     ] + [
+    #         "cp -fv bazel-bin/{doc_path}/{gen_doc} {doc_path}/{src_doc}".format(
+    #             doc_path = doc_path,
+    #             gen_doc = doc_prov.out_basename,
+    #             src_doc = doc_prov.doc_basename,
+    #         )
+    #         for doc_prov in doc_provs
+    #     ],
+    # )
+
+    # native.sh_binary(
+    #     name = "update",
+    #     srcs = ["update.sh"],
+    #     data = [doc_prov.out_basename for doc_prov in doc_provs],
+    #     # The '@' in the following visibility is important. It makes the
+    #     # target visible relative to the repository where it is being used.
+    #     visibility = ["@//visibility:public"],
+    # )

--- a/bazeldoc/private/update_doc.bzl
+++ b/bazeldoc/private/update_doc.bzl
@@ -1,24 +1,16 @@
 load("//updatesrc:defs.bzl", "updatesrc_update")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
-load("@bazel_skylib//lib:paths.bzl", "paths")
 
-def update_doc(doc_provs, name = "update", doc_path = "doc"):
+def update_doc(doc_provs, name = "update"):
     """Defines an executable target that copies the documentation from the output directory to the workspace directory.
 
     Args:
         doc_provs: A `list` of document provider `struct` values as returned
                    from `providers.create()`.
-        doc_path: The relative path for the documentation directory. Do not
-                  include a leading or trailing slash.
-
-    Returns:
-        None.
     """
     srcs = []
     outs = []
     for doc_prov in doc_provs:
-        # srcs.append(paths.join(doc_path, doc_prov.doc_basename))
-        # outs.append(paths.join(doc_path, doc_prov.out_basename))
         srcs.append(doc_prov.doc_basename)
         outs.append(doc_prov.out_basename)
 
@@ -27,28 +19,3 @@ def update_doc(doc_provs, name = "update", doc_path = "doc"):
         srcs = srcs,
         outs = outs,
     )
-
-    # write_file(
-    #     name = "gen_update",
-    #     out = "update.sh",
-    #     content = [
-    #         "#!/usr/bin/env bash",
-    #         "cd $BUILD_WORKSPACE_DIRECTORY",
-    #     ] + [
-    #         "cp -fv bazel-bin/{doc_path}/{gen_doc} {doc_path}/{src_doc}".format(
-    #             doc_path = doc_path,
-    #             gen_doc = doc_prov.out_basename,
-    #             src_doc = doc_prov.doc_basename,
-    #         )
-    #         for doc_prov in doc_provs
-    #     ],
-    # )
-
-    # native.sh_binary(
-    #     name = "update",
-    #     srcs = ["update.sh"],
-    #     data = [doc_prov.out_basename for doc_prov in doc_provs],
-    #     # The '@' in the following visibility is important. It makes the
-    #     # target visible relative to the repository where it is being used.
-    #     visibility = ["@//visibility:public"],
-    # )

--- a/bazeldoc/private/update_doc.bzl
+++ b/bazeldoc/private/update_doc.bzl
@@ -1,13 +1,12 @@
 load("//updatesrc:defs.bzl", "updatesrc_update")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 
-def update_doc(doc_provs, name = "update", chicken = None):
+def update_doc(doc_provs, name = "update"):
     """Defines an executable target that copies the documentation from the output directory to the workspace directory.
 
     Args:
         doc_provs: A `list` of document provider `struct` values as returned
                    from `providers.create()`.
-        chicken: This is not real.
     """
     srcs = []
     outs = []

--- a/bazeldoc/private/write_file_list.bzl
+++ b/bazeldoc/private/write_file_list.bzl
@@ -1,14 +1,11 @@
 load(":write_doc.bzl", "write_doc")
 load(":doc_utilities.bzl", "doc_utilities")
 
-# TODO: Try using package_name() to remove doc_path.
-
 def write_file_list(
         name,
         out,
         header_content = [],
         doc_provs = [],
-        doc_path = "doc",
         do_not_edit_warning = True):
     """Defines a target that writes a documentation file that contains a header and a list of files.
 
@@ -19,14 +16,13 @@ def write_file_list(
                         the file.
         doc_provs: A `list` of document provider `struct` values as returned
                    from `providers.create()`.
-        doc_path: The relative path for the documentation directory. Do not
-                  include a leading or trailing slash.
         do_not_edit_warning: A `bool` specifying whether a comment should be
                              added to the top of the written file.
 
     Returns:
         None.
     """
+    doc_path = native.package_name()
     content = []
     content.extend(header_content)
     if doc_provs != []:

--- a/bazeldoc/private/write_file_list.bzl
+++ b/bazeldoc/private/write_file_list.bzl
@@ -1,6 +1,8 @@
 load(":write_doc.bzl", "write_doc")
 load(":doc_utilities.bzl", "doc_utilities")
 
+# TODO: Try using package_name() to remove doc_path.
+
 def write_file_list(
         name,
         out,

--- a/doc/bazeldoc/BUILD.bazel
+++ b/doc/bazeldoc/BUILD.bazel
@@ -101,6 +101,5 @@ write_header(
 ]
 
 doc_for_provs(
-    doc_path = _DOC_PATH,
     doc_provs = _ALL_DOC_PROVIDERS,
 )

--- a/doc/bazeldoc/BUILD.bazel
+++ b/doc/bazeldoc/BUILD.bazel
@@ -24,8 +24,6 @@ _DOC_DEPS = [
     "//bazeldoc:defs",
 ]
 
-_DOC_PATH = "doc/bazeldoc"
-
 _API_DOC_PROVIDERS = [
     doc_providers.create(
         name = name,
@@ -62,7 +60,6 @@ _ALL_DOC_PROVIDERS = [
 write_file_list(
     name = "api_doc",
     out = "api.md_",
-    doc_path = _DOC_PATH,
     doc_provs = _API_DOC_PROVIDERS,
     header_content = [
         "# Documentation API",

--- a/doc/bazeldoc/BUILD.bazel
+++ b/doc/bazeldoc/BUILD.bazel
@@ -15,6 +15,7 @@ bzlformat_pkg(name = "bzlformat")
 # MARK: - Documentation Declarations
 
 _API_SRCS = [
+    "doc_utilities",
     "providers",
 ]
 
@@ -38,9 +39,15 @@ _BUILD_RULES_PROV = doc_providers.create(
     name = "build_rules_overview",
     stardoc_input = _STARDOC_INPUT,
     symbols = [
+        "diff_test_for_prov",
+        "diff_test_for_provs",
         "doc_for_provs",
-        "write_header",
+        "stardoc_for_prov",
+        "stardoc_for_provs",
+        "update_doc",
+        "write_doc",
         "write_file_list",
+        "write_header",
     ],
     deps = _DOC_DEPS,
 )

--- a/doc/bazeldoc/api.md
+++ b/doc/bazeldoc/api.md
@@ -5,5 +5,6 @@ The APIs described below are used by
 [the build rules](build_rules_overview.md) to facilitate the 
 generation of the Starlark documentation.
 
+  * [doc_utilities](/doc/bazeldoc/doc_utilities.md)
   * [providers](/doc/bazeldoc/providers.md)
 

--- a/doc/bazeldoc/build_rules_overview.md
+++ b/doc/bazeldoc/build_rules_overview.md
@@ -6,9 +6,15 @@ Starlark documentation.
 
 On this page:
 
+  * [diff_test_for_prov](#diff_test_for_prov)
+  * [diff_test_for_provs](#diff_test_for_provs)
   * [doc_for_provs](#doc_for_provs)
-  * [write_header](#write_header)
+  * [stardoc_for_prov](#stardoc_for_prov)
+  * [stardoc_for_provs](#stardoc_for_provs)
+  * [update_doc](#update_doc)
+  * [write_doc](#write_doc)
   * [write_file_list](#write_file_list)
+  * [write_header](#write_header)
 
 
 <a id="#doc_for_provs"></a>

--- a/doc/bazeldoc/build_rules_overview.md
+++ b/doc/bazeldoc/build_rules_overview.md
@@ -38,7 +38,7 @@ None.
 ## write_file_list
 
 <pre>
-write_file_list(<a href="#write_file_list-name">name</a>, <a href="#write_file_list-out">out</a>, <a href="#write_file_list-header_content">header_content</a>, <a href="#write_file_list-doc_provs">doc_provs</a>, <a href="#write_file_list-doc_path">doc_path</a>, <a href="#write_file_list-do_not_edit_warning">do_not_edit_warning</a>)
+write_file_list(<a href="#write_file_list-name">name</a>, <a href="#write_file_list-out">out</a>, <a href="#write_file_list-header_content">header_content</a>, <a href="#write_file_list-doc_provs">doc_provs</a>, <a href="#write_file_list-do_not_edit_warning">do_not_edit_warning</a>)
 </pre>
 
 Defines a target that writes a documentation file that contains a header and a list of files.
@@ -52,7 +52,6 @@ Defines a target that writes a documentation file that contains a header and a l
 | <a id="write_file_list-out"></a>out |  The basename of the output filename as a <code>string</code>.   |  none |
 | <a id="write_file_list-header_content"></a>header_content |  A <code>list</code> of strings representing the header content of the file.   |  <code>[]</code> |
 | <a id="write_file_list-doc_provs"></a>doc_provs |  A <code>list</code> of document provider <code>struct</code> values as returned from <code>providers.create()</code>.   |  <code>[]</code> |
-| <a id="write_file_list-doc_path"></a>doc_path |  The relative path for the documentation directory. Do not include a leading or trailing slash.   |  <code>"doc"</code> |
 | <a id="write_file_list-do_not_edit_warning"></a>do_not_edit_warning |  A <code>bool</code> specifying whether a comment should be added to the top of the written file.   |  <code>True</code> |
 
 **RETURNS**

--- a/doc/bazeldoc/build_rules_overview.md
+++ b/doc/bazeldoc/build_rules_overview.md
@@ -16,7 +16,7 @@ On this page:
 ## doc_for_provs
 
 <pre>
-doc_for_provs(<a href="#doc_for_provs-doc_provs">doc_provs</a>, <a href="#doc_for_provs-doc_path">doc_path</a>)
+doc_for_provs(<a href="#doc_for_provs-doc_provs">doc_provs</a>)
 </pre>
 
 Defines targets for generating documentation, testing that the generated doc matches the workspace directory, and copying the generated doc to the workspace directory.
@@ -27,7 +27,6 @@ Defines targets for generating documentation, testing that the generated doc mat
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="doc_for_provs-doc_provs"></a>doc_provs |  A <code>list</code> of document provider <code>struct</code> values as returned from <code>providers.create()</code>.   |  none |
-| <a id="doc_for_provs-doc_path"></a>doc_path |  <p align="center"> - </p>   |  <code>"doc"</code> |
 
 **RETURNS**
 

--- a/doc/bazeldoc/doc_utilities.md
+++ b/doc/bazeldoc/doc_utilities.md
@@ -1,0 +1,4 @@
+<!-- Generated with Stardoc, Do Not Edit! -->
+# `doc_utilities` API
+
+

--- a/doc/bzlformat/BUILD.bazel
+++ b/doc/bzlformat/BUILD.bazel
@@ -48,6 +48,5 @@ write_header(
 # MARK: - Generate Documentation from Providers
 
 doc_for_provs(
-    doc_path = _DOC_PATH,
     doc_provs = _ALL_DOC_PROVIDERS,
 )

--- a/doc/bzllib/BUILD.bazel
+++ b/doc/bzllib/BUILD.bazel
@@ -121,6 +121,5 @@ write_file_list(
 # MARK: - Generate Documentation from Providers
 
 doc_for_provs(
-    doc_path = _DOC_PATH,
     doc_provs = _ALL_DOC_PROVIDERS,
 )

--- a/doc/bzllib/api.md
+++ b/doc/bzllib/api.md
@@ -3,5 +3,5 @@
 
 The APIs listed below are available in this repository.
 
-  * [src_utils](/doc/src_utils.md)
+  * [src_utils](/doc/bzllib/src_utils.md)
 

--- a/doc/bzllib/rules.md
+++ b/doc/bzllib/rules.md
@@ -3,5 +3,5 @@
 
 The rules listed below are available in this repository.
 
-  * [filter_srcs](/doc/filter_srcs.md)
+  * [filter_srcs](/doc/bzllib/filter_srcs.md)
 

--- a/doc/bzlrelease/BUILD.bazel
+++ b/doc/bzlrelease/BUILD.bazel
@@ -107,6 +107,5 @@ write_file_list(
 # MARK: - Generate Documentation from Providers
 
 doc_for_provs(
-    doc_path = "doc/bzlrelease",
     doc_provs = _ALL_DOC_PROVIDERS,
 )

--- a/doc/bzlrelease/rules.md
+++ b/doc/bzlrelease/rules.md
@@ -3,9 +3,9 @@
 
 The rules listed below are available in this repository.
 
-  * [create_release](/doc/create_release.md)
-  * [generate_release_notes](/doc/generate_release_notes.md)
-  * [generate_workspace_snippet](/doc/generate_workspace_snippet.md)
-  * [hash_sha256](/doc/hash_sha256.md)
-  * [update_readme](/doc/update_readme.md)
+  * [create_release](/doc/bzlrelease/create_release.md)
+  * [generate_release_notes](/doc/bzlrelease/generate_release_notes.md)
+  * [generate_workspace_snippet](/doc/bzlrelease/generate_workspace_snippet.md)
+  * [hash_sha256](/doc/bzlrelease/hash_sha256.md)
+  * [update_readme](/doc/bzlrelease/update_readme.md)
 

--- a/doc/shlib/BUILD.bazel
+++ b/doc/shlib/BUILD.bazel
@@ -11,8 +11,6 @@ bzlformat_pkg(name = "bzlformat")
 
 # MARK: - Documentation Providers
 
-_DOC_PATH = "doc/shlib"
-
 _RULE_NAMES = [
     "binary_pkg",
     "execute_binary",
@@ -89,7 +87,6 @@ _ALL_DOC_PROVIDERS = [
 write_file_list(
     name = "api_doc",
     out = "api.md_",
-    doc_path = _DOC_PATH,
     doc_provs = _API_DOC_PROVIDERS,
     header_content = [
         "# Build API",
@@ -103,7 +100,6 @@ write_file_list(
 write_file_list(
     name = "rules_doc",
     out = "rules.md_",
-    doc_path = _DOC_PATH,
     doc_provs = _RULE_DOC_PROVIDERS,
     header_content = [
         "# Rules",

--- a/doc/shlib/BUILD.bazel
+++ b/doc/shlib/BUILD.bazel
@@ -116,6 +116,5 @@ write_file_list(
 # MARK: - Generate Documentation from Providers
 
 doc_for_provs(
-    doc_path = _DOC_PATH,
     doc_provs = _ALL_DOC_PROVIDERS,
 )

--- a/doc/updatesrc/BUILD.bazel
+++ b/doc/updatesrc/BUILD.bazel
@@ -15,8 +15,6 @@ _STARDOC_INPUT = "//updatesrc:defs.bzl"
 
 _DOC_DEPS = ["//updatesrc:defs"]
 
-_DOC_PATH = "doc/updatesrc"
-
 _PROVIDERS_DOC_PROVIDER = doc_providers.create(
     name = "providers_overview",
     stardoc_input = _STARDOC_INPUT,
@@ -104,7 +102,6 @@ write_header(
 write_file_list(
     name = "api_doc",
     out = "api.md_",
-    doc_path = _DOC_PATH,
     doc_provs = _API_DOC_PROVIDERS,
     header_content = [
         "# Build API",

--- a/doc/updatesrc/BUILD.bazel
+++ b/doc/updatesrc/BUILD.bazel
@@ -117,6 +117,5 @@ write_file_list(
 # MARK: - Generate Documentation from Providers
 
 doc_for_provs(
-    doc_path = _DOC_PATH,
     doc_provs = _ALL_DOC_PROVIDERS,
 )


### PR DESCRIPTION
Closes #43.

- Updated `update_doc` to use `updatesrc_update`.
- Removed `doc_path` attribute in `bazeldoc` macros.
- Generate documentation for all `bazeldoc` macros and libraries.