### PR TITLE
Updated updatesrc's simple example so that it does not pollute the workspace directory.

### DIFF
--- a/examples/updatesrc/simple/header/BUILD.bazel
+++ b/examples/updatesrc/simple/header/BUILD.bazel
@@ -8,3 +8,8 @@ bzl_library(
     name = "header",
     srcs = ["header.bzl"],
 )
+
+sh_binary(
+    name = "add_header",
+    srcs = ["header.sh"],
+)

--- a/examples/updatesrc/simple/header/header.sh
+++ b/examples/updatesrc/simple/header/header.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 src="$1"
 out="$2"
 header="$3"

--- a/examples/updatesrc/simple/srcs/Bar/BUILD.bazel
+++ b/examples/updatesrc/simple/srcs/Bar/BUILD.bazel
@@ -11,19 +11,6 @@ srcs = [
 outs = [f + "_modified" for f in srcs]
 
 [
-    # genrule(
-    #     name = "gen_" + outs[idx],
-    #     srcs = [srcs[idx]],
-    #     outs = [outs[idx]],
-    #     cmd = """\
-    # src_file=$(location {src})
-    # header="# Howdy"
-    # rm -f $@
-    # # [[ "$src_content" =~ "$header" ]] || echo "$header" > $@
-    # grep "$header" "$src_file" || echo "$header" > $@
-    # echo "$src_content" >> $@
-    # """.format(src = srcs[idx]),
-    # )
     genrule(
         name = "gen_" + outs[idx],
         srcs = [srcs[idx]],
@@ -40,35 +27,3 @@ updatesrc_diff_and_update(
     srcs = srcs,
     outs = outs,
 )
-
-# genrule(
-#     name = "c_modified",
-#     srcs = ["c.txt"],
-#     outs = ["c.txt_modified"],
-#     cmd = """\
-# echo "# Howdy" > $@
-# cat $(location c.txt) >> $@
-# """,
-# )
-
-# genrule(
-#     name = "d_modified",
-#     srcs = ["d.txt"],
-#     outs = ["d.txt_modified"],
-#     cmd = """\
-# echo "# Howdy" > $@
-# cat $(location d.txt) >> $@
-# """,
-# )
-
-# updatesrc_update(
-#     name = "update",
-#     srcs = [
-#         "c.txt",
-#         "d.txt",
-#     ],
-#     outs = [
-#         ":c_modified",
-#         ":d_modified",
-#     ],
-# )

--- a/examples/updatesrc/simple/srcs/Bar/BUILD.bazel
+++ b/examples/updatesrc/simple/srcs/Bar/BUILD.bazel
@@ -11,24 +11,32 @@ srcs = [
 outs = [f + "_modified" for f in srcs]
 
 [
+    # genrule(
+    #     name = "gen_" + outs[idx],
+    #     srcs = [srcs[idx]],
+    #     outs = [outs[idx]],
+    #     cmd = """\
+    # src_file=$(location {src})
+    # header="# Howdy"
+    # rm -f $@
+    # # [[ "$src_content" =~ "$header" ]] || echo "$header" > $@
+    # grep "$header" "$src_file" || echo "$header" > $@
+    # echo "$src_content" >> $@
+    # """.format(src = srcs[idx]),
+    # )
     genrule(
         name = "gen_" + outs[idx],
         srcs = [srcs[idx]],
         outs = [outs[idx]],
         cmd = """\
-src_file=$(location {src})
-header="# Howdy"
-src_content="$(< "${src_file}")"
-rm -f $@
-[[ "${src_content}" =~ "${header}" ]] || echo "${header}" > $@
-echo "${src_content}" >> $@
-""",
+$(location //header:add_header) $(location {src}) $@ "# Howdy"
+""".format(src = srcs[idx]),
+        tools = ["//header:add_header"],
     )
     for idx in range(len(srcs))
 ]
 
-updatesrc_diff_update(
-    name = "update",
+updatesrc_diff_and_update(
     srcs = srcs,
     outs = outs,
 )

--- a/examples/updatesrc/simple/srcs/Bar/BUILD.bazel
+++ b/examples/updatesrc/simple/srcs/Bar/BUILD.bazel
@@ -1,36 +1,66 @@
 load(
     "@cgrindel_bazel_starlib//updatesrc:defs.bzl",
-    "updatesrc_update",
+    "updatesrc_diff_and_update",
 )
 
-genrule(
-    name = "c_modified",
-    srcs = ["c.txt"],
-    outs = ["c.txt_modified"],
-    cmd = """\
-echo "# Howdy" > $@
-cat $(location c.txt) >> $@
+srcs = [
+    "c.txt",
+    "d.txt",
+]
+
+outs = [f + "_modified" for f in srcs]
+
+[
+    genrule(
+        name = "gen_" + outs[idx],
+        srcs = [srcs[idx]],
+        outs = [outs[idx]],
+        cmd = """\
+src_file=$(location {src})
+header="# Howdy"
+src_content="$(< "${src_file}")"
+rm -f $@
+[[ "${src_content}" =~ "${header}" ]] || echo "${header}" > $@
+echo "${src_content}" >> $@
 """,
-)
+    )
+    for idx in range(len(srcs))
+]
 
-genrule(
-    name = "d_modified",
-    srcs = ["d.txt"],
-    outs = ["d.txt_modified"],
-    cmd = """\
-echo "# Howdy" > $@
-cat $(location d.txt) >> $@
-""",
-)
-
-updatesrc_update(
+updatesrc_diff_update(
     name = "update",
-    srcs = [
-        "c.txt",
-        "d.txt",
-    ],
-    outs = [
-        ":c_modified",
-        ":d_modified",
-    ],
+    srcs = srcs,
+    outs = outs,
 )
+
+# genrule(
+#     name = "c_modified",
+#     srcs = ["c.txt"],
+#     outs = ["c.txt_modified"],
+#     cmd = """\
+# echo "# Howdy" > $@
+# cat $(location c.txt) >> $@
+# """,
+# )
+
+# genrule(
+#     name = "d_modified",
+#     srcs = ["d.txt"],
+#     outs = ["d.txt_modified"],
+#     cmd = """\
+# echo "# Howdy" > $@
+# cat $(location d.txt) >> $@
+# """,
+# )
+
+# updatesrc_update(
+#     name = "update",
+#     srcs = [
+#         "c.txt",
+#         "d.txt",
+#     ],
+#     outs = [
+#         ":c_modified",
+#         ":d_modified",
+#     ],
+# )

--- a/examples/updatesrc/simple/srcs/Bar/c.txt
+++ b/examples/updatesrc/simple/srcs/Bar/c.txt
@@ -1,3 +1,2 @@
 # Howdy
-# Howdy
 This is c.txt.

--- a/examples/updatesrc/simple/srcs/Bar/d.txt
+++ b/examples/updatesrc/simple/srcs/Bar/d.txt
@@ -1,3 +1,2 @@
 # Howdy
-# Howdy
 This is d.txt.


### PR DESCRIPTION
Closes #51.

- Updated updatesrc's simple example so that it does not pollute the workspace directory.
- Updated one of the simple example packages to use `updatesrc_diff_and_update`.