### PR TITLE
Fixed issues with documentation for `bazel-starlib`, `bzlformat`, `bazeldoc`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,6 @@ bazel_starlib_dependencies()
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
-
-load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
-
-stardoc_repositories()
 ```
 <!-- END WORKSPACE SNIPPET -->
 

--- a/bazeldoc/README.md
+++ b/bazeldoc/README.md
@@ -9,6 +9,20 @@ documentation for Starlark code.
 
 ## Quickstart
 
+### 1. Configure your workspace to use `bazeldoc`
+
+In addition to the [workspace snippet for the repository](/README.md#workspace-configuration), add
+the following to your `WORKSPACE` file:
+
+```python
+load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
+
+stardoc_repositories()
+```
+
+
+### 2. Review sample implementations
+
 Look at the BUILD.bazel files in the documentation directories (e.g.
 [bazeldoc](/doc/bazeldoc/BUILD.bazel), [bzlformat](/doc/bzlformat/BUILD.bazel)). They use the macros
 and APIs defined in this project.

--- a/bzlformat/README.md
+++ b/bzlformat/README.md
@@ -27,6 +27,8 @@ the following to your `WORKSPACE` file. These are dependencies for
 [Buildifier](https://github.com/bazelbuild/buildtools/tree/master/buildifier).
 
 ```python
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+
 go_rules_dependencies()
 
 go_register_toolchains(version = "1.17.2")

--- a/release/workspace_snippet.tmpl
+++ b/release/workspace_snippet.tmpl
@@ -9,7 +9,3 @@ bazel_starlib_dependencies()
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
-
-load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
-
-stardoc_repositories()


### PR DESCRIPTION
- Add missing load statement to bzlformat `README.md`.
- Removed `stardoc` refs from `bazel-starlib` workspace config.
- Added `stardoc` ref to `bazeldoc` documentation.