### PR TITLE
Added `@cgrindel_rules_bazel_integration_test//tools:update_deleted_packages` to update_all.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -16,6 +16,7 @@ bzlformat_missing_pkgs(
 updatesrc_update_all(
     name = "update_all",
     targets_to_run = [
+        "@cgrindel_rules_bazel_integration_test//tools:update_deleted_packages",
         ":bzlformat_missing_pkgs_fix",
     ],
 )


### PR DESCRIPTION
Closes #52.

- It turns out that the `targets_to_run` target executes before the update commands.