### PR TITLE
Changed call to runfiles `merge_all` to `merge`.

### DIFF
--- a/examples/markdown/simple/BUILD.bazel
+++ b/examples/markdown/simple/BUILD.bazel
@@ -3,3 +3,5 @@ filegroup(
     srcs = glob(["*.md"]),
     visibility = ["//tests:__subpackages__"],
 )
+
+# Add a change.

--- a/markdown/private/markdown_check_links_test.bzl
+++ b/markdown/private/markdown_check_links_test.bzl
@@ -20,9 +20,9 @@ def _markdown_check_links_test_impl(ctx):
     if ctx.file.config != None:
         files.append(ctx.file.config)
 
-    runfiles = ctx.runfiles(files = files).merge_all([
+    runfiles = ctx.runfiles(files = files).merge(
         ctx.attr._link_checker[DefaultInfo].default_runfiles,
-    ])
+    )
 
     config_file_path = ""
     if ctx.file.config != None:


### PR DESCRIPTION
Closes #85 .

- Bazel 4.2.2 does not support `runfiles.merge_all`. Since we were only merging one runfiles object, I switched it to `runfiles.merge`.