### PR TITLE
Allow for a custom workspace name in generated workspace snippets.

### DIFF
--- a/bzlrelease/private/generate_workspace_snippet.bzl
+++ b/bzlrelease/private/generate_workspace_snippet.bzl
@@ -1,6 +1,6 @@
 load("//shlib/rules:execute_binary.bzl", "execute_binary", "file_placeholder")
 
-def generate_workspace_snippet(name, template = None):
+def generate_workspace_snippet(name, template = None, workspace_name = None):
     """Defines an executable target that generates a workspace snippet suitable \
     for inclusion in a markdown document.
 
@@ -18,6 +18,8 @@ def generate_workspace_snippet(name, template = None):
         file_key = "template"
         arguments.extend(["--template", file_placeholder(file_key)])
         file_arguments[template] = file_key
+    if workspace_name != None:
+        arguments.extend(["--workspace_name", workspace_name])
 
     execute_binary(
         name = name,

--- a/bzlrelease/private/generate_workspace_snippet.bzl
+++ b/bzlrelease/private/generate_workspace_snippet.bzl
@@ -10,7 +10,10 @@ def generate_workspace_snippet(name, template = None, workspace_name = None):
 
     Args:
         name: The name of the executable target as a `string`.
-        template: The path to a template file  as a `string`.
+        template: Optional. The path to a template file  as a `string`.
+        workspace_name: Optional. The name of the workspace. If not provided,
+                        the workspace name is derived from the owner and
+                        repository name.
     """
     file_arguments = {}
     arguments = []

--- a/bzlrelease/tools/generate_workspace_snippet.sh
+++ b/bzlrelease/tools/generate_workspace_snippet.sh
@@ -134,7 +134,6 @@ strip_prefix_suffix="${tag}"
 [[ "${strip_prefix_suffix}" =~ ^v ]] && strip_prefix_suffix="${strip_prefix_suffix:1}"
 strip_prefix="${repo}-${strip_prefix_suffix}"
 
-
 if [[ -z "${workspace_name:-}" ]]; then
   workspace_name="${owner}_${repo}"
   # Replace hyphens with underscores
@@ -149,7 +148,6 @@ urls="$(
   done
 )"
 
-
 # Generate the workspace snippet
 http_archive_statement="$(cat  <<-EOF
 http_archive(
@@ -162,7 +160,6 @@ ${urls}
 )
 EOF
 )"
-
 
 if [[ -z "${template:-}" ]]; then
   snippet="${http_archive_statement}"
@@ -183,8 +180,6 @@ else
       "${template}"
   )"
 fi
-
-
 
 # Wrap the resulting snippet in a markdown codeblock.
 snippet="$(cat <<-EOF

--- a/bzlrelease/tools/generate_workspace_snippet.sh
+++ b/bzlrelease/tools/generate_workspace_snippet.sh
@@ -134,6 +134,7 @@ strip_prefix_suffix="${tag}"
 [[ "${strip_prefix_suffix}" =~ ^v ]] && strip_prefix_suffix="${strip_prefix_suffix:1}"
 strip_prefix="${repo}-${strip_prefix_suffix}"
 
+
 if [[ -z "${workspace_name:-}" ]]; then
   workspace_name="${owner}_${repo}"
   # Replace hyphens with underscores
@@ -148,6 +149,7 @@ urls="$(
   done
 )"
 
+
 # Generate the workspace snippet
 http_archive_statement="$(cat  <<-EOF
 http_archive(
@@ -160,6 +162,7 @@ ${urls}
 )
 EOF
 )"
+
 
 if [[ -z "${template:-}" ]]; then
   snippet="${http_archive_statement}"
@@ -180,6 +183,8 @@ else
       "${template}"
   )"
 fi
+
+
 
 # Wrap the resulting snippet in a markdown codeblock.
 snippet="$(cat <<-EOF

--- a/doc/bzlrelease/generate_workspace_snippet.md
+++ b/doc/bzlrelease/generate_workspace_snippet.md
@@ -21,7 +21,7 @@ Without a template, the utility will output an `http_archive` declaration.     W
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="generate_workspace_snippet-name"></a>name |  The name of the executable target as a <code>string</code>.   |  none |
-| <a id="generate_workspace_snippet-template"></a>template |  The path to a template file  as a <code>string</code>.   |  <code>None</code> |
-| <a id="generate_workspace_snippet-workspace_name"></a>workspace_name |  <p align="center"> - </p>   |  <code>None</code> |
+| <a id="generate_workspace_snippet-template"></a>template |  Optional. The path to a template file  as a <code>string</code>.   |  <code>None</code> |
+| <a id="generate_workspace_snippet-workspace_name"></a>workspace_name |  Optional. The name of the workspace. If not provided, the workspace name is derived from the owner and repository name.   |  <code>None</code> |
 
 

--- a/doc/bzlrelease/generate_workspace_snippet.md
+++ b/doc/bzlrelease/generate_workspace_snippet.md
@@ -7,7 +7,7 @@
 ## generate_workspace_snippet
 
 <pre>
-generate_workspace_snippet(<a href="#generate_workspace_snippet-name">name</a>, <a href="#generate_workspace_snippet-template">template</a>)
+generate_workspace_snippet(<a href="#generate_workspace_snippet-name">name</a>, <a href="#generate_workspace_snippet-template">template</a>, <a href="#generate_workspace_snippet-workspace_name">workspace_name</a>)
 </pre>
 
 Defines an executable target that generates a workspace snippet suitable     for inclusion in a markdown document.
@@ -22,5 +22,6 @@ Without a template, the utility will output an `http_archive` declaration.     W
 | :------------- | :------------- | :------------- |
 | <a id="generate_workspace_snippet-name"></a>name |  The name of the executable target as a <code>string</code>.   |  none |
 | <a id="generate_workspace_snippet-template"></a>template |  The path to a template file  as a <code>string</code>.   |  <code>None</code> |
+| <a id="generate_workspace_snippet-workspace_name"></a>workspace_name |  <p align="center"> - </p>   |  <code>None</code> |
 
 

--- a/tests/bzlrelease_tests/rules_tests/generate_release_notes_tests/BUILD.bazel
+++ b/tests/bzlrelease_tests/rules_tests/generate_release_notes_tests/BUILD.bazel
@@ -5,20 +5,32 @@ load("//tests:integration_test_common.bzl", "GH_ENV_INHERIT", "INTEGRATION_TEST_
 bzlformat_pkg(name = "bzlformat")
 
 generate_workspace_snippet(
-    name = "generate_workspace_snippet",
+    name = "generate_snippet_with_template",
     template = "workspace_snippet.tmpl",
 )
 
 generate_release_notes(
-    name = "generate_release_notes",
-    generate_workspace_snippet = ":generate_workspace_snippet",
+    name = "generate_release_notes_with_template",
+    generate_workspace_snippet = ":generate_snippet_with_template",
+)
+
+generate_workspace_snippet(
+    name = "generate_snippet_with_workspace_name",
+    template = "workspace_snippet.tmpl",
+    workspace_name = "foo_bar",
+)
+
+generate_release_notes(
+    name = "generate_release_notes_with_workspace_name",
+    generate_workspace_snippet = ":generate_snippet_with_workspace_name",
 )
 
 sh_test(
     name = "generate_release_notes_test",
     srcs = ["generate_release_notes_test.sh"],
     data = [
-        ":generate_release_notes",
+        ":generate_release_notes_with_template",
+        ":generate_release_notes_with_workspace_name",
     ],
     env_inherit = GH_ENV_INHERIT,
     tags = INTEGRATION_TEST_TAGS,

--- a/tests/bzlrelease_tests/rules_tests/generate_release_notes_tests/generate_release_notes_test.sh
+++ b/tests/bzlrelease_tests/rules_tests/generate_release_notes_tests/generate_release_notes_test.sh
@@ -18,10 +18,13 @@ setup_git_repo_sh_location=cgrindel_bazel_starlib/tests/setup_git_repo.sh
 setup_git_repo_sh="$(rlocation "${setup_git_repo_sh_location}")" || \
   (echo >&2 "Failed to locate ${setup_git_repo_sh_location}" && exit 1)
 
-generate_release_notes_sh_location=cgrindel_bazel_starlib/tests/bzlrelease_tests/rules_tests/generate_release_notes_tests/generate_release_notes.sh
-generate_release_notes_sh="$(rlocation "${generate_release_notes_sh_location}")" || \
-  (echo >&2 "Failed to locate ${generate_release_notes_sh_location}" && exit 1)
+generate_release_notes_with_template_sh_location=cgrindel_bazel_starlib/tests/bzlrelease_tests/rules_tests/generate_release_notes_tests/generate_release_notes_with_template.sh
+generate_release_notes_with_template_sh="$(rlocation "${generate_release_notes_with_template_sh_location}")" || \
+  (echo >&2 "Failed to locate ${generate_release_notes_with_template_sh_location}" && exit 1)
 
+generate_release_notes_with_workspace_name_sh_location=cgrindel_bazel_starlib/tests/bzlrelease_tests/rules_tests/generate_release_notes_tests/generate_release_notes_with_workspace_name.sh
+generate_release_notes_with_workspace_name_sh="$(rlocation "${generate_release_notes_with_workspace_name_sh_location}")" || \
+  (echo >&2 "Failed to locate ${generate_release_notes_with_workspace_name_sh_location}" && exit 1)
 
 # MARK - Setup
 
@@ -32,6 +35,14 @@ source "${setup_git_repo_sh}"
 
 tag="v999.0.0"
 
-actual="$( "${generate_release_notes_sh}" "${tag}" )"
+# Test with template
+actual="$( "${generate_release_notes_with_template_sh}" "${tag}" )"
+assert_match "name = \"cgrindel_bazel_starlib\"" "${actual}" "Did not find workspace name."
+assert_match "## What's Changed" "${actual}" "Did not find release notes header."
+assert_match "bazel_starlib_dependencies()" "${actual}" "Did not find template content."
+
+# Test with workspace_name
+actual="$( "${generate_release_notes_with_workspace_name_sh}" "${tag}" )"
+assert_match "name = \"foo_bar\"" "${actual}" "Did not find workspace name."
 assert_match "## What's Changed" "${actual}" "Did not find release notes header."
 assert_match "bazel_starlib_dependencies()" "${actual}" "Did not find template content."

--- a/tests/bzlrelease_tests/tools_tests/generate_workspace_snippet_test.sh
+++ b/tests/bzlrelease_tests/tools_tests/generate_workspace_snippet_test.sh
@@ -63,9 +63,49 @@ EOF
 [[ "${actual_snippet}" == "${expected_snippet}" ]] || \
   fail $'Snippet with defaults did not match expected.  actual:\n'"${actual_snippet}"$'\nexpected:\n'"${expected_snippet}"
 
+# MARK - Test with custom workspace_name
+
+
+actual_snippet="$(
+"${generate_workspace_snippet_sh}" \
+  --workspace_name "foo_bar" \
+  --sha256 "${sha256}" \
+  --tag "${tag}"
+)"
+
+expected_snippet=$(cat <<-EOF
+\`\`\`python
+http_archive(
+    name = "foo_bar",
+    sha256 = "${sha256}",
+    strip_prefix = "${strip_prefix}",
+    urls = [
+        "http://github.com/cgrindel/bazel-starlib/archive/${tag}.tar.gz",
+    ],
+)
+\`\`\`
+EOF
+)
+[[ "${actual_snippet}" == "${expected_snippet}" ]] || \
+  fail $'Snippet with custom workspace_name did not match expected.  actual:\n'"${actual_snippet}"$'\nexpected:\n'"${expected_snippet}"
+
 # MARK - Test write to file
 
 output_path="snippet.bzl"
+
+expected_snippet=$(cat <<-EOF
+\`\`\`python
+http_archive(
+    name = "cgrindel_bazel_starlib",
+    sha256 = "${sha256}",
+    strip_prefix = "${strip_prefix}",
+    urls = [
+        "http://github.com/cgrindel/bazel-starlib/archive/${tag}.tar.gz",
+    ],
+)
+\`\`\`
+EOF
+)
 
 "${generate_workspace_snippet_sh}" \
   --sha256 "${sha256}" \


### PR DESCRIPTION
Closes #106.

- Added `workspace_name` to `generate_workspace_name.bzl`.
- Added tests confirming that the customization works correctly in `generate_workspace_snippet.sh` and that it carries through to dependent tasks.