### PR TITLE
Implemented `markdown_pkg` to aid in the maintenance of markdown files.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -6,10 +6,7 @@ load(
 load("//updatesrc:defs.bzl", "updatesrc_update_all")
 load("//tests:integration_test_common.bzl", "GH_ENV_INHERIT", "INTEGRATION_TEST_TAGS")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-
-# GH086: Finish markdown_pkg  and markdown_generate_toc implementation.
-
-# load("//markdown:defs.bzl", "markdown_pkg")
+load("//markdown:defs.bzl", "markdown_pkg")
 
 bzlformat_pkg(name = "bzlformat")
 
@@ -40,11 +37,9 @@ filegroup(
     visibility = ["//:markdown_test_visibility"],
 )
 
-# GH086: Finish markdown_pkg  and markdown_generate_toc implementation.
-
-# markdown_pkg(
-#     name = "markdown",
-# )
+markdown_pkg(
+    name = "markdown",
+)
 
 # MARK: - Integration Tests
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -31,14 +31,9 @@ package_group(
     ],
 )
 
-filegroup(
-    name = "doc_files",
-    srcs = glob(["*.md"]),
-    visibility = ["//:markdown_test_visibility"],
-)
-
 markdown_pkg(
     name = "markdown",
+    doc_files_visibility = ["//:markdown_test_visibility"],
 )
 
 # MARK: - Integration Tests

--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ the implementation of Bazel projects.
 
 ## Table of Contents
 
+<!-- MARKDOWN TOC: BEGIN -->
 * [Quickstart](#quickstart)
   * [Workspace Configuration](#workspace-configuration)
 * [Other Documentation](#other-documentation)
+<!-- MARKDOWN TOC: END -->
 
 
 ## Quickstart

--- a/doc/markdown/BUILD.bazel
+++ b/doc/markdown/BUILD.bazel
@@ -27,8 +27,9 @@ _RULES_AND_MACROS_DOC_PROVIDER = doc_providers.create(
     name = "rules_and_macros_overview",
     stardoc_input = _STARDOC_INPUT,
     symbols = [
-        "markdown_generate_toc",
         "markdown_check_links_test",
+        "markdown_generate_toc",
+        "markdown_pkg",
         "markdown_register_node_deps",
     ],
     deps = _DOC_DEPS,

--- a/doc/markdown/rules_and_macros_overview.md
+++ b/doc/markdown/rules_and_macros_overview.md
@@ -6,8 +6,9 @@ files.
 
 On this page:
 
-  * [markdown_generate_toc](#markdown_generate_toc)
   * [markdown_check_links_test](#markdown_check_links_test)
+  * [markdown_generate_toc](#markdown_generate_toc)
+  * [markdown_pkg](#markdown_pkg)
   * [markdown_register_node_deps](#markdown_register_node_deps)
 
 
@@ -55,6 +56,27 @@ markdown_generate_toc(<a href="#markdown_generate_toc-name">name</a>, <a href="#
 | <a id="markdown_generate_toc-remove_toc_header_entry"></a>remove_toc_header_entry |  Specifies whether the header for the TOC should be removed from the TOC.   | Boolean | optional | True |
 | <a id="markdown_generate_toc-srcs"></a>srcs |  The markdown files that will be updated with a table of contents.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
 | <a id="markdown_generate_toc-toc_header"></a>toc_header |  The header that leads the TOC.   | String | optional | "Table of Contents" |
+
+
+<a id="#markdown_pkg"></a>
+
+## markdown_pkg
+
+<pre>
+markdown_pkg(<a href="#markdown_pkg-name">name</a>, <a href="#markdown_pkg-srcs">srcs</a>, <a href="#markdown_pkg-toc_visibility">toc_visibility</a>, <a href="#markdown_pkg-update_visibility">update_visibility</a>)
+</pre>
+
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="markdown_pkg-name"></a>name |  <p align="center"> - </p>   |  <code>"markdown"</code> |
+| <a id="markdown_pkg-srcs"></a>srcs |  <p align="center"> - </p>   |  <code>None</code> |
+| <a id="markdown_pkg-toc_visibility"></a>toc_visibility |  <p align="center"> - </p>   |  <code>None</code> |
+| <a id="markdown_pkg-update_visibility"></a>update_visibility |  <p align="center"> - </p>   |  <code>None</code> |
 
 
 <a id="#markdown_register_node_deps"></a>

--- a/doc/markdown/rules_and_macros_overview.md
+++ b/doc/markdown/rules_and_macros_overview.md
@@ -63,7 +63,8 @@ markdown_generate_toc(<a href="#markdown_generate_toc-name">name</a>, <a href="#
 ## markdown_pkg
 
 <pre>
-markdown_pkg(<a href="#markdown_pkg-name">name</a>, <a href="#markdown_pkg-srcs">srcs</a>, <a href="#markdown_pkg-toc_visibility">toc_visibility</a>, <a href="#markdown_pkg-update_visibility">update_visibility</a>)
+markdown_pkg(<a href="#markdown_pkg-name">name</a>, <a href="#markdown_pkg-srcs">srcs</a>, <a href="#markdown_pkg-toc_visibility">toc_visibility</a>, <a href="#markdown_pkg-update_visibility">update_visibility</a>, <a href="#markdown_pkg-define_doc_files">define_doc_files</a>, <a href="#markdown_pkg-doc_files_visibility">doc_files_visibility</a>,
+             <a href="#markdown_pkg-additional_doc_files">additional_doc_files</a>)
 </pre>
 
 
@@ -77,6 +78,9 @@ markdown_pkg(<a href="#markdown_pkg-name">name</a>, <a href="#markdown_pkg-srcs"
 | <a id="markdown_pkg-srcs"></a>srcs |  <p align="center"> - </p>   |  <code>None</code> |
 | <a id="markdown_pkg-toc_visibility"></a>toc_visibility |  <p align="center"> - </p>   |  <code>None</code> |
 | <a id="markdown_pkg-update_visibility"></a>update_visibility |  <p align="center"> - </p>   |  <code>None</code> |
+| <a id="markdown_pkg-define_doc_files"></a>define_doc_files |  <p align="center"> - </p>   |  <code>True</code> |
+| <a id="markdown_pkg-doc_files_visibility"></a>doc_files_visibility |  <p align="center"> - </p>   |  <code>["@//:__subpackages__"]</code> |
+| <a id="markdown_pkg-additional_doc_files"></a>additional_doc_files |  <p align="center"> - </p>   |  <code>[]</code> |
 
 
 <a id="#markdown_register_node_deps"></a>

--- a/doc/markdown/rules_and_macros_overview.md
+++ b/doc/markdown/rules_and_macros_overview.md
@@ -67,6 +67,9 @@ markdown_pkg(<a href="#markdown_pkg-name">name</a>, <a href="#markdown_pkg-srcs"
              <a href="#markdown_pkg-additional_doc_files">additional_doc_files</a>)
 </pre>
 
+Adds targets to maintain markdown files in the package.
+
+This macro adds targets to generate a table of contents (TOC) for markdown     files (`markdown_generate_toc`), adds `diff_test` targets to confirm that     the markdown files are up-to-date with the latest TOC, adds a target to     update the markdown files with the generated files (`updatesrc_update`)     and defines a `filegroup` that is useful to collecting documentation files     for confirming that a markdown files links are valid     (`markdown_check_links_test`)
 
 
 **PARAMETERS**
@@ -74,13 +77,13 @@ markdown_pkg(<a href="#markdown_pkg-name">name</a>, <a href="#markdown_pkg-srcs"
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="markdown_pkg-name"></a>name |  <p align="center"> - </p>   |  <code>"markdown"</code> |
-| <a id="markdown_pkg-srcs"></a>srcs |  <p align="center"> - </p>   |  <code>None</code> |
-| <a id="markdown_pkg-toc_visibility"></a>toc_visibility |  <p align="center"> - </p>   |  <code>None</code> |
-| <a id="markdown_pkg-update_visibility"></a>update_visibility |  <p align="center"> - </p>   |  <code>None</code> |
-| <a id="markdown_pkg-define_doc_files"></a>define_doc_files |  <p align="center"> - </p>   |  <code>True</code> |
-| <a id="markdown_pkg-doc_files_visibility"></a>doc_files_visibility |  <p align="center"> - </p>   |  <code>["@//:__subpackages__"]</code> |
-| <a id="markdown_pkg-additional_doc_files"></a>additional_doc_files |  <p align="center"> - </p>   |  <code>[]</code> |
+| <a id="markdown_pkg-name"></a>name |  A prefix <code>string</code> that will be added to all of the targets defined by this macro.   |  <code>"markdown"</code> |
+| <a id="markdown_pkg-srcs"></a>srcs |  Optional. The markdown sources to be used by the macro. If none are specified, all of the <code>.md</code> and <code>.markdown</code> files are used.   |  <code>None</code> |
+| <a id="markdown_pkg-toc_visibility"></a>toc_visibility |  Optional. The visibility for the TOC generation targets.   |  <code>None</code> |
+| <a id="markdown_pkg-update_visibility"></a>update_visibility |  Optional. The visibility for the update target.   |  <code>None</code> |
+| <a id="markdown_pkg-define_doc_files"></a>define_doc_files |  Optional. A <code>bool</code> that specifies whether to define a <code>filegroup</code> that can be used for documentation validity tests.   |  <code>True</code> |
+| <a id="markdown_pkg-doc_files_visibility"></a>doc_files_visibility |  Optional. The visibility for the documentation <code>filegroup</code> target.   |  <code>["@//:__subpackages__"]</code> |
+| <a id="markdown_pkg-additional_doc_files"></a>additional_doc_files |  Optional. Additional files that should be included in the documentation <code>filegroup</code>.   |  <code>[]</code> |
 
 
 <a id="#markdown_register_node_deps"></a>

--- a/examples/markdown/simple/BUILD.bazel
+++ b/examples/markdown/simple/BUILD.bazel
@@ -1,10 +1,20 @@
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+load("@cgrindel_bazel_starlib//markdown:defs.bzl", "markdown_pkg")
 
 filegroup(
     name = "doc_files",
     srcs = glob(["*.md"]),
     visibility = ["//tests:__subpackages__"],
 )
+
+markdown_pkg(
+    name = "markdown",
+)
+
+# MARK: - Settings Needed to Address CI Execution on MacOS
+
+# NOTE: You should not need to implement these targets to use the markdown
+# rules and macros.
 
 string_flag(
     name = "execution_env",

--- a/examples/markdown/simple/BUILD.bazel
+++ b/examples/markdown/simple/BUILD.bazel
@@ -1,14 +1,9 @@
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@cgrindel_bazel_starlib//markdown:defs.bzl", "markdown_pkg")
 
-filegroup(
-    name = "doc_files",
-    srcs = glob(["*.md"]),
-    visibility = ["//tests:__subpackages__"],
-)
-
 markdown_pkg(
     name = "markdown",
+    doc_files_visibility = ["//tests:__subpackages__"],
 )
 
 # MARK: - Settings Needed to Address CI Execution on MacOS

--- a/examples/markdown/simple/README.md
+++ b/examples/markdown/simple/README.md
@@ -10,3 +10,28 @@ tests to work properly.
 - [External Link](https://bazel.build/)
 - [Internal Link, same package](/foo.md)
 - [Link to bar package](/bar/)
+
+
+## Table of Contents
+
+The following TOC is maintained by a
+[`markdown_generate_toc`](https://github.com/cgrindel/bazel-starlib/blob/main/doc/markdown/rules_and_macros_overview.md#markdown_generate_toc)
+rule that is defined by a
+[`markdown_pkg`](https://github.com/cgrindel/bazel-starlib/blob/main/doc/markdown/rules_and_macros_overview.md#markdown_pkg).
+
+<!-- MARKDOWN TOC: BEGIN -->
+* [Foo](#foo)
+  * [Foo Subtitle](#foo-subtitle)
+* [Bar](#bar)
+<!-- MARKDOWN TOC: END -->
+
+## Foo
+
+This section talks about foo.
+
+### Foo Subtitle
+
+This section talks about something specific to foo.
+
+## Bar
+

--- a/examples/markdown/simple/WORKSPACE
+++ b/examples/markdown/simple/WORKSPACE
@@ -20,3 +20,17 @@ build_bazel_rules_nodejs_dependencies()
 load("@cgrindel_bazel_starlib//markdown:defs.bzl", "markdown_register_node_deps")
 
 markdown_register_node_deps()
+
+# MARK: - Markdown TOC Deps
+
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+load("@cgrindel_bazel_starlib//markdown:deps.bzl", "bazel_starlib_markdown_dependencies")
+
+bazel_starlib_markdown_dependencies()
+
+go_rules_dependencies()
+
+go_register_toolchains(version = "1.17.6")
+
+gazelle_dependencies()

--- a/examples/markdown/simple/bar/BUILD.bazel
+++ b/examples/markdown/simple/bar/BUILD.bazel
@@ -1,14 +1,10 @@
 load("@cgrindel_bazel_starlib//markdown:defs.bzl", "markdown_pkg")
 
-filegroup(
-    name = "doc_files",
-    srcs = glob(["*.md"]) + [
+markdown_pkg(
+    name = "markdown",
+    additional_doc_files = [
         # The README.md in this package contains a link to hello.sh.
         "hello.sh",
     ],
-    visibility = ["//tests:__subpackages__"],
-)
-
-markdown_pkg(
-    name = "markdown",
+    doc_files_visibility = ["//tests:__subpackages__"],
 )

--- a/examples/markdown/simple/bar/BUILD.bazel
+++ b/examples/markdown/simple/bar/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@cgrindel_bazel_starlib//markdown:defs.bzl", "markdown_pkg")
+
 filegroup(
     name = "doc_files",
     srcs = glob(["*.md"]) + [
@@ -5,4 +7,8 @@ filegroup(
         "hello.sh",
     ],
     visibility = ["//tests:__subpackages__"],
+)
+
+markdown_pkg(
+    name = "markdown",
 )

--- a/examples/markdown/simple/tests/BUILD.bazel
+++ b/examples/markdown/simple/tests/BUILD.bazel
@@ -3,8 +3,8 @@ load("@cgrindel_bazel_starlib//markdown:defs.bzl", "markdown_check_links_test")
 filegroup(
     name = "all_doc_files",
     srcs = [
-        "//:doc_files",
-        "//bar:doc_files",
+        "//:markdown_doc_files",
+        "//bar:markdown_doc_files",
     ],
 )
 

--- a/markdown/defs.bzl
+++ b/markdown/defs.bzl
@@ -10,18 +10,13 @@ load(
     "//markdown/private:markdown_generate_toc.bzl",
     _markdown_generate_toc = "markdown_generate_toc",
 )
-
-# GH086: Finish markdown_pkg  and markdown_generate_toc implementation.
-
-# load(
-#     "//markdown/private:markdown_pkg.bzl",
-#     _markdown_pkg = "markdown_pkg",
-# )
+load(
+    "//markdown/private:markdown_pkg.bzl",
+    _markdown_pkg = "markdown_pkg",
+)
 
 markdown_check_links_test = _markdown_check_links_test
 markdown_register_node_deps = _markdown_register_node_deps
 
 markdown_generate_toc = _markdown_generate_toc
-
-# GH086: Finish markdown_pkg  and markdown_generate_toc implementation.
-# markdown_pkg = _markdown_pkg
+markdown_pkg = _markdown_pkg

--- a/markdown/private/markdown_pkg.bzl
+++ b/markdown/private/markdown_pkg.bzl
@@ -11,6 +11,31 @@ def markdown_pkg(
         define_doc_files = True,
         doc_files_visibility = ["@//:__subpackages__"],
         additional_doc_files = []):
+    """Adds targets to maintain markdown files in the package.
+
+    This macro adds targets to generate a table of contents (TOC) for markdown \
+    files (`markdown_generate_toc`), adds `diff_test` targets to confirm that \
+    the markdown files are up-to-date with the latest TOC, adds a target to \
+    update the markdown files with the generated files (`updatesrc_update`) \
+    and defines a `filegroup` that is useful to collecting documentation files \
+    for confirming that a markdown files links are valid \
+    (`markdown_check_links_test`)
+
+    Args:
+        name: A prefix `string` that will be added to all of the targets
+              defined by this macro.
+        srcs: Optional. The markdown sources to be used by the macro. If none
+              are specified, all of the `.md` and `.markdown` files are used.
+        toc_visibility: Optional. The visibility for the TOC generation targets.
+        update_visibility: Optional. The visibility for the update target.
+        define_doc_files: Optional. A `bool` that specifies whether to define a
+                          `filegroup` that can be used for documentation
+                          validity tests.
+        doc_files_visibility: Optional. The visibility for the documentation
+                              `filegroup` target.
+        additional_doc_files: Optional. Additional files that should be
+                              included in the documentation `filegroup`.
+    """
     if srcs == None:
         srcs = native.glob(["*.md", "*.markdown"])
 

--- a/markdown/private/markdown_pkg.bzl
+++ b/markdown/private/markdown_pkg.bzl
@@ -2,7 +2,6 @@ load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load("//bzllib:defs.bzl", "src_utils")
 load("//updatesrc:defs.bzl", "updatesrc_update")
 load(":markdown_generate_toc.bzl", "markdown_generate_toc")
-load(":markdown_check_links_test.bzl", "markdown_check_links_test")
 
 def markdown_pkg(
         name = "markdown",
@@ -37,9 +36,4 @@ def markdown_pkg(
         name = name + "_update",
         deps = toc_names,
         visibility = update_visibility,
-    )
-
-    markdown_check_links_test(
-        name = name + "_check_links",
-        srcs = srcs,
     )

--- a/markdown/private/markdown_pkg.bzl
+++ b/markdown/private/markdown_pkg.bzl
@@ -2,38 +2,44 @@ load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load("//bzllib:defs.bzl", "src_utils")
 load("//updatesrc:defs.bzl", "updatesrc_update")
 load(":markdown_generate_toc.bzl", "markdown_generate_toc")
+load(":markdown_check_links_test.bzl", "markdown_check_links_test")
 
-# GH086: Finish markdown_pkg implementation.
+def markdown_pkg(
+        name = "markdown",
+        srcs = None,
+        toc_visibility = None,
+        update_visibility = None):
+    if srcs == None:
+        srcs = native.glob(["*.md", "*.markdown"])
 
-# def markdown_pkg(name = "markdown", srcs = None, toc_visibility = None, update_visibility = None):
-#     if srcs == None:
-#         srcs = native.glob(["*.md", "*.markdown"])
+    # Only process paths; ignore labels
+    src_paths = [src for src in srcs if src_utils.is_path(src)]
 
-#     # Only process paths; ignore labels
-#     src_paths = [src for src in srcs if src_utils.is_path(src)]
+    name_prefix = name + "_"
+    toc_names = []
+    for src in src_paths:
+        src_name = src_utils.path_to_name(src)
+        toc_name = name_prefix + src_name + "_toc"
+        toc_names.append(toc_name)
 
-#     name_prefix = name + "_"
-#     toc_names = []
-#     for src in src_paths:
-#         src_name = src_utils.path_to_name(src)
-#         toc_name = name_prefix + src_name + "_toc"
-#         toc_names.append(toc_name)
-#         # toc_names.append(":" + toc_name)
+        markdown_generate_toc(
+            name = toc_name,
+            srcs = [src],
+            visibility = toc_visibility,
+        )
+        diff_test(
+            name = name_prefix + src_name + "_toctest",
+            file1 = src,
+            file2 = toc_name,
+        )
 
-#         markdown_generate_toc(
-#             name = toc_name,
-#             srcs = [src],
-#             visibility = toc_visibility,
-#         )
-#         diff_test(
-#             name = name_prefix + src_name + "_fmttest",
-#             file1 = src,
-#             # file2 = ":" + toc_name,
-#             file2 = toc_name,
-#         )
+    updatesrc_update(
+        name = name + "_update",
+        deps = toc_names,
+        visibility = update_visibility,
+    )
 
-#     updatesrc_update(
-#         name = name + "_update",
-#         deps = toc_names,
-#         visibility = update_visibility,
-#     )
+    markdown_check_links_test(
+        name = name + "_check_links",
+        srcs = srcs,
+    )

--- a/markdown/private/markdown_pkg.bzl
+++ b/markdown/private/markdown_pkg.bzl
@@ -7,13 +7,17 @@ def markdown_pkg(
         name = "markdown",
         srcs = None,
         toc_visibility = None,
-        update_visibility = None):
+        update_visibility = None,
+        define_doc_files = True,
+        doc_files_visibility = ["@//:__subpackages__"],
+        additional_doc_files = []):
     if srcs == None:
         srcs = native.glob(["*.md", "*.markdown"])
 
     # Only process paths; ignore labels
     src_paths = [src for src in srcs if src_utils.is_path(src)]
 
+    # Add targets to maintain the TOC
     name_prefix = name + "_"
     toc_names = []
     for src in src_paths:
@@ -37,3 +41,10 @@ def markdown_pkg(
         deps = toc_names,
         visibility = update_visibility,
     )
+
+    if define_doc_files:
+        native.filegroup(
+            name = name + "_doc_files",
+            srcs = srcs + additional_doc_files,
+            visibility = doc_files_visibility,
+        )

--- a/tests/markdown_tests/BUILD.bazel
+++ b/tests/markdown_tests/BUILD.bazel
@@ -12,7 +12,6 @@ markdown_pkg(
 build_test(
     name = "markdown_pkg_expansion_test",
     targets = [
-        ":markdown_check_links",
         ":markdown_links_md_toc",
         ":markdown_links_md_toctest",
         ":markdown_test_md_toc",

--- a/tests/markdown_tests/BUILD.bazel
+++ b/tests/markdown_tests/BUILD.bazel
@@ -1,14 +1,22 @@
 load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
-load("//markdown:defs.bzl", "markdown_check_links_test")
+load("//markdown:defs.bzl", "markdown_check_links_test", "markdown_pkg")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
 bzlformat_pkg(name = "bzlformat")
 
-filegroup(
-    name = "markdown_files",
-    srcs = glob(["*.md"]),
+markdown_pkg(
+    name = "markdown",
 )
 
-markdown_check_links_test(
-    name = "check_links_test",
-    data = [":markdown_files"],
+# Confirm that these targets are created by markdown_pkg and build.
+build_test(
+    name = "markdown_pkg_expansion_test",
+    targets = [
+        ":markdown_check_links",
+        ":markdown_links_md_toc",
+        ":markdown_links_md_toctest",
+        ":markdown_test_md_toc",
+        ":markdown_test_md_toctest",
+        ":markdown_update",
+    ],
 )

--- a/tests/repo_markdown_tests/BUILD.bazel
+++ b/tests/repo_markdown_tests/BUILD.bazel
@@ -6,7 +6,7 @@ bzlformat_pkg(name = "bzlformat")
 filegroup(
     name = "all_doc_files",
     srcs = [
-        "//:doc_files",
+        "//:markdown_doc_files",
         "//bazeldoc:doc_files",
         "//bzlformat:doc_files",
         "//bzllib:doc_files",


### PR DESCRIPTION
Closes #86.

- Implemented `markdown_pkg` macro to define targets for TOC generation, a `diff_test` to confirm that the markdown files are up-to-date, an update target to copy the generated files to the source directory, and a `filegroup` that is useful for collecting files for link check tests.
- Updated the `examples/markdown/simple` example to use `markdown_pkg`.
- Updated the root of the parent workspace to use `markdown_pkg`.