### PR TITLE
Updated `bzlformat_format` to support fixing lint warnings when possible.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,12 +1,12 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(
     "//bzlformat:defs.bzl",
     "bzlformat_missing_pkgs",
     "bzlformat_pkg",
 )
-load("//updatesrc:defs.bzl", "updatesrc_update_all")
-load("//tests:integration_test_common.bzl", "GH_ENV_INHERIT", "INTEGRATION_TEST_TAGS")
-load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("//markdown:defs.bzl", "markdown_pkg")
+load("//tests:integration_test_common.bzl", "INTEGRATION_TEST_TAGS")
+load("//updatesrc:defs.bzl", "updatesrc_update_all")
 
 bzlformat_pkg(name = "bzlformat")
 

--- a/bazeldoc/BUILD.bazel
+++ b/bazeldoc/BUILD.bazel
@@ -1,5 +1,5 @@
-load("//bzlformat:defs.bzl", "bzlformat_pkg")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/bazeldoc/defs.bzl
+++ b/bazeldoc/defs.bzl
@@ -1,7 +1,7 @@
 load("//bazeldoc/private:doc_for_provs.bzl", _doc_for_provs = "doc_for_provs")
-load("//bazeldoc/private:write_header.bzl", _write_header = "write_header")
 load("//bazeldoc/private:providers.bzl", _providers = "providers")
 load("//bazeldoc/private:write_file_list.bzl", _write_file_list = "write_file_list")
+load("//bazeldoc/private:write_header.bzl", _write_header = "write_header")
 
 # Rules and Macros
 doc_for_provs = _doc_for_provs

--- a/bazeldoc/private/BUILD.bazel
+++ b/bazeldoc/private/BUILD.bazel
@@ -1,5 +1,5 @@
-load("//bzlformat:defs.bzl", "bzlformat_pkg")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 package(default_visibility = ["//bazeldoc:__subpackages__"])
 

--- a/bazeldoc/private/doc_for_provs.bzl
+++ b/bazeldoc/private/doc_for_provs.bzl
@@ -1,5 +1,5 @@
-load(":stardoc_for_prov.bzl", "stardoc_for_provs")
 load("//updatesrc:defs.bzl", "updatesrc_diff_and_update")
+load(":stardoc_for_prov.bzl", "stardoc_for_provs")
 
 def doc_for_provs(doc_provs):
     """Defines targets for generating documentation, testing that the generated doc matches the workspace directory, and copying the generated doc to the workspace directory.

--- a/bazeldoc/private/write_file_list.bzl
+++ b/bazeldoc/private/write_file_list.bzl
@@ -1,5 +1,5 @@
-load(":write_doc.bzl", "write_doc")
 load(":doc_utilities.bzl", "doc_utilities")
+load(":write_doc.bzl", "write_doc")
 
 def write_file_list(
         name,

--- a/bazeldoc/private/write_header.bzl
+++ b/bazeldoc/private/write_header.bzl
@@ -1,5 +1,5 @@
-load(":write_doc.bzl", "write_doc")
 load(":doc_utilities.bzl", "doc_utilities")
+load(":write_doc.bzl", "write_doc")
 
 def write_header(
         name,

--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 
 bzlformat_pkg(name = "bzlformat")
 

--- a/bzlformat/defs.bzl
+++ b/bzlformat/defs.bzl
@@ -3,12 +3,12 @@ load(
     _bzlformat_format = "bzlformat_format",
 )
 load(
-    "//bzlformat/private:bzlformat_pkg.bzl",
-    _bzlformat_pkg = "bzlformat_pkg",
-)
-load(
     "//bzlformat/private:bzlformat_missing_pkgs.bzl",
     _bzlformat_missing_pkgs = "bzlformat_missing_pkgs",
+)
+load(
+    "//bzlformat/private:bzlformat_pkg.bzl",
+    _bzlformat_pkg = "bzlformat_pkg",
 )
 
 bzlformat_format = _bzlformat_format

--- a/bzlformat/private/bzlformat_format.bzl
+++ b/bzlformat/private/bzlformat_format.bzl
@@ -7,10 +7,11 @@ def _bzlformat_format_impl(ctx):
         updsrcs.append(update_srcs.create(src = src, out = out))
 
         args = ctx.actions.args()
-        args.add_all([
-            src,
-            out,
-        ])
+        lint_mode = "fix" if ctx.attr.fix_lint_warnings else "off"
+        args.add_all(["--lint_mode", lint_mode])
+        args.add_all(["--warnings", ctx.attr.warnings])
+        args.add_all([src, out])
+
         ctx.actions.run(
             outputs = [out],
             inputs = [src],
@@ -26,14 +27,22 @@ def _bzlformat_format_impl(ctx):
 bzlformat_format = rule(
     implementation = _bzlformat_format_impl,
     attrs = {
+        "fix_lint_warnings": attr.bool(
+            default = True,
+            doc = "Should lint warnings be fixed, if possible.",
+        ),
+        "output_suffix": attr.string(
+            default = ".formatted",
+            doc = "The suffix added to the formatted output filename.",
+        ),
         "srcs": attr.label_list(
             allow_files = True,
             mandatory = True,
             doc = "The Starlark source files to format.",
         ),
-        "output_suffix": attr.string(
-            default = ".formatted",
-            doc = "The suffix added to the formatted output filename.",
+        "warnings": attr.string(
+            doc = "The warnings that should be fixed if lint fix is enabled.",
+            default = "all",
         ),
         "_buildifier": attr.label(
             default = "//bzlformat/tools:buildifier",

--- a/bzlformat/private/bzlformat_pkg.bzl
+++ b/bzlformat/private/bzlformat_pkg.bzl
@@ -1,7 +1,7 @@
-load(":bzlformat_format.bzl", "bzlformat_format")
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load("//bzllib/rules:defs.bzl", "src_utils")
 load("//updatesrc:defs.bzl", "updatesrc_update")
+load(":bzlformat_format.bzl", "bzlformat_format")
 
 def bzlformat_pkg(name = "bzlformat", srcs = None, format_visibility = None, update_visibility = None):
     """Defines targets that format, test, and update the specified Starlark source files.

--- a/bzlformat/tools/BUILD.bazel
+++ b/bzlformat/tools/BUILD.bazel
@@ -7,7 +7,11 @@ sh_binary(
     srcs = ["buildifier.sh"],
     data = ["@bazel_starlib_buildtools//:buildifier"],
     visibility = ["//visibility:public"],
-    deps = ["@bazel_tools//tools/bash/runfiles"],
+    deps = [
+        "//shlib/lib:arrays",
+        "//shlib/lib:fail",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
 )
 
 bzlformat_pkg(name = "bzlformat")

--- a/bzlformat/tools/buildifier.sh
+++ b/bzlformat/tools/buildifier.sh
@@ -101,17 +101,17 @@ exec_buildifier() {
 
 cat_cmd=( cat "${bzl_path}" ) 
 
-lint_cmd=( exec_buildifier "${bzl_path}" "--warnings=${warnings}" )
+buildifier_cmd=( exec_buildifier "${bzl_path}" "--warnings=${warnings}" )
 case "${lint_mode}" in
   "fix")
-    lint_cmd+=( "--lint=fix" )
+    buildifier_cmd+=( "--lint=fix" )
     ;;
   "warn")
-    lint_cmd+=( "--lint=warn" )
+    buildifier_cmd+=( "--lint=warn" )
     ;;
   "off")
-    lint_cmd+=( "--lint=off" )
+    buildifier_cmd+=( "--lint=off" )
     ;;
 esac
 
-"${cat_cmd[@]}" | "${lint_cmd[@]}" > "${out_path}"
+"${cat_cmd[@]}" | "${buildifier_cmd[@]}" > "${out_path}"

--- a/bzlformat/tools/buildifier.sh
+++ b/bzlformat/tools/buildifier.sh
@@ -39,19 +39,19 @@ lint_mode="off"
 
 warnings="all"
 
-# TODO: Update usage.
-
 get_usage() {
   local utility="$(basename "${BASH_SOURCE[0]}")"
   echo "$(cat <<-EOF
-One line description of the utility.
+Executes buildifier for a Starlark file and writes the resulting output to a file.
 
 Usage:
-${utility} --flag <flag_value> [OPTION]... <arg0>
+${utility} [OPTION]... <input> <output>
 
 Options:
-  --flag <flag_value>  Describe flag
-  <arg0>               Describe arg0
+  --lint_mode <lint_mode>  The buildifier lint mode: $( join_by ", " "${lint_modes[@]}" ) (default: ${lint_mode})
+  --warnings <warnings>    A comma-separated warnings used in the lint mode or "all" (default: ${warnings})
+  <input>                  A path to a Starlark file
+  <output>                 A path where to write the output from buildifier
 EOF
   )"
 }

--- a/bzlformat/tools/buildifier.sh
+++ b/bzlformat/tools/buildifier.sh
@@ -11,11 +11,94 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
+# MARK - Locate Deps
+
+fail_sh_location=cgrindel_bazel_starlib/shlib/lib/fail.sh
+fail_sh="$(rlocation "${fail_sh_location}")" || \
+  (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
+source "${fail_sh}"
+
+arrays_sh_location=cgrindel_bazel_starlib/shlib/lib/arrays.sh
+arrays_sh="$(rlocation "${arrays_sh_location}")" || \
+  (echo >&2 "Failed to locate ${arrays_sh_location}" && exit 1)
+source "${arrays_sh}"
+
 buildifier_location=bazel_starlib_buildtools/buildifier
 buildifier="$(rlocation "${buildifier_location}")" || \
   (echo >&2 "Failed to locate ${buildifier_location}" && exit 1)
 
-bzl_path="${1}"
-out_path="${2}"
+
+# MARK - Process Args
+
+# Format Mode
+# off - Do not format
+# fix - Format the file.
+format_modes=( off fix )
+format_mode="fix"
+
+# Lint Mode
+# off - Do not lint
+# warn - Report lint issues.
+# fix = Attempt to fix lint issues.
+lint_modes=( off warn fix )
+lint_mode="off"
+
+fail_on_lint_warnings=true
+
+# TODO: Update usage.
+
+get_usage() {
+  local utility="$(basename "${BASH_SOURCE[0]}")"
+  echo "$(cat <<-EOF
+One line description of the utility.
+
+Usage:
+${utility} --flag <flag_value> [OPTION]... <arg0>
+
+Options:
+  --flag <flag_value>  Describe flag
+  <arg0>               Describe arg0
+EOF
+  )"
+}
+
+
+args=()
+while (("$#")); do
+  case "${1}" in
+    "--help")
+      show_usage
+      exit 0
+      ;;
+    "--format_mode")
+      format_mode="${2}"
+      shift 2
+      ;;
+    "--lint_mode")
+      lint_mode="${2}"
+      shift 2
+      ;;
+    "--no_fail_on_lint_warnings")
+      fail_on_lint_warnings=false
+      shift 1
+      ;;
+    *)
+      args+=("${1}")
+      shift 1
+      ;;
+  esac
+done
+
+[[ ${#args[@]} < 2 ]] && usage_error "Expected an input path and an output path."
+bzl_path="${args[0]}"
+out_path="${args[1]}"
+
+contains_item "${format_mode}" "${format_modes[@]}" || \
+  usage_error "Invalid format_mode (${format_mode}). Expected to be one of the following: $( join_by ", " "${format_modes[@]}" )."
+contains_item "${lint_mode}" "${lint_modes[@]}" || \
+  usage_error "Invalid lint_mode (${lint_mode}). Expected to be one of the following: $( join_by ", " "${lint_modes[@]}" )."
+
+
+# MARK - Execute Buildifier
 
 cat "${bzl_path}" | "${buildifier}" "--path=${bzl_path}" > "${out_path}"

--- a/bzlformat/tools/buildifier.sh
+++ b/bzlformat/tools/buildifier.sh
@@ -30,12 +30,6 @@ buildifier="$(rlocation "${buildifier_location}")" || \
 
 # MARK - Process Args
 
-# # Format Mode
-# # off - Do not format
-# # fix - Format the file.
-# format_modes=( off fix )
-# format_mode="fix"
-
 # Lint Mode
 # off - Do not lint
 # warn - Report lint issues.
@@ -70,10 +64,6 @@ while (("$#")); do
       show_usage
       exit 0
       ;;
-    # "--format_mode")
-    #   format_mode="${2}"
-    #   shift 2
-    #   ;;
     "--lint_mode")
       lint_mode="${2}"
       shift 2
@@ -100,16 +90,11 @@ done
 bzl_path="${args[0]}"
 out_path="${args[1]}"
 
-# contains_item "${format_mode}" "${format_modes[@]}" || \
-#   usage_error "Invalid format_mode (${format_mode}). Expected to be one of the following: $( join_by ", " "${format_modes[@]}" )."
-
 contains_item "${lint_mode}" "${lint_modes[@]}" || \
   usage_error "Invalid lint_mode (${lint_mode}). Expected to be one of the following: $( join_by ", " "${lint_modes[@]}" )."
 
 
 # MARK - Execute Buildifier
-
-# cat "${bzl_path}" | "${buildifier}" "--path=${bzl_path}" > "${out_path}"
 
 exec_buildifier() {
   local bzl_path="${1}"
@@ -120,11 +105,6 @@ exec_buildifier() {
 }
 
 cat_cmd=( cat "${bzl_path}" ) 
-
-# format_cmd=()
-# if [[ "${format_mode}" == fix ]]; then
-#   format_cmd+=( exec_buildifier "${bzl_path}" )
-# fi
 
 lint_cmd=( exec_buildifier "${bzl_path}" "--warnings=${warnings}" )
 case "${lint_mode}" in
@@ -139,28 +119,4 @@ case "${lint_mode}" in
     ;;
 esac
 
-
 "${cat_cmd[@]}" | "${lint_cmd[@]}" > "${out_path}"
-
-
-# if [[ ${#format_cmd[@]} > 0 && ${#lint_cmd[@]} > 0 ]]; then
-#   # DEBUG BEGIN
-#   echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") FORMAT AND LINT" 
-#   # DEBUG END
-#   "${cat_cmd[@]}" | "${format_cmd[@]}" | "${lint_cmd[@]}" > "${out_path}"
-# elif [[ ${#format_cmd[@]} > 0 ]]; then
-#   # DEBUG BEGIN
-#   echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") FORMAT ONLY" 
-#   # DEBUG END
-#   "${cat_cmd[@]}" | "${format_cmd[@]}" > "${out_path}"
-# elif [[ ${#lint_cmd[@]} > 0 ]]; then
-#   # DEBUG BEGIN
-#   echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") LINT ONLY" 
-#   # DEBUG END
-#   "${cat_cmd[@]}" | "${lint_cmd[@]}" > "${out_path}"
-# else
-#   # DEBUG BEGIN
-#   echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") CAT ONLY" 
-#   # DEBUG END
-#   "${cat_cmd[@]}" > "${out_path}"
-# fi

--- a/bzlformat/tools/buildifier.sh
+++ b/bzlformat/tools/buildifier.sh
@@ -38,7 +38,6 @@ lint_modes=( off warn fix )
 lint_mode="off"
 
 warnings="all"
-fail_on_lint_warnings=true
 
 # TODO: Update usage.
 
@@ -71,10 +70,6 @@ while (("$#")); do
     "--warnings")
       warnings="${2}"
       shift 2
-      ;;
-    "--no_fail_on_lint_warnings")
-      fail_on_lint_warnings=false
-      shift 1
       ;;
     --*)
       usage_error "Unexpected option. ${1}"

--- a/bzllib/rules/BUILD.bazel
+++ b/bzllib/rules/BUILD.bazel
@@ -1,5 +1,5 @@
-load("//bzlformat:defs.bzl", "bzlformat_pkg")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 bzlformat_pkg(name = "bzlformat")
 

--- a/bzllib/rules/defs.bzl
+++ b/bzllib/rules/defs.bzl
@@ -1,5 +1,5 @@
-load("//bzllib/rules/private:src_utils.bzl", _src_utils = "src_utils")
 load("//bzllib/rules/private:filter_srcs.bzl", _filter_srcs = "filter_srcs")
+load("//bzllib/rules/private:src_utils.bzl", _src_utils = "src_utils")
 
 src_utils = _src_utils
 

--- a/bzllib/rules/private/BUILD.bazel
+++ b/bzllib/rules/private/BUILD.bazel
@@ -1,5 +1,5 @@
-load("//bzlformat:defs.bzl", "bzlformat_pkg")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 package(default_visibility = ["//bzllib:__subpackages__"])
 

--- a/bzllib/rules/private/filter_srcs.bzl
+++ b/bzllib/rules/private/filter_srcs.bzl
@@ -23,17 +23,17 @@ def _filter_srcs_impl(ctx):
 filter_srcs = rule(
     implementation = _filter_srcs_impl,
     attrs = {
-        "srcs": attr.label_list(
-            allow_files = True,
-            mandatory = True,
-            doc = "The inputs that will be evaluated by the filter.",
+        "expected_count": attr.int(
+            default = -1,
+            doc = "The expected number of results.",
         ),
         "filename_ends_with": attr.string(
             doc = "The suffix of the path will be compared to this value.",
         ),
-        "expected_count": attr.int(
-            default = -1,
-            doc = "The expected number of results.",
+        "srcs": attr.label_list(
+            allow_files = True,
+            mandatory = True,
+            doc = "The inputs that will be evaluated by the filter.",
         ),
     },
     doc = "Filters the provided inputs using the specified criteria.",

--- a/bzlrelease/BUILD.bazel
+++ b/bzlrelease/BUILD.bazel
@@ -1,5 +1,5 @@
-load("//bzlformat:defs.bzl", "bzlformat_pkg")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/bzlrelease/defs.bzl
+++ b/bzlrelease/defs.bzl
@@ -1,4 +1,8 @@
 load(
+    "//bzlrelease/private:create_release.bzl",
+    _create_release = "create_release",
+)
+load(
     "//bzlrelease/private:generate_release_notes.bzl",
     _generate_release_notes = "generate_release_notes",
 )
@@ -10,10 +14,6 @@ load("//bzlrelease/private:hash_sha256.bzl", _hash_sha256 = "hash_sha256")
 load(
     "//bzlrelease/private:update_readme.bzl",
     _update_readme = "update_readme",
-)
-load(
-    "//bzlrelease/private:create_release.bzl",
-    _create_release = "create_release",
 )
 
 create_release = _create_release

--- a/bzlrelease/private/BUILD.bazel
+++ b/bzlrelease/private/BUILD.bazel
@@ -1,5 +1,5 @@
-load("//bzlformat:defs.bzl", "bzlformat_pkg")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 bzlformat_pkg(name = "bzlformat")
 

--- a/deps.bzl
+++ b/deps.bzl
@@ -69,19 +69,19 @@ sh_binary(
 bazel_starlib_buildtools = repository_rule(
     implementation = _bazel_starlib_buildtools,
     attrs = {
-        "buildifier_target": attr.string(
-            mandatory = True,
-            doc = "The `buildifier` target.",
-        ),
         "buildifier_location": attr.string(
             mandatory = True,
             doc = "The `buildifier` location in runfiles.",
         ),
-        "buildozer_target": attr.string(
+        "buildifier_target": attr.string(
+            mandatory = True,
+            doc = "The `buildifier` target.",
+        ),
+        "buildozer_location": attr.string(
             mandatory = True,
             doc = "The `buildozer` target.",
         ),
-        "buildozer_location": attr.string(
+        "buildozer_target": attr.string(
             mandatory = True,
             doc = "The `buildozer` target.",
         ),

--- a/doc/bazeldoc/BUILD.bazel
+++ b/doc/bazeldoc/BUILD.bazel
@@ -1,4 +1,3 @@
-load("//bzlformat:defs.bzl", "bzlformat_pkg")
 load(
     "//bazeldoc:defs.bzl",
     "doc_for_provs",
@@ -6,6 +5,7 @@ load(
     "write_header",
     doc_providers = "providers",
 )
+load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 bzlformat_pkg(name = "bzlformat")
 

--- a/doc/bzlformat/BUILD.bazel
+++ b/doc/bzlformat/BUILD.bazel
@@ -1,11 +1,10 @@
-load("//bzlformat:defs.bzl", "bzlformat_pkg")
 load(
     "//bazeldoc:defs.bzl",
     "doc_for_provs",
-    "write_file_list",
     "write_header",
     doc_providers = "providers",
 )
+load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 bzlformat_pkg(name = "bzlformat")
 

--- a/doc/bzlformat/rules_and_macros_overview.md
+++ b/doc/bzlformat/rules_and_macros_overview.md
@@ -16,7 +16,7 @@ On this page:
 ## bzlformat_format
 
 <pre>
-bzlformat_format(<a href="#bzlformat_format-name">name</a>, <a href="#bzlformat_format-output_suffix">output_suffix</a>, <a href="#bzlformat_format-srcs">srcs</a>)
+bzlformat_format(<a href="#bzlformat_format-name">name</a>, <a href="#bzlformat_format-fix_lint_warnings">fix_lint_warnings</a>, <a href="#bzlformat_format-output_suffix">output_suffix</a>, <a href="#bzlformat_format-srcs">srcs</a>, <a href="#bzlformat_format-warnings">warnings</a>)
 </pre>
 
 Formats Starlark source files using Buildifier.
@@ -27,8 +27,10 @@ Formats Starlark source files using Buildifier.
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="bzlformat_format-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| <a id="bzlformat_format-fix_lint_warnings"></a>fix_lint_warnings |  Should lint warnings be fixed, if possible.   | Boolean | optional | True |
 | <a id="bzlformat_format-output_suffix"></a>output_suffix |  The suffix added to the formatted output filename.   | String | optional | ".formatted" |
 | <a id="bzlformat_format-srcs"></a>srcs |  The Starlark source files to format.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
+| <a id="bzlformat_format-warnings"></a>warnings |  The warnings that should be fixed if lint fix is enabled.   | String | optional | "all" |
 
 
 <a id="#bzlformat_missing_pkgs"></a>

--- a/doc/bzllib/BUILD.bazel
+++ b/doc/bzllib/BUILD.bazel
@@ -1,4 +1,3 @@
-load("//bzlformat:defs.bzl", "bzlformat_pkg")
 load(
     "//bazeldoc:defs.bzl",
     "doc_for_provs",
@@ -6,6 +5,7 @@ load(
     "write_header",
     doc_providers = "providers",
 )
+load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 bzlformat_pkg(name = "bzlformat")
 

--- a/doc/bzlrelease/BUILD.bazel
+++ b/doc/bzlrelease/BUILD.bazel
@@ -1,4 +1,3 @@
-load("//bzlformat:defs.bzl", "bzlformat_pkg")
 load(
     "//bazeldoc:defs.bzl",
     "doc_for_provs",
@@ -6,6 +5,7 @@ load(
     "write_header",
     doc_providers = "providers",
 )
+load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 bzlformat_pkg(name = "bzlformat")
 

--- a/doc/markdown/BUILD.bazel
+++ b/doc/markdown/BUILD.bazel
@@ -1,11 +1,10 @@
-load("//bzlformat:defs.bzl", "bzlformat_pkg")
 load(
     "//bazeldoc:defs.bzl",
     "doc_for_provs",
-    "write_file_list",
     "write_header",
     doc_providers = "providers",
 )
+load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 bzlformat_pkg(name = "bzlformat")
 

--- a/doc/shlib/BUILD.bazel
+++ b/doc/shlib/BUILD.bazel
@@ -1,4 +1,3 @@
-load("//bzlformat:defs.bzl", "bzlformat_pkg")
 load(
     "//bazeldoc:defs.bzl",
     "doc_for_provs",
@@ -6,6 +5,7 @@ load(
     "write_header",
     doc_providers = "providers",
 )
+load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 bzlformat_pkg(name = "bzlformat")
 

--- a/doc/updatesrc/BUILD.bazel
+++ b/doc/updatesrc/BUILD.bazel
@@ -1,4 +1,3 @@
-load("//bzlformat:defs.bzl", "bzlformat_pkg")
 load(
     "//bazeldoc:defs.bzl",
     "doc_for_provs",
@@ -6,6 +5,7 @@ load(
     "write_header",
     doc_providers = "providers",
 )
+load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 bzlformat_pkg(name = "bzlformat")
 

--- a/examples/bzlformat/BUILD.bazel
+++ b/examples/bzlformat/BUILD.bazel
@@ -1,4 +1,3 @@
-load("//bzlformat:defs.bzl", "bzlformat_pkg")
 load(
     "@cgrindel_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
     "bazel_integration_test",
@@ -7,6 +6,7 @@ load(
     "integration_test_utils",
 )
 load("//:bazel_versions.bzl", "CURRENT_BAZEL_VERSION", "SUPPORTED_BAZEL_VERSIONS")
+load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 bzlformat_pkg(name = "bzlformat")
 

--- a/examples/bzlformat/build_buildtools/BUILD.bazel
+++ b/examples/bzlformat/build_buildtools/BUILD.bazel
@@ -1,11 +1,11 @@
 load(
-    "@cgrindel_bazel_starlib//updatesrc:defs.bzl",
-    "updatesrc_update_all",
-)
-load(
     "@cgrindel_bazel_starlib//bzlformat:defs.bzl",
     "bzlformat_missing_pkgs",
     "bzlformat_pkg",
+)
+load(
+    "@cgrindel_bazel_starlib//updatesrc:defs.bzl",
+    "updatesrc_update_all",
 )
 
 # Ensures that the Starlark files in this package are formatted properly.

--- a/examples/bzlformat/simple/BUILD.bazel
+++ b/examples/bzlformat/simple/BUILD.bazel
@@ -1,11 +1,11 @@
 load(
-    "@cgrindel_bazel_starlib//updatesrc:defs.bzl",
-    "updatesrc_update_all",
-)
-load(
     "@cgrindel_bazel_starlib//bzlformat:defs.bzl",
     "bzlformat_missing_pkgs",
     "bzlformat_pkg",
+)
+load(
+    "@cgrindel_bazel_starlib//updatesrc:defs.bzl",
+    "updatesrc_update_all",
 )
 
 # Ensures that the Starlark files in this package are formatted properly.

--- a/examples/markdown/BUILD.bazel
+++ b/examples/markdown/BUILD.bazel
@@ -1,12 +1,11 @@
 load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//shlib/rules:execute_binary.bzl", "execute_binary")
 load(
     "@cgrindel_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
     "bazel_integration_tests",
-    "default_test_runner",
     "integration_test_utils",
 )
 load("//:bazel_versions.bzl", "SUPPORTED_BAZEL_VERSIONS")
-load("@cgrindel_bazel_starlib//shlib/rules:execute_binary.bzl", "execute_binary")
 
 bzlformat_pkg(name = "bzlformat")
 

--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -1,5 +1,5 @@
-load("//bzlformat:defs.bzl", "bzlformat_pkg")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 bzlformat_pkg(name = "bzlformat")
 

--- a/markdown/defs.bzl
+++ b/markdown/defs.bzl
@@ -3,16 +3,16 @@ load(
     _markdown_check_links_test = "markdown_check_links_test",
 )
 load(
-    "//markdown/private:markdown_register_node_deps.bzl",
-    _markdown_register_node_deps = "markdown_register_node_deps",
-)
-load(
     "//markdown/private:markdown_generate_toc.bzl",
     _markdown_generate_toc = "markdown_generate_toc",
 )
 load(
     "//markdown/private:markdown_pkg.bzl",
     _markdown_pkg = "markdown_pkg",
+)
+load(
+    "//markdown/private:markdown_register_node_deps.bzl",
+    _markdown_register_node_deps = "markdown_register_node_deps",
 )
 
 markdown_check_links_test = _markdown_check_links_test

--- a/markdown/private/markdown_check_links_test.bzl
+++ b/markdown/private/markdown_check_links_test.bzl
@@ -1,4 +1,3 @@
-load("//bzllib/rules:defs.bzl", "src_utils")
 load("@bazel_skylib//lib:shell.bzl", "shell")
 
 def _markdown_check_links_test_impl(ctx):
@@ -77,13 +76,6 @@ markdown_check_links_test = rule(
     implementation = _markdown_check_links_test_impl,
     test = True,
     attrs = {
-        "srcs": attr.label_list(
-            allow_files = [".md", ".markdown"],
-            doc = """\
-The markdown files that should be checked. If no srcs are provided, all of \
-the markdown files (.md, .markdown) in the `data` will be checked.\
-""",
-        ),
         "config": attr.label(
             allow_single_file = True,
             doc = "A `markdown-link-check` JSON configuration file.",
@@ -95,10 +87,9 @@ the markdown files (.md, .markdown) in the `data` will be checked.\
 Any data files that need to be present for the link check to succeed.\
 """,
         ),
-        "verbose": attr.bool(
-            doc = """\
-If set to true, the markdown-link-check will be configured for verbose output.\
-""",
+        "max_econnreset_retry_count": attr.int(
+            default = 3,
+            doc = "The maximum number of times to retry on an ECONNRESET error.",
         ),
         "quiet": attr.bool(
             default = True,
@@ -107,9 +98,17 @@ If set to true, the markdown-link-check will be configured to only display \
 errors.\
 """,
         ),
-        "max_econnreset_retry_count": attr.int(
-            default = 3,
-            doc = "The maximum number of times to retry on an ECONNRESET error.",
+        "srcs": attr.label_list(
+            allow_files = [".md", ".markdown"],
+            doc = """\
+The markdown files that should be checked. If no srcs are provided, all of \
+the markdown files (.md, .markdown) in the `data` will be checked.\
+""",
+        ),
+        "verbose": attr.bool(
+            doc = """\
+If set to true, the markdown-link-check will be configured for verbose output.\
+""",
         ),
         "_link_checker": attr.label(
             default = "@cgrindel_bazel_starlib//markdown/tools:check_links",

--- a/markdown/private/markdown_generate_toc.bzl
+++ b/markdown/private/markdown_generate_toc.bzl
@@ -34,12 +34,9 @@ def _markdown_generate_toc_impl(ctx):
 markdown_generate_toc = rule(
     implementation = _markdown_generate_toc_impl,
     attrs = {
-        "srcs": attr.label_list(
-            mandatory = True,
-            allow_files = [".md", ".markdown"],
-            doc = """\
-The markdown files that will be updated with a table of contents.\
-""",
+        "output_suffix": attr.string(
+            default = ".toc_updated",
+            doc = "The suffix added to the output file with the updated TOC.",
         ),
         "remove_toc_header_entry": attr.bool(
             default = True,
@@ -47,13 +44,16 @@ The markdown files that will be updated with a table of contents.\
 Specifies whether the header for the TOC should be removed from the TOC.\
 """,
         ),
+        "srcs": attr.label_list(
+            mandatory = True,
+            allow_files = [".md", ".markdown"],
+            doc = """\
+The markdown files that will be updated with a table of contents.\
+""",
+        ),
         "toc_header": attr.string(
             default = "Table of Contents",
             doc = "The header that leads the TOC.",
-        ),
-        "output_suffix": attr.string(
-            default = ".toc_updated",
-            doc = "The suffix added to the output file with the updated TOC.",
         ),
         "_toc_generator": attr.label(
             default = "@cgrindel_bazel_starlib//markdown/tools:update_markdown_toc",

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -6,7 +6,6 @@ load(
     "generate_workspace_snippet",
     "update_readme",
 )
-load("//shlib/rules:execute_binary.bzl", "execute_binary", "file_placeholder")
 
 bzlformat_pkg(name = "bzlformat")
 

--- a/shlib/rules/BUILD.bazel
+++ b/shlib/rules/BUILD.bazel
@@ -1,5 +1,5 @@
-load("//bzlformat:defs.bzl", "bzlformat_pkg")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/shlib/rules/private/BUILD.bazel
+++ b/shlib/rules/private/BUILD.bazel
@@ -1,5 +1,5 @@
-load("//bzlformat:defs.bzl", "bzlformat_pkg")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 package(default_visibility = ["//shlib/rules:__pkg__"])
 

--- a/shlib/rules/private/execute_binary.bzl
+++ b/shlib/rules/private/execute_binary.bzl
@@ -104,12 +104,6 @@ cmd=( "${binary}" )
 execute_binary = rule(
     implementation = _execute_binary_impl,
     attrs = {
-        "binary": attr.label(
-            executable = True,
-            mandatory = True,
-            cfg = "target",
-            doc = "The binary to be executed.",
-        ),
         "arguments": attr.string_list(
             doc = """\
 The list of arguments that will be embedded into the resulting executable. 
@@ -117,6 +111,12 @@ The list of arguments that will be embedded into the resulting executable.
 NOTE: Use this attribute instead of `args`. The `args` attribute is not \
 processed for file arguments and is not preserved in the resulting script. 
 """,
+        ),
+        "binary": attr.label(
+            executable = True,
+            mandatory = True,
+            cfg = "target",
+            doc = "The binary to be executed.",
         ),
         "data": attr.label_list(
             allow_files = True,

--- a/tests/bzlformat_tests/tools_tests/BUILD.bazel
+++ b/tests/bzlformat_tests/tools_tests/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
+
+bzlformat_pkg(name = "bzlformat")
+
+sh_test(
+    name = "buildifier_test",
+    srcs = ["buildifier_test.sh"],
+    data = [
+        "//bzlformat/tools:buildifier",
+    ],
+    deps = [
+        "@bazel_tools//tools/bash/runfiles",
+        "@cgrindel_bazel_starlib//shlib/lib:assertions",
+    ],
+)

--- a/tests/bzlformat_tests/tools_tests/buildifier_test.sh
+++ b/tests/bzlformat_tests/tools_tests/buildifier_test.sh
@@ -158,5 +158,7 @@ actual="$(< "${out_path}")"
 assert_equal "${expected}" "${actual}" "Format and lint (warn) with good file."
 
 
+# MARK - Test Help
 
-
+output="$( "${buildifier_sh}" --help )"
+assert_match "Executes buildifier for a Starlark file" "${output}" "Confirm help output."

--- a/tests/bzlformat_tests/tools_tests/buildifier_test.sh
+++ b/tests/bzlformat_tests/tools_tests/buildifier_test.sh
@@ -29,16 +29,33 @@ buildifier_sh="$(rlocation "${buildifier_sh_location}")" || \
 out_path=result.bzl
 bzl_path=foo.bzl
 
+# MARK - Test With Defaults (format: fix, lint: off)
+
+# TODO: Add unsorted load statement
+
+cat >"${bzl_path}" <<-'EOF'
+FOO_LIST = [
+"first",
+"second"
+]
+EOF
+
+expected="$(cat <<-'EOF'
+FOO_LIST = [
+    "first",
+    "second",
+]
+EOF
+)"
+
+"${buildifier_sh}" "${bzl_path}" "${out_path}"
+actual="$(< "${out_path}")"
+assert_equal "${expected}" "${actual}" "With defaults"
+
 
 # MARK - Test Format
 
-# bzl_content="$(cat <<-'EOF'
-# FOO_LIST = [
-# "first",
-# "second"
-# ]
-# EOF
-# )"
+# TODO: Add unsorted load statement
 
 cat >"${bzl_path}" <<-'EOF'
 FOO_LIST = [

--- a/tests/bzlformat_tests/tools_tests/buildifier_test.sh
+++ b/tests/bzlformat_tests/tools_tests/buildifier_test.sh
@@ -11,6 +11,7 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
+
 # MARK - Locate Deps
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
@@ -18,7 +19,47 @@ assertions_sh="$(rlocation "${assertions_sh_location}")" || \
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 source "${assertions_sh}"
 
-# MARK - Test
+buildifier_sh_location=cgrindel_bazel_starlib/bzlformat/tools/buildifier.sh
+buildifier_sh="$(rlocation "${buildifier_sh_location}")" || \
+  (echo >&2 "Failed to locate ${buildifier_sh_location}" && exit 1)
 
 
-fail "IMPLEMENT ME!"
+# MARK - Constants
+
+out_path=result.bzl
+bzl_path=foo.bzl
+
+
+# MARK - Test Format
+
+# bzl_content="$(cat <<-'EOF'
+# FOO_LIST = [
+# "first",
+# "second"
+# ]
+# EOF
+# )"
+
+cat >"${bzl_path}" <<-'EOF'
+FOO_LIST = [
+"first",
+"second"
+]
+EOF
+
+expected="$(cat <<-'EOF'
+FOO_LIST = [
+    "first",
+    "second",
+]
+EOF
+)"
+
+"${buildifier_sh}" --format_mode fix --lint_mode off "${bzl_path}" "${out_path}"
+actual="$(< "${out_path}")"
+assert_equal "${expected}" "${actual}" "Format fix, lint off."
+
+
+# DEBUG BEGIN
+fail "STOP"
+# DEBUG END

--- a/tests/bzlformat_tests/tools_tests/buildifier_test.sh
+++ b/tests/bzlformat_tests/tools_tests/buildifier_test.sh
@@ -160,6 +160,3 @@ assert_equal "${expected}" "${actual}" "Format and lint (warn) with good file."
 
 
 
-# DEBUG BEGIN
-fail "STOP"
-# DEBUG END

--- a/tests/bzlformat_tests/tools_tests/buildifier_test.sh
+++ b/tests/bzlformat_tests/tools_tests/buildifier_test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+# MARK - Locate Deps
+
+assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
+assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+  (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
+source "${assertions_sh}"
+
+# MARK - Test
+
+
+fail "IMPLEMENT ME!"

--- a/tests/bzlformat_tests/tools_tests/buildifier_test.sh
+++ b/tests/bzlformat_tests/tools_tests/buildifier_test.sh
@@ -29,18 +29,23 @@ buildifier_sh="$(rlocation "${buildifier_sh_location}")" || \
 out_path=result.bzl
 bzl_path=foo.bzl
 
-# MARK - Test With Defaults (format: fix, lint: off)
-
-# TODO: Add unsorted load statement
-
 cat >"${bzl_path}" <<-'EOF'
+load("@zzz//:deps.bzl", "go_rules_dependencies")
+load("@aaaa//:deps.bzl", "gazelle_dependencies")
+
 FOO_LIST = [
 "first",
 "second"
 ]
 EOF
 
+
+# MARK - Test With Defaults (format: fix, lint: off)
+
 expected="$(cat <<-'EOF'
+load("@zzz//:deps.bzl", "go_rules_dependencies")
+load("@aaaa//:deps.bzl", "gazelle_dependencies")
+
 FOO_LIST = [
     "first",
     "second",
@@ -55,16 +60,10 @@ assert_equal "${expected}" "${actual}" "With defaults"
 
 # MARK - Test Format
 
-# TODO: Add unsorted load statement
-
-cat >"${bzl_path}" <<-'EOF'
-FOO_LIST = [
-"first",
-"second"
-]
-EOF
-
 expected="$(cat <<-'EOF'
+load("@zzz//:deps.bzl", "go_rules_dependencies")
+load("@aaaa//:deps.bzl", "gazelle_dependencies")
+
 FOO_LIST = [
     "first",
     "second",

--- a/tests/bzlformat_tests/tools_tests/missing_pkgs_tests/BUILD.bazel
+++ b/tests/bzlformat_tests/tools_tests/missing_pkgs_tests/BUILD.bazel
@@ -1,10 +1,10 @@
-load("//bzlformat:defs.bzl", "bzlformat_pkg")
 load(
     "@cgrindel_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
     "bazel_integration_tests",
     "integration_test_utils",
 )
 load("//:bazel_versions.bzl", "SUPPORTED_BAZEL_VERSIONS")
+load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 bzlformat_pkg(name = "bzlformat")
 

--- a/tests/bzllib_tests/rules_tests/BUILD.bazel
+++ b/tests/bzllib_tests/rules_tests/BUILD.bazel
@@ -1,6 +1,6 @@
 load("//bzlformat:defs.bzl", "bzlformat_pkg")
-load(":src_utils_tests.bzl", "src_utils_test_suite")
 load(":filter_srcs_tests.bzl", "filter_srcs_test_suite")
+load(":src_utils_tests.bzl", "src_utils_test_suite")
 
 bzlformat_pkg(name = "bzlformat")
 

--- a/tests/bzlrelease_tests/BUILD.bazel
+++ b/tests/bzlrelease_tests/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//bzlformat:defs.bzl", "bzlformat_pkg")
-load("//tests:integration_test_common.bzl", "GH_ENV_INHERIT", "INTEGRATION_TEST_TAGS")
+load("//tests:integration_test_common.bzl", "INTEGRATION_TEST_TAGS")
 
 bzlformat_pkg(name = "bzlformat")
 

--- a/tests/bzlrelease_tests/rules_tests/hash_sha256_tests/BUILD.bazel
+++ b/tests/bzlrelease_tests/rules_tests/hash_sha256_tests/BUILD.bazel
@@ -1,6 +1,6 @@
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("//bzlformat:defs.bzl", "bzlformat_pkg")
 load("//bzlrelease:defs.bzl", "hash_sha256")
-load("@bazel_skylib//rules:write_file.bzl", "write_file")
 
 bzlformat_pkg(name = "bzlformat")
 

--- a/tests/markdown_tests/BUILD.bazel
+++ b/tests/markdown_tests/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
-load("//markdown:defs.bzl", "markdown_check_links_test", "markdown_pkg")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
+load("//markdown:defs.bzl", "markdown_pkg")
 
 bzlformat_pkg(name = "bzlformat")
 

--- a/tests/markdown_tests/markdown_generate_toc_tests/BUILD.bazel
+++ b/tests/markdown_tests/markdown_generate_toc_tests/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load("//markdown:defs.bzl", "markdown_generate_toc")
 
 bzlformat_pkg(name = "bzlformat")

--- a/tests/shlib_tests/rules_tests/binary_pkg_tests/BUILD.bazel
+++ b/tests/shlib_tests/rules_tests/binary_pkg_tests/BUILD.bazel
@@ -1,5 +1,5 @@
-load("//bzlformat:defs.bzl", "bzlformat_pkg")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("//bzlformat:defs.bzl", "bzlformat_pkg")
 load("//shlib/rules:binary_pkg.bzl", "binary_pkg")
 load("//shlib/rules:execute_binary.bzl", "execute_binary", "file_placeholder")
 

--- a/tests/shlib_tests/rules_tests/execute_binary_tests/BUILD.bazel
+++ b/tests/shlib_tests/rules_tests/execute_binary_tests/BUILD.bazel
@@ -1,6 +1,6 @@
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("//bzlformat:defs.bzl", "bzlformat_pkg")
 load("//shlib/rules:execute_binary.bzl", "execute_binary", "file_placeholder")
-load("@bazel_skylib//rules:write_file.bzl", "write_file")
 
 bzlformat_pkg(name = "bzlformat")
 

--- a/tests/toolchains_tests/lib_tests/assets_tests.bzl
+++ b/tests/toolchains_tests/lib_tests/assets_tests.bzl
@@ -1,5 +1,5 @@
-load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("@bazel_skylib//lib:new_sets.bzl", "sets")
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//toolchains/lib:assets.bzl", "assets")
 
 def _create_asset_test(ctx):
@@ -164,10 +164,10 @@ def _create_assets_test(ctx):
         names = ["buildifier", "buildozer"],
         sha256_values = {
             "buildifier_darwin_amd64": "954ec397089344b1564e45dc095e9331e121eb0f20e72032fcc8e94de78e5663",
-            "buildozer_darwin_amd64": "edcabae1d97bdc42559d7d1d65dfe7f8970db8d95d4bc9e7bf6656a9f2fb5592",
             "buildifier_darwin_arm64": "9434043897a3c3821fda87046918e5a6c4320d8352df700f62046744c4d168a3",
-            "buildozer_darwin_arm64": "f8d0994620dec1247328f13db1d434b6489dd007f8e9b961dbd9363bc6fe7071",
             "buildifier_linux_amd64": "a19126536bae9a3917a7fc4bdbbf0378371a1d1683ab2415857cf53bce9dee49",
+            "buildozer_darwin_amd64": "edcabae1d97bdc42559d7d1d65dfe7f8970db8d95d4bc9e7bf6656a9f2fb5592",
+            "buildozer_darwin_arm64": "f8d0994620dec1247328f13db1d434b6489dd007f8e9b961dbd9363bc6fe7071",
             "buildozer_linux_amd64": "6b4177321b770fb788b618caa453d34561b8c05081ae8b27657e527c2a3b5d52",
         },
     )

--- a/tests/updatesrc_tests/BUILD.bazel
+++ b/tests/updatesrc_tests/BUILD.bazel
@@ -1,4 +1,3 @@
-load("//bzlformat:defs.bzl", "bzlformat_pkg")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load(
     "@cgrindel_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
@@ -7,6 +6,7 @@ load(
     "integration_test_utils",
 )
 load("//:bazel_versions.bzl", "SUPPORTED_BAZEL_VERSIONS")
+load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 bzlformat_pkg(name = "bzlformat")
 

--- a/toolchains/lib/BUILD.bazel
+++ b/toolchains/lib/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 
 bzlformat_pkg(name = "bzlformat")
 

--- a/toolchains/lib/assets.bzl
+++ b/toolchains/lib/assets.bzl
@@ -1,5 +1,4 @@
 load("@bazel_skylib//lib:types.bzl", "types")
-load("@bazel_skylib//lib:new_sets.bzl", "sets")
 
 _TYPICAL_PLATFORMS = ["darwin", "linux"]
 _TYPICAL_ARCHES = ["amd64", "arm64"]

--- a/toolchains/lib/assets.bzl
+++ b/toolchains/lib/assets.bzl
@@ -1,5 +1,5 @@
-load("@bazel_skylib//lib:new_sets.bzl", "sets")
 load("@bazel_skylib//lib:types.bzl", "types")
+load("@bazel_skylib//lib:new_sets.bzl", "sets")
 
 _TYPICAL_PLATFORMS = ["darwin", "linux"]
 _TYPICAL_ARCHES = ["amd64", "arm64"]

--- a/updatesrc/BUILD.bazel
+++ b/updatesrc/BUILD.bazel
@@ -1,5 +1,5 @@
-load("//bzlformat:defs.bzl", "bzlformat_pkg")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/updatesrc/defs.bzl
+++ b/updatesrc/defs.bzl
@@ -3,20 +3,20 @@ load(
     _UpdateSrcsInfo = "UpdateSrcsInfo",
 )
 load(
-    "//updatesrc/private:updatesrc_update.bzl",
-    _updatesrc_update = "updatesrc_update",
-)
-load(
-    "//updatesrc/private:updatesrc_update_all.bzl",
-    _updatesrc_update_all = "updatesrc_update_all",
-)
-load(
     "//updatesrc/private:update_srcs.bzl",
     _update_srcs = "update_srcs",
 )
 load(
     "//updatesrc/private:updatesrc_diff_and_update.bzl",
     _updatesrc_diff_and_update = "updatesrc_diff_and_update",
+)
+load(
+    "//updatesrc/private:updatesrc_update.bzl",
+    _updatesrc_update = "updatesrc_update",
+)
+load(
+    "//updatesrc/private:updatesrc_update_all.bzl",
+    _updatesrc_update_all = "updatesrc_update_all",
 )
 
 # Providers

--- a/updatesrc/private/BUILD.bazel
+++ b/updatesrc/private/BUILD.bazel
@@ -1,5 +1,5 @@
-load("//bzlformat:defs.bzl", "bzlformat_pkg")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 package(default_visibility = ["//updatesrc:__subpackages__"])
 

--- a/updatesrc/private/updatesrc_diff_and_update.bzl
+++ b/updatesrc/private/updatesrc_diff_and_update.bzl
@@ -1,5 +1,5 @@
-load(":updatesrc_update.bzl", "updatesrc_update")
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+load(":updatesrc_update.bzl", "updatesrc_update")
 
 def updatesrc_diff_and_update(
         srcs,

--- a/updatesrc/private/updatesrc_update.bzl
+++ b/updatesrc/private/updatesrc_update.bzl
@@ -63,13 +63,9 @@ fi
 updatesrc_update = rule(
     implementation = _updatesrc_update_impl,
     attrs = {
-        "srcs": attr.label_list(
-            doc = """\
-Source files that will be updated by the files listed in the `outs` attribute. \
-Every file listed in the `srcs` attribute must have a corresponding output \
-file listed in the `outs` attribute.\
-""",
-            allow_files = True,
+        "deps": attr.label_list(
+            providers = [[UpdateSrcsInfo]],
+            doc = "Build targets that output `UpdateSrcsInfo`.",
         ),
         "outs": attr.label_list(
             doc = """\
@@ -79,9 +75,13 @@ source file list in the `srcs` attribute.\
 """,
             allow_files = True,
         ),
-        "deps": attr.label_list(
-            providers = [[UpdateSrcsInfo]],
-            doc = "Build targets that output `UpdateSrcsInfo`.",
+        "srcs": attr.label_list(
+            doc = """\
+Source files that will be updated by the files listed in the `outs` attribute. \
+Every file listed in the `srcs` attribute must have a corresponding output \
+file listed in the `outs` attribute.\
+""",
+            allow_files = True,
         ),
     },
     executable = True,

--- a/updatesrc/private/updatesrc_update_test.bzl
+++ b/updatesrc/private/updatesrc_update_test.bzl
@@ -73,18 +73,18 @@ assert_same() {
 updatesrc_update_test = rule(
     implementation = _updatesrc_update_test_impl,
     attrs = {
-        "update_target": attr.label(
-            allow_single_file = True,
-            executable = True,
-            cfg = "host",
+        "outs": attr.label_list(
+            allow_files = True,
+            mandatory = True,
         ),
         "srcs": attr.label_list(
             allow_files = True,
             mandatory = True,
         ),
-        "outs": attr.label_list(
-            allow_files = True,
-            mandatory = True,
+        "update_target": attr.label(
+            allow_single_file = True,
+            executable = True,
+            cfg = "host",
         ),
     },
     test = True,


### PR DESCRIPTION
Related to #126.

- Updated `buildifier.sh` to support lint options and to pass those to `buildifier`.
- Updated `bzlformat_format` to include lint-related attributes.
- Updated code in the repository with lint fixes applied by `bzlformat_format`.