### PR TITLE
Implemented `bzlformat_lint_test` to lint Bazel Starlark files using `buildifier`.

### DIFF
--- a/bazel_versions.bzl
+++ b/bazel_versions.bzl
@@ -1,3 +1,5 @@
+"""Bazel Version Declarations"""
+
 CURRENT_BAZEL_VERSION = "5.0.0"
 
 OTHER_BAZEL_VERSIONS = [

--- a/bazeldoc/defs.bzl
+++ b/bazeldoc/defs.bzl
@@ -1,3 +1,5 @@
+"""Public API for bazeldoc."""
+
 load("//bazeldoc/private:doc_for_provs.bzl", _doc_for_provs = "doc_for_provs")
 load("//bazeldoc/private:providers.bzl", _providers = "providers")
 load("//bazeldoc/private:write_file_list.bzl", _write_file_list = "write_file_list")

--- a/bazeldoc/private/doc_for_provs.bzl
+++ b/bazeldoc/private/doc_for_provs.bzl
@@ -1,3 +1,5 @@
+"""Definition for doc_for_provs macro."""
+
 load("//updatesrc:defs.bzl", "updatesrc_diff_and_update")
 load(":stardoc_for_prov.bzl", "stardoc_for_provs")
 

--- a/bazeldoc/private/stardoc_for_prov.bzl
+++ b/bazeldoc/private/stardoc_for_prov.bzl
@@ -1,3 +1,5 @@
+"""Defintion for stardoc_for_prov and stardoc_for_provs macros."""
+
 load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
 
 def stardoc_for_prov(doc_prov):
@@ -24,14 +26,9 @@ def stardoc_for_provs(doc_provs):
     Args:
         doc_provs: A `list` of document provider `struct` values as returned
                    from `providers.create()`.
-
-    Returns:
-        None.
     """
-    [
-        stardoc_for_prov(
-            doc_prov = doc_prov,
-        )
-        for doc_prov in doc_provs
-        if doc_prov.is_stardoc
-    ]
+    for doc_prov in doc_provs:
+        if doc_prov.is_stardoc:
+            stardoc_for_prov(
+                doc_prov = doc_prov,
+            )

--- a/bazeldoc/private/write_doc.bzl
+++ b/bazeldoc/private/write_doc.bzl
@@ -1,3 +1,5 @@
+"""Definition for write_doc macro."""
+
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 
 def write_doc(name, out, content = [], do_not_edit_warning = True):

--- a/bazeldoc/private/write_file_list.bzl
+++ b/bazeldoc/private/write_file_list.bzl
@@ -1,3 +1,5 @@
+"""Definition for write_file_list macro."""
+
 load(":doc_utilities.bzl", "doc_utilities")
 load(":write_doc.bzl", "write_doc")
 

--- a/bazeldoc/private/write_header.bzl
+++ b/bazeldoc/private/write_header.bzl
@@ -1,3 +1,5 @@
+"""Definition for write_header macro."""
+
 load(":doc_utilities.bzl", "doc_utilities")
 load(":write_doc.bzl", "write_doc")
 

--- a/bzlformat/BUILD.bazel
+++ b/bzlformat/BUILD.bazel
@@ -16,6 +16,7 @@ bzl_library(
     srcs = ["defs.bzl"],
     deps = [
         "//bzlformat/private:bzlformat_format",
+        "//bzlformat/private:bzlformat_lint_test",
         "//bzlformat/private:bzlformat_missing_pkgs",
         "//bzlformat/private:bzlformat_pkg",
     ],

--- a/bzlformat/defs.bzl
+++ b/bzlformat/defs.bzl
@@ -3,6 +3,10 @@ load(
     _bzlformat_format = "bzlformat_format",
 )
 load(
+    "//bzlformat/private:bzlformat_lint_test.bzl",
+    _bzlformat_lint_test = "bzlformat_lint_test",
+)
+load(
     "//bzlformat/private:bzlformat_missing_pkgs.bzl",
     _bzlformat_missing_pkgs = "bzlformat_missing_pkgs",
 )
@@ -14,3 +18,4 @@ load(
 bzlformat_format = _bzlformat_format
 bzlformat_pkg = _bzlformat_pkg
 bzlformat_missing_pkgs = _bzlformat_missing_pkgs
+bzlformat_lint_test = _bzlformat_lint_test

--- a/bzlformat/defs.bzl
+++ b/bzlformat/defs.bzl
@@ -1,3 +1,5 @@
+"""Public API for bzlformat"""
+
 load(
     "//bzlformat/private:bzlformat_format.bzl",
     _bzlformat_format = "bzlformat_format",

--- a/bzlformat/private/BUILD.bazel
+++ b/bzlformat/private/BUILD.bazel
@@ -3,7 +3,7 @@ load(":bzlformat_pkg.bzl", "bzlformat_pkg")
 
 package(default_visibility = ["//bzlformat:__subpackages__"])
 
-bzlformat_pkg(name = "bzlformat")
+bzlformat_pkg(name = "bzlformat_no_conflict")
 
 bzl_library(
     name = "bzlformat_format",

--- a/bzlformat/private/BUILD.bazel
+++ b/bzlformat/private/BUILD.bazel
@@ -32,6 +32,15 @@ bzl_library(
     ],
 )
 
+bzl_library(
+    name = "bzlformat_lint_test",
+    srcs = ["bzlformat_lint_test.bzl"],
+    deps = [
+        "//shlib/rules:execute_binary",
+        "@bazel_skylib//lib:shell",
+    ],
+)
+
 # MARK: - Collect Files for Integation Tests
 
 filegroup(

--- a/bzlformat/private/bzlformat_format.bzl
+++ b/bzlformat/private/bzlformat_format.bzl
@@ -1,3 +1,5 @@
+"""Definition for bzlformat_format rule"""
+
 load("//updatesrc:defs.bzl", "UpdateSrcsInfo", "update_srcs")
 
 def _bzlformat_format_impl(ctx):

--- a/bzlformat/private/bzlformat_lint_test.bzl
+++ b/bzlformat/private/bzlformat_lint_test.bzl
@@ -1,9 +1,74 @@
-# TODO: FINISH ME!
+load("@bazel_skylib//lib:shell.bzl", "shell")
+load("//shlib/rules:execute_binary.bzl", "execute_binary_utils")
 
 def _bzlformat_lint_test_impl(ctx):
-    # for src in ctx.files.srcs:
-    #     write_execute_binary_action(ctx.actions, exec_binary_out, )
-    pass
+    bin_path = ctx.executable._buildifier.short_path
+    common_arguments = ["--lint_mode", "warn", "--warnings", ctx.attr.warnings]
+
+    # Generate the lint tests
+    lint_tests = []
+    for src in ctx.files.srcs:
+        exec_binary_out = ctx.actions.declare_file(ctx.label.name + "_" + src.basename + ".sh")
+        lint_tests.append(exec_binary_out)
+        arguments = common_arguments + [src.short_path]
+        execute_binary_utils.write_execute_binary_script(
+            write_file = ctx.actions.write,
+            out = exec_binary_out,
+            bin_path = bin_path,
+            arguments = arguments,
+            workspace_name = ctx.workspace_name,
+        )
+    lint_test_names = [lt.short_path for lt in lint_tests]
+
+    # Write a script that executes all of the lint tests
+    out = ctx.actions.declare_file(ctx.label.name + ".sh")
+    ctx.actions.write(
+        output = out,
+        is_executable = True,
+        content = """\
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+""" + """\
+lint_tests={lint_tests}
+""".format(lint_tests = shell.array_literal(lint_test_names)) + """\
+
+# # DEBUG BEGIN
+# echo >&2 "*** CHUCK  lint_tests:"
+# for (( i = 0; i < ${#lint_tests[@]}; i++ )); do
+#   echo >&2 "*** CHUCK   ${i}: ${lint_tests[${i}]}"
+# done
+# tree >&2
+# # DEBUG END
+
+failure_count=0
+for lint_test in "${lint_tests[@]}"; do
+    exit_code=0
+    # "${lint_test}" || (exit_code=$? ; failure_count=$(( ${failure_count} + 1 )) ; echo "${lint_test} failed with ${exit_code}." )
+    # "${lint_test}" || failure_count=$(( ${failure_count} + 1 ))
+    "${lint_test}" || exit_code=$?
+    [[ ${exit_code} != 0 ]] && failure_count=$(( ${failure_count} + 1 )) ; echo >&2 "${lint_test} failed with ${exit_code}."
+done
+
+# DEBUG BEGIN
+# echo >&2 "STOP" ; exit 1
+# DEBUG END
+
+[[ ${failure_count} > 0 ]] && echo >&2 "${failure_count} lint tests failed." && exit 1
+echo "All tests succeeded!"
+""",
+    )
+
+    # Gather the runfiles
+    runfiles = ctx.runfiles(files = ctx.files.srcs + lint_tests)
+    runfiles = execute_binary_utils.collect_runfiles(
+        runfiles,
+        [ctx.attr._buildifier],
+    )
+
+    # Return the DefaultInfo
+    return DefaultInfo(executable = out, runfiles = runfiles)
 
 bzlformat_lint_test = rule(
     implementation = _bzlformat_lint_test_impl,

--- a/bzlformat/private/bzlformat_lint_test.bzl
+++ b/bzlformat/private/bzlformat_lint_test.bzl
@@ -1,0 +1,36 @@
+# TODO: FINISH ME!
+
+def _bzlformat_lint_test_impl(ctx):
+    # for src in ctx.files.srcs:
+    #     write_execute_binary_action(ctx.actions, exec_binary_out, )
+    pass
+
+bzlformat_lint_test = rule(
+    implementation = _bzlformat_lint_test_impl,
+    test = True,
+    attrs = {
+        "srcs": attr.label_list(
+            allow_files = True,
+            mandatory = True,
+            doc = "The Starlark source files to lint.",
+        ),
+        "warnings": attr.string(
+            doc = "The warnings that should be fixed if lint fix is enabled.",
+            default = "all",
+        ),
+        "_buildifier": attr.label(
+            default = "//bzlformat/tools:buildifier",
+            executable = True,
+            cfg = "host",
+            allow_files = True,
+            doc = "The `buildifier` script that executes the formatting.",
+        ),
+    },
+    doc = "Lints the specified Starlark files using Buildifier.",
+)
+
+# def bzlformat_lint_test(name, srcs, warnings = None):
+#     for src in srcs:
+#         exec_buildifier_name =
+#         execute_binary(
+#         )

--- a/bzlformat/private/bzlformat_lint_test.bzl
+++ b/bzlformat/private/bzlformat_lint_test.bzl
@@ -1,3 +1,5 @@
+"""Definition for bzlformat_lint_test rule."""
+
 load("@bazel_skylib//lib:shell.bzl", "shell")
 load("//shlib/rules:execute_binary.bzl", "execute_binary_utils")
 
@@ -38,7 +40,10 @@ failure_count=0
 for lint_test in "${lint_tests[@]}"; do
     exit_code=0
     "${lint_test}" || exit_code=$?
-    [[ ${exit_code} != 0 ]] && failure_count=$(( ${failure_count} + 1 )) ; echo >&2 "${lint_test} failed with ${exit_code}."
+    if [[ ${exit_code} != 0 ]]; then
+      failure_count=$(( ${failure_count} + 1 )) 
+      echo >&2 "${lint_test} failed with ${exit_code}."
+    fi
 done
 
 [[ ${failure_count} > 0 ]] && echo >&2 "${failure_count} lint tests failed." && exit 1

--- a/bzlformat/private/bzlformat_lint_test.bzl
+++ b/bzlformat/private/bzlformat_lint_test.bzl
@@ -36,6 +36,10 @@ set -euo pipefail
 lint_tests={lint_tests}
 """.format(lint_tests = shell.array_literal(lint_test_names)) + """\
 
+# Buildifier tries to find the workspace root. Since we are running in a
+# sandbox, we need to provide a WORKSPACE file for it to find.
+[[ ! -e WORKSPACE ]] && touch WORKSPACE
+
 failure_count=0
 for lint_test in "${lint_tests[@]}"; do
     exit_code=0

--- a/bzlformat/private/bzlformat_lint_test.bzl
+++ b/bzlformat/private/bzlformat_lint_test.bzl
@@ -34,26 +34,12 @@ set -euo pipefail
 lint_tests={lint_tests}
 """.format(lint_tests = shell.array_literal(lint_test_names)) + """\
 
-# # DEBUG BEGIN
-# echo >&2 "*** CHUCK  lint_tests:"
-# for (( i = 0; i < ${#lint_tests[@]}; i++ )); do
-#   echo >&2 "*** CHUCK   ${i}: ${lint_tests[${i}]}"
-# done
-# tree >&2
-# # DEBUG END
-
 failure_count=0
 for lint_test in "${lint_tests[@]}"; do
     exit_code=0
-    # "${lint_test}" || (exit_code=$? ; failure_count=$(( ${failure_count} + 1 )) ; echo "${lint_test} failed with ${exit_code}." )
-    # "${lint_test}" || failure_count=$(( ${failure_count} + 1 ))
     "${lint_test}" || exit_code=$?
     [[ ${exit_code} != 0 ]] && failure_count=$(( ${failure_count} + 1 )) ; echo >&2 "${lint_test} failed with ${exit_code}."
 done
-
-# DEBUG BEGIN
-# echo >&2 "STOP" ; exit 1
-# DEBUG END
 
 [[ ${failure_count} > 0 ]] && echo >&2 "${failure_count} lint tests failed." && exit 1
 echo "All tests succeeded!"

--- a/bzlformat/private/bzlformat_lint_test.bzl
+++ b/bzlformat/private/bzlformat_lint_test.bzl
@@ -84,9 +84,3 @@ bzlformat_lint_test = rule(
     },
     doc = "Lints the specified Starlark files using Buildifier.",
 )
-
-# def bzlformat_lint_test(name, srcs, warnings = None):
-#     for src in srcs:
-#         exec_buildifier_name =
-#         execute_binary(
-#         )

--- a/bzlformat/private/bzlformat_missing_pkgs.bzl
+++ b/bzlformat/private/bzlformat_missing_pkgs.bzl
@@ -1,3 +1,5 @@
+"""Definition for bzlformat_missing_pkgs macro."""
+
 load("//shlib/rules:execute_binary.bzl", "execute_binary")
 
 def bzlformat_missing_pkgs(name, exclude = []):

--- a/bzlformat/private/bzlformat_pkg.bzl
+++ b/bzlformat/private/bzlformat_pkg.bzl
@@ -1,3 +1,5 @@
+"""Definition for bzlformat_pkg macro."""
+
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load("//bzllib/rules:defs.bzl", "src_utils")
 load("//updatesrc:defs.bzl", "updatesrc_update")
@@ -20,6 +22,8 @@ def bzlformat_pkg(
         srcs: Optional. A `list` of Starlark source files. If no value is
               provided, any files that match `*.bzl`, `BUILD` or `BUILD.bazel`
               are used.
+        lint_test: Optional. A `bool` specifying whether a lint test should be
+                             defined.
         format_visibility: Optional. A `list` of Bazel visibility declarations
                            for the format targets.
         update_visibility: Optional. A `list` of Bazel visibility declarations
@@ -58,6 +62,7 @@ def bzlformat_pkg(
         bzlformat_lint_test(
             name = name + "_lint_test",
             srcs = srcs,
+            visibility = lint_test_visibility,
         )
 
     updatesrc_update(

--- a/bzlformat/private/bzlformat_pkg.bzl
+++ b/bzlformat/private/bzlformat_pkg.bzl
@@ -2,8 +2,15 @@ load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load("//bzllib/rules:defs.bzl", "src_utils")
 load("//updatesrc:defs.bzl", "updatesrc_update")
 load(":bzlformat_format.bzl", "bzlformat_format")
+load(":bzlformat_lint_test.bzl", "bzlformat_lint_test")
 
-def bzlformat_pkg(name = "bzlformat", srcs = None, format_visibility = None, update_visibility = None):
+def bzlformat_pkg(
+        name = "bzlformat",
+        srcs = None,
+        lint_test = True,
+        format_visibility = None,
+        update_visibility = None,
+        lint_test_visibility = None):
     """Defines targets that format, test, and update the specified Starlark source files.
 
     NOTE: Any labels detected in the `srcs` will be ignored.
@@ -17,6 +24,8 @@ def bzlformat_pkg(name = "bzlformat", srcs = None, format_visibility = None, upd
                            for the format targets.
         update_visibility: Optional. A `list` of Bazel visibility declarations
                            for the update target.
+        lint_test_visibility: Optional. A `list` of Bazel visibility declarations
+                              for the lint test target.
 
     Returns:
         None.
@@ -43,6 +52,12 @@ def bzlformat_pkg(name = "bzlformat", srcs = None, format_visibility = None, upd
             name = name_prefix + src_name + "_fmttest",
             file1 = src,
             file2 = ":" + format_name,
+        )
+
+    if lint_test:
+        bzlformat_lint_test(
+            name = name + "_lint_test",
+            srcs = srcs,
         )
 
     updatesrc_update(

--- a/bzlformat/tools/buildifier.sh
+++ b/bzlformat/tools/buildifier.sh
@@ -81,9 +81,9 @@ while (("$#")); do
   esac
 done
 
-[[ ${#args[@]} < 2 ]] && usage_error "Expected an input path and an output path."
+[[ ${#args[@]} < 1 ]] && usage_error "Expected a path to a Starlark file."
 bzl_path="${args[0]}"
-out_path="${args[1]}"
+[[ ${#args[@]} > 1 ]] && out_path="${args[1]}"
 
 contains_item "${lint_mode}" "${lint_modes[@]}" || \
   usage_error "Invalid lint_mode (${lint_mode}). Expected to be one of the following: $( join_by ", " "${lint_modes[@]}" )."
@@ -114,4 +114,8 @@ case "${lint_mode}" in
     ;;
 esac
 
-"${cat_cmd[@]}" | "${buildifier_cmd[@]}" > "${out_path}"
+if [[ -n "${out_path:-}" ]]; then
+  "${cat_cmd[@]}" | "${buildifier_cmd[@]}" > "${out_path}"
+else
+  "${cat_cmd[@]}" | "${buildifier_cmd[@]}" > /dev/null
+fi

--- a/bzllib/rules/BUILD.bazel
+++ b/bzllib/rules/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
-bzlformat_pkg(name = "bzlformat")
-
 package(default_visibility = ["//visibility:public"])
+
+bzlformat_pkg(name = "bzlformat")
 
 filegroup(
     name = "doc_files",

--- a/bzllib/rules/defs.bzl
+++ b/bzllib/rules/defs.bzl
@@ -1,3 +1,5 @@
+"""Public API for bzllib Rules"""
+
 load("//bzllib/rules/private:filter_srcs.bzl", _filter_srcs = "filter_srcs")
 load("//bzllib/rules/private:src_utils.bzl", _src_utils = "src_utils")
 

--- a/bzllib/rules/private/filter_srcs.bzl
+++ b/bzllib/rules/private/filter_srcs.bzl
@@ -1,3 +1,5 @@
+"""filter_srcs Rule"""
+
 def _do_filename_ends_with(ctx, files):
     suffix = ctx.attr.filename_ends_with
     return [f for f in files if f.path.endswith(suffix)]

--- a/bzllib/rules/private/src_utils.bzl
+++ b/bzllib/rules/private/src_utils.bzl
@@ -1,3 +1,5 @@
+"""Utilities for Bazel Starlark Rules and Functions"""
+
 def _is_label(src):
     """Determines whether the provided string is a label.
 
@@ -25,8 +27,10 @@ def _path_to_name(path, prefix = None, suffix = None):
 
     Args:
         path: A path as a `string`.
-        prefix: Optional. A string which will be prefixed to the namefied
+        prefix: Optional. A string which will be prefixed to the namified
                 path with an underscore separating the prefix.
+        suffix: Optional. A `string` which will be appended to the namified
+                path with an underscore separating the suffix.
 
     Returns:
         A `string` suitable for use as a label name.

--- a/bzlrelease/defs.bzl
+++ b/bzlrelease/defs.bzl
@@ -1,3 +1,5 @@
+"""Public API for bzlrelease."""
+
 load(
     "//bzlrelease/private:create_release.bzl",
     _create_release = "create_release",

--- a/bzlrelease/private/BUILD.bazel
+++ b/bzlrelease/private/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
-bzlformat_pkg(name = "bzlformat")
-
 package(default_visibility = ["//bzlrelease:__subpackages__"])
+
+bzlformat_pkg(name = "bzlformat")
 
 bzl_library(
     name = "hash_sha256",

--- a/bzlrelease/private/create_release.bzl
+++ b/bzlrelease/private/create_release.bzl
@@ -1,3 +1,5 @@
+"""Definition for create_release macro."""
+
 load("//shlib/rules:execute_binary.bzl", "execute_binary")
 
 def create_release(name, workflow_name):

--- a/bzlrelease/private/generate_release_notes.bzl
+++ b/bzlrelease/private/generate_release_notes.bzl
@@ -1,3 +1,5 @@
+"""Definition for generate_release_notes macro."""
+
 load("//shlib/rules:execute_binary.bzl", "execute_binary", "file_placeholder")
 
 def generate_release_notes(name, generate_workspace_snippet):

--- a/bzlrelease/private/generate_workspace_snippet.bzl
+++ b/bzlrelease/private/generate_workspace_snippet.bzl
@@ -1,3 +1,5 @@
+"""Definition for generate_workspace_snippet macro."""
+
 load("//shlib/rules:execute_binary.bzl", "execute_binary", "file_placeholder")
 
 def generate_workspace_snippet(name, template = None, workspace_name = None):

--- a/bzlrelease/private/hash_sha256.bzl
+++ b/bzlrelease/private/hash_sha256.bzl
@@ -1,3 +1,5 @@
+"""Definition for hash_sha256 rule."""
+
 def _hash_sha256_impl(ctx):
     out = ctx.actions.declare_file(ctx.label.name)
     args = ctx.actions.args()

--- a/bzlrelease/private/update_readme.bzl
+++ b/bzlrelease/private/update_readme.bzl
@@ -1,3 +1,5 @@
+"""Definition for update_readme macro."""
+
 load("//shlib/rules:execute_binary.bzl", "execute_binary", "file_placeholder")
 
 def update_readme(name, generate_workspace_snippet, readme = None):

--- a/deps.bzl
+++ b/deps.bzl
@@ -1,7 +1,9 @@
+"""Dependencies for bazel-starlib"""
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
-def _generate_trampoline_content(repository_ctx, filename, exec_target, exec_location):
+def _generate_trampoline_content(repository_ctx, filename, exec_location):
     content = """\
 #!/usr/bin/env bash
 
@@ -34,13 +36,11 @@ def _bazel_starlib_buildtools(repository_ctx):
     _generate_trampoline_content(
         repository_ctx,
         "buildifier.sh",
-        repository_ctx.attr.buildifier_target,
         repository_ctx.attr.buildifier_location,
     )
     _generate_trampoline_content(
         repository_ctx,
         "buildozer.sh",
-        repository_ctx.attr.buildozer_target,
         repository_ctx.attr.buildozer_location,
     )
 
@@ -89,6 +89,12 @@ bazel_starlib_buildtools = repository_rule(
 )
 
 def bazel_starlib_dependencies(use_prebuilt_buildtools = True):
+    """Declares the dependencies for bazel-starlib.
+
+    Args:
+        use_prebuilt_buildtools: A `bool` specifying whether to use a prebuilt
+                                 version of `bazelbuild/buildtools`.
+    """
     maybe(
         http_archive,
         name = "bazel_skylib",

--- a/doc/bzlformat/BUILD.bazel
+++ b/doc/bzlformat/BUILD.bazel
@@ -32,6 +32,7 @@ _RULES_AND_MACROS_DOC_PROVIDER = doc_providers.create(
         "bzlformat_format",
         "bzlformat_pkg",
         "bzlformat_missing_pkgs",
+        "bzlformat_lint_test",
     ],
     deps = _DOC_DEPS,
 )

--- a/doc/bzlformat/BUILD.bazel
+++ b/doc/bzlformat/BUILD.bazel
@@ -19,8 +19,6 @@ filegroup(
 
 # MARK: - Documentation Providers
 
-_DOC_PATH = "doc/bzlformat"
-
 _STARDOC_INPUT = "//bzlformat:defs.bzl"
 
 _DOC_DEPS = ["//bzlformat:defs"]

--- a/doc/bzlformat/rules_and_macros_overview.md
+++ b/doc/bzlformat/rules_and_macros_overview.md
@@ -97,7 +97,7 @@ None.
 ## bzlformat_pkg
 
 <pre>
-bzlformat_pkg(<a href="#bzlformat_pkg-name">name</a>, <a href="#bzlformat_pkg-srcs">srcs</a>, <a href="#bzlformat_pkg-format_visibility">format_visibility</a>, <a href="#bzlformat_pkg-update_visibility">update_visibility</a>)
+bzlformat_pkg(<a href="#bzlformat_pkg-name">name</a>, <a href="#bzlformat_pkg-srcs">srcs</a>, <a href="#bzlformat_pkg-lint_test">lint_test</a>, <a href="#bzlformat_pkg-format_visibility">format_visibility</a>, <a href="#bzlformat_pkg-update_visibility">update_visibility</a>, <a href="#bzlformat_pkg-lint_test_visibility">lint_test_visibility</a>)
 </pre>
 
 Defines targets that format, test, and update the specified Starlark source files.
@@ -112,8 +112,10 @@ NOTE: Any labels detected in the `srcs` will be ignored.
 | :------------- | :------------- | :------------- |
 | <a id="bzlformat_pkg-name"></a>name |  The prefix <code>string</code> that is used when creating the targets.   |  <code>"bzlformat"</code> |
 | <a id="bzlformat_pkg-srcs"></a>srcs |  Optional. A <code>list</code> of Starlark source files. If no value is provided, any files that match <code>*.bzl</code>, <code>BUILD</code> or <code>BUILD.bazel</code> are used.   |  <code>None</code> |
+| <a id="bzlformat_pkg-lint_test"></a>lint_test |  Optional. A <code>bool</code> specifying whether a lint test should be defined.   |  <code>True</code> |
 | <a id="bzlformat_pkg-format_visibility"></a>format_visibility |  Optional. A <code>list</code> of Bazel visibility declarations for the format targets.   |  <code>None</code> |
 | <a id="bzlformat_pkg-update_visibility"></a>update_visibility |  Optional. A <code>list</code> of Bazel visibility declarations for the update target.   |  <code>None</code> |
+| <a id="bzlformat_pkg-lint_test_visibility"></a>lint_test_visibility |  Optional. A <code>list</code> of Bazel visibility declarations for the lint test target.   |  <code>None</code> |
 
 **RETURNS**
 

--- a/doc/bzlformat/rules_and_macros_overview.md
+++ b/doc/bzlformat/rules_and_macros_overview.md
@@ -9,6 +9,7 @@ On this page:
   * [bzlformat_format](#bzlformat_format)
   * [bzlformat_pkg](#bzlformat_pkg)
   * [bzlformat_missing_pkgs](#bzlformat_missing_pkgs)
+  * [bzlformat_lint_test](#bzlformat_lint_test)
 
 
 <a id="#bzlformat_format"></a>
@@ -31,6 +32,26 @@ Formats Starlark source files using Buildifier.
 | <a id="bzlformat_format-output_suffix"></a>output_suffix |  The suffix added to the formatted output filename.   | String | optional | ".formatted" |
 | <a id="bzlformat_format-srcs"></a>srcs |  The Starlark source files to format.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
 | <a id="bzlformat_format-warnings"></a>warnings |  The warnings that should be fixed if lint fix is enabled.   | String | optional | "all" |
+
+
+<a id="#bzlformat_lint_test"></a>
+
+## bzlformat_lint_test
+
+<pre>
+bzlformat_lint_test(<a href="#bzlformat_lint_test-name">name</a>, <a href="#bzlformat_lint_test-srcs">srcs</a>, <a href="#bzlformat_lint_test-warnings">warnings</a>)
+</pre>
+
+Lints the specified Starlark files using Buildifier.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="bzlformat_lint_test-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| <a id="bzlformat_lint_test-srcs"></a>srcs |  The Starlark source files to lint.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
+| <a id="bzlformat_lint_test-warnings"></a>warnings |  The warnings that should be fixed if lint fix is enabled.   | String | optional | "all" |
 
 
 <a id="#bzlformat_missing_pkgs"></a>

--- a/doc/bzllib/BUILD.bazel
+++ b/doc/bzllib/BUILD.bazel
@@ -23,8 +23,6 @@ _DOC_DEPS = [
     "//bzllib/rules:defs",
 ]
 
-_DOC_PATH = "doc/bzllib"
-
 _RULE_NAMES = [
     "filter_srcs",
 ]

--- a/doc/bzllib/src_utils.md
+++ b/doc/bzllib/src_utils.md
@@ -62,8 +62,8 @@ Converts a path string to a name suitable for use as a label name.
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="src_utils.path_to_name-path"></a>path |  A path as a <code>string</code>.   |  none |
-| <a id="src_utils.path_to_name-prefix"></a>prefix |  Optional. A string which will be prefixed to the namefied path with an underscore separating the prefix.   |  <code>None</code> |
-| <a id="src_utils.path_to_name-suffix"></a>suffix |  <p align="center"> - </p>   |  <code>None</code> |
+| <a id="src_utils.path_to_name-prefix"></a>prefix |  Optional. A string which will be prefixed to the namified path with an underscore separating the prefix.   |  <code>None</code> |
+| <a id="src_utils.path_to_name-suffix"></a>suffix |  Optional. A <code>string</code> which will be appended to the namified path with an underscore separating the suffix.   |  <code>None</code> |
 
 **RETURNS**
 

--- a/doc/bzlrelease/BUILD.bazel
+++ b/doc/bzlrelease/BUILD.bazel
@@ -35,8 +35,6 @@ _RULE_DOC_PROVIDERS = [
     for rule in _RULE_NAMES
 ]
 
-_API_SRCS = []
-
 _API_DOC_PROVIDERS = []
 
 _ALL_DOC_PROVIDERS = [

--- a/doc/markdown/BUILD.bazel
+++ b/doc/markdown/BUILD.bazel
@@ -16,8 +16,6 @@ filegroup(
 
 # MARK: - Documentation Providers
 
-_DOC_PATH = "doc/markdown"
-
 _STARDOC_INPUT = "//markdown:defs.bzl"
 
 _DOC_DEPS = ["//markdown:defs"]

--- a/doc/updatesrc/rules_and_macros_overview.md
+++ b/doc/updatesrc/rules_and_macros_overview.md
@@ -45,8 +45,8 @@ Option #2: Rules that provide `UpdateSrcsInfo` can be specified in the `deps` at
 ## updatesrc_diff_and_update
 
 <pre>
-updatesrc_diff_and_update(<a href="#updatesrc_diff_and_update-srcs">srcs</a>, <a href="#updatesrc_diff_and_update-outs">outs</a>, <a href="#updatesrc_diff_and_update-name">name</a>, <a href="#updatesrc_diff_and_update-diff_test_prefix">diff_test_prefix</a>, <a href="#updatesrc_diff_and_update-diff_test_suffix">diff_test_suffix</a>, <a href="#updatesrc_diff_and_update-update_visibility">update_visibility</a>,
-                          <a href="#updatesrc_diff_and_update-diff_test_visibility">diff_test_visibility</a>)
+updatesrc_diff_and_update(<a href="#updatesrc_diff_and_update-srcs">srcs</a>, <a href="#updatesrc_diff_and_update-outs">outs</a>, <a href="#updatesrc_diff_and_update-name">name</a>, <a href="#updatesrc_diff_and_update-update_name">update_name</a>, <a href="#updatesrc_diff_and_update-diff_test_prefix">diff_test_prefix</a>, <a href="#updatesrc_diff_and_update-diff_test_suffix">diff_test_suffix</a>,
+                          <a href="#updatesrc_diff_and_update-update_visibility">update_visibility</a>, <a href="#updatesrc_diff_and_update-diff_test_visibility">diff_test_visibility</a>)
 </pre>
 
 Defines an `updatesrc_update` for the package and `diff_test` targets for each src-out pair.
@@ -58,7 +58,8 @@ Defines an `updatesrc_update` for the package and `diff_test` targets for each s
 | :------------- | :------------- | :------------- |
 | <a id="updatesrc_diff_and_update-srcs"></a>srcs |  Source files that will be updated by the files listed in the <code>outs</code> attribute.  Every file listed in the <code>srcs</code> attribute must have a corresponding output file listed in the <code>outs</code> attribute.   |  none |
 | <a id="updatesrc_diff_and_update-outs"></a>outs |  Output files that will be used to update the files listed in the <code>srcs</code> attribute. Every file listed in the <code>outs</code> attribute must have a corresponding source file list in the <code>srcs</code> attribute.   |  none |
-| <a id="updatesrc_diff_and_update-name"></a>name |  Optional. The name of the <code>updatesrc_update</code> target.   |  <code>"update"</code> |
+| <a id="updatesrc_diff_and_update-name"></a>name |  Optional. The name of the <code>updatesrc_update</code> target.   |  <code>None</code> |
+| <a id="updatesrc_diff_and_update-update_name"></a>update_name |  Deprecated. The name of the <code>updatesrc_update</code> target.   |  <code>"update"</code> |
 | <a id="updatesrc_diff_and_update-diff_test_prefix"></a>diff_test_prefix |  Optional. The prefix to be used for the <code>diff_test</code> target names.   |  <code>""</code> |
 | <a id="updatesrc_diff_and_update-diff_test_suffix"></a>diff_test_suffix |  Optional. The suffix to be used for the <code>diff_test</code> target names.   |  <code>"_difftest"</code> |
 | <a id="updatesrc_diff_and_update-update_visibility"></a>update_visibility |  Optional. The visibility declarations for the <code>updatesrc_update</code> target.   |  <code>None</code> |

--- a/doc/updatesrc/rules_and_macros_overview.md
+++ b/doc/updatesrc/rules_and_macros_overview.md
@@ -45,8 +45,8 @@ Option #2: Rules that provide `UpdateSrcsInfo` can be specified in the `deps` at
 ## updatesrc_diff_and_update
 
 <pre>
-updatesrc_diff_and_update(<a href="#updatesrc_diff_and_update-srcs">srcs</a>, <a href="#updatesrc_diff_and_update-outs">outs</a>, <a href="#updatesrc_diff_and_update-update_name">update_name</a>, <a href="#updatesrc_diff_and_update-diff_test_prefix">diff_test_prefix</a>, <a href="#updatesrc_diff_and_update-diff_test_suffix">diff_test_suffix</a>,
-                          <a href="#updatesrc_diff_and_update-update_visibility">update_visibility</a>, <a href="#updatesrc_diff_and_update-diff_test_visibility">diff_test_visibility</a>)
+updatesrc_diff_and_update(<a href="#updatesrc_diff_and_update-srcs">srcs</a>, <a href="#updatesrc_diff_and_update-outs">outs</a>, <a href="#updatesrc_diff_and_update-name">name</a>, <a href="#updatesrc_diff_and_update-diff_test_prefix">diff_test_prefix</a>, <a href="#updatesrc_diff_and_update-diff_test_suffix">diff_test_suffix</a>, <a href="#updatesrc_diff_and_update-update_visibility">update_visibility</a>,
+                          <a href="#updatesrc_diff_and_update-diff_test_visibility">diff_test_visibility</a>)
 </pre>
 
 Defines an `updatesrc_update` for the package and `diff_test` targets for each src-out pair.
@@ -58,7 +58,7 @@ Defines an `updatesrc_update` for the package and `diff_test` targets for each s
 | :------------- | :------------- | :------------- |
 | <a id="updatesrc_diff_and_update-srcs"></a>srcs |  Source files that will be updated by the files listed in the <code>outs</code> attribute.  Every file listed in the <code>srcs</code> attribute must have a corresponding output file listed in the <code>outs</code> attribute.   |  none |
 | <a id="updatesrc_diff_and_update-outs"></a>outs |  Output files that will be used to update the files listed in the <code>srcs</code> attribute. Every file listed in the <code>outs</code> attribute must have a corresponding source file list in the <code>srcs</code> attribute.   |  none |
-| <a id="updatesrc_diff_and_update-update_name"></a>update_name |  Optional. The name of the <code>updatesrc_update</code> target.   |  <code>"update"</code> |
+| <a id="updatesrc_diff_and_update-name"></a>name |  Optional. The name of the <code>updatesrc_update</code> target.   |  <code>"update"</code> |
 | <a id="updatesrc_diff_and_update-diff_test_prefix"></a>diff_test_prefix |  Optional. The prefix to be used for the <code>diff_test</code> target names.   |  <code>""</code> |
 | <a id="updatesrc_diff_and_update-diff_test_suffix"></a>diff_test_suffix |  Optional. The suffix to be used for the <code>diff_test</code> target names.   |  <code>"_difftest"</code> |
 | <a id="updatesrc_diff_and_update-update_visibility"></a>update_visibility |  Optional. The visibility declarations for the <code>updatesrc_update</code> target.   |  <code>None</code> |

--- a/examples/bzlformat/simple/mockascript/deps.bzl
+++ b/examples/bzlformat/simple/mockascript/deps.bzl
@@ -1,3 +1,5 @@
+"""Dependencies for mockascript rules."""
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 

--- a/examples/bzlformat/simple/mockascript/internal/foo.bzl
+++ b/examples/bzlformat/simple/mockascript/internal/foo.bzl
@@ -1,5 +1,7 @@
+"""Definition for foo macro."""
+
 # This file provides no functionality. It needs to exist to test some
 # formatting changes that are applied to BUILD.bazel files.
 
 def foo(tags = [], srcs = []):
-    pass
+    return tags + srcs

--- a/examples/bzlformat/simple/mockascript/internal/mockascript_library.bzl
+++ b/examples/bzlformat/simple/mockascript/internal/mockascript_library.bzl
@@ -1,3 +1,6 @@
+"""Definition for mockascript_library rule."""
+
+# buildifier: disable=unused-variable
 def _mockascript_library_impl(ctx):
     pass
 

--- a/examples/bzlformat/simple/mockascript/mockascript.bzl
+++ b/examples/bzlformat/simple/mockascript/mockascript.bzl
@@ -1,3 +1,5 @@
+"""Public API for mockascript."""
+
 load(
     "//mockascript/internal:mockascript_library",
     _mockascript_library = "mockascript_library",

--- a/lib/src_utils.bzl
+++ b/lib/src_utils.bzl
@@ -1,3 +1,5 @@
+"""Deprecated."""
+
 load("//bzllib/rules:defs.bzl", _src_utils = "src_utils")
 
 src_utils = _src_utils

--- a/markdown/defs.bzl
+++ b/markdown/defs.bzl
@@ -1,3 +1,5 @@
+"""Public API for markdown."""
+
 load(
     "//markdown/private:markdown_check_links_test.bzl",
     _markdown_check_links_test = "markdown_check_links_test",

--- a/markdown/deps.bzl
+++ b/markdown/deps.bzl
@@ -1,3 +1,5 @@
+"""Dependency Functions for markdown"""
+
 load("//markdown/private:github_markdown_toc_go_repositories.bzl", "github_markdown_toc_go_repositories")
 
 def bazel_starlib_markdown_dependencies():

--- a/markdown/private/github_markdown_toc_go_repositories.bzl
+++ b/markdown/private/github_markdown_toc_go_repositories.bzl
@@ -1,6 +1,9 @@
+"""Go repository dependencies for github-markdown-toc-go."""
+
 load("@bazel_gazelle//:deps.bzl", "go_repository")
 
 def github_markdown_toc_go_repositories():
+    """Declares the Golang repository dependencies for github-markdown-toc-go."""
     go_repository(
         name = "com_github_alecthomas_assert",
         importpath = "github.com/alecthomas/assert",

--- a/markdown/private/markdown_check_links_test.bzl
+++ b/markdown/private/markdown_check_links_test.bzl
@@ -1,3 +1,5 @@
+"""Definition for markdown_check_links_test rule."""
+
 load("@bazel_skylib//lib:shell.bzl", "shell")
 
 def _markdown_check_links_test_impl(ctx):

--- a/markdown/private/markdown_generate_toc.bzl
+++ b/markdown/private/markdown_generate_toc.bzl
@@ -1,3 +1,5 @@
+"""Definition for markdown_generate_toc rule."""
+
 load("//updatesrc:defs.bzl", "UpdateSrcsInfo", "update_srcs")
 
 def _markdown_generate_toc_impl(ctx):

--- a/markdown/private/markdown_pkg.bzl
+++ b/markdown/private/markdown_pkg.bzl
@@ -1,3 +1,5 @@
+"""Definition for markdown_pkg macro."""
+
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load("//bzllib/rules:defs.bzl", "src_utils")
 load("//updatesrc:defs.bzl", "updatesrc_update")

--- a/markdown/private/markdown_register_node_deps.bzl
+++ b/markdown/private/markdown_register_node_deps.bzl
@@ -1,3 +1,5 @@
+"""Configures the node dependencies for the markdown functionality."""
+
 load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories", "yarn_install")
 
 def markdown_register_node_deps(name = "cgrindel_bazel_starlib_markdown_npm"):

--- a/shlib/rules/BUILD.bazel
+++ b/shlib/rules/BUILD.bazel
@@ -18,6 +18,7 @@ bzl_library(
     srcs = ["execute_binary.bzl"],
     deps = [
         "//shlib/rules/private:execute_binary",
+        "//shlib/rules/private:execute_binary_utils",
     ],
 )
 

--- a/shlib/rules/binary_pkg.bzl
+++ b/shlib/rules/binary_pkg.bzl
@@ -1,3 +1,5 @@
+"""Public API for binary_pkg"""
+
 load("//shlib/rules/private:binary_pkg.bzl", _binary_pkg = "binary_pkg")
 
 binary_pkg = _binary_pkg

--- a/shlib/rules/execute_binary.bzl
+++ b/shlib/rules/execute_binary.bzl
@@ -3,6 +3,11 @@ load(
     _execute_binary = "execute_binary",
     _file_placeholder = "file_placeholder",
 )
+load(
+    "//shlib/rules/private:execute_binary_utils.bzl",
+    _execute_binary_utils = "execute_binary_utils",
+)
 
 execute_binary = _execute_binary
 file_placeholder = _file_placeholder
+execute_binary_utils = _execute_binary_utils

--- a/shlib/rules/execute_binary.bzl
+++ b/shlib/rules/execute_binary.bzl
@@ -1,3 +1,5 @@
+"""Public """
+
 load(
     "//shlib/rules/private:execute_binary.bzl",
     _execute_binary = "execute_binary",

--- a/shlib/rules/private/BUILD.bazel
+++ b/shlib/rules/private/BUILD.bazel
@@ -8,10 +8,18 @@ bzlformat_pkg(name = "bzlformat")
 exports_files(["decompress.sh.tmpl"])
 
 bzl_library(
+    name = "execute_binary_utils",
+    srcs = ["execute_binary_utils.bzl"],
+    deps = [
+        "@bazel_skylib//lib:paths",
+    ],
+)
+
+bzl_library(
     name = "execute_binary",
     srcs = ["execute_binary.bzl"],
     deps = [
-        "@bazel_skylib//lib:paths",
+        ":execute_binary_utils",
     ],
 )
 

--- a/shlib/rules/private/binary_pkg.bzl
+++ b/shlib/rules/private/binary_pkg.bzl
@@ -1,3 +1,5 @@
+"""Definition for binary_pkg rule."""
+
 load("@bazel_skylib//lib:paths.bzl", "paths")
 
 # Lovingly inspired by https://www.linuxjournal.com/node/1005818.

--- a/shlib/rules/private/execute_binary.bzl
+++ b/shlib/rules/private/execute_binary.bzl
@@ -1,3 +1,5 @@
+"""Definittion for execute_binary rule."""
+
 load(":execute_binary_utils.bzl", "execute_binary_utils")
 
 file_placeholder = execute_binary_utils.file_placeholder

--- a/shlib/rules/private/execute_binary.bzl
+++ b/shlib/rules/private/execute_binary.bzl
@@ -2,25 +2,6 @@ load(":execute_binary_utils.bzl", "execute_binary_utils")
 
 file_placeholder = execute_binary_utils.file_placeholder
 
-# def file_placeholder(key):
-#     """Returns a placeholder string that is suitable for inclusion in the args for `execute_binary`.
-
-#     Args:
-#         key: The name for the placeholder as a `string`.
-
-#     Returns:
-#         A `string` that can be added to the arguments of `execute_binary`.
-#     """
-#     return "{%s}" % (key)
-
-# def _substitute_placehodlers(ctx, placeholder_dict, value):
-#     new_value = value
-#     for key, file in placeholder_dict.items():
-#         p_str = file_placeholder(key)
-#         path = paths.join("${RUNFILES_DIR}", ctx.workspace_name, file.short_path)
-#         new_value = new_value.replace(p_str, path)
-#     return new_value
-
 def _create_file_args_placeholder_dict(ctx):
     return {p: fa.files.to_list()[0] for fa, p in ctx.attr.file_arguments.items()}
 
@@ -50,84 +31,6 @@ The args attribute is not supported for execute_binary. Use the arguments instea
     )
 
     return DefaultInfo(executable = out, runfiles = runfiles)
-
-#def _execute_binary_impl(ctx):
-#    if len(ctx.attr.args) > 0:
-#        fail("""\
-#The args attribute is not supported for execute_binary. Use the arguments instead.\
-#""")
-
-#    bin_path = ctx.executable.binary.short_path
-#    bin_runfiles = ctx.attr.binary[DefaultInfo].default_runfiles
-
-#    placeholder_dict = _create_file_args_placeholder_dict(ctx)
-#    quoted_args = []
-#    for arg in ctx.attr.arguments:
-#        arg = _substitute_placehodlers(ctx, placeholder_dict, arg)
-#        if arg.startswith("\"") and arg.endswith("\""):
-#            quoted_args.append(arg)
-#        else:
-#            quoted_args.append("\"%s\"" % (arg))
-
-#    out = ctx.actions.declare_file(ctx.label.name + ".sh")
-#    ctx.actions.write(
-#        output = out,
-#        is_executable = True,
-#        content = """\
-##!/usr/bin/env bash
-
-#set -euo pipefail
-
-## Set the RUNFILES_DIR. If an embedded binary is a sh_binary, it has trouble
-## finding the runfiles directory. So, we help.
-#[[ -z "${RUNFILES_DIR:-}" ]] && \
-#  [[ -f "${PWD}/../MANIFEST" ]] && \
-#  export RUNFILES_DIR="${PWD}/.."
-
-#[[ -z "${RUNFILES_DIR:-}" ]] && \
-#  echo >&2 "The RUNFILES_DIR for $(basename "${BASH_SOURCE[0]}") could not be found."
-
-#""" + """\
-#workspace_name="{workspace_name}"
-#bin_path="{bin_path}"
-#""".format(bin_path = bin_path, workspace_name = ctx.workspace_name) + """\
-
-## If the bin_path can be found relative to the current directory, use it.
-## Otherwise, look for it under the runfiles directory.
-#if [[ -f "${bin_path}" ]]; then
-#  binary="${bin_path}"
-#else
-#  binary="${RUNFILES_DIR}/${workspace_name}/${bin_path}"
-#fi
-
-## Construct the command (binary plus args).
-#cmd=( "${binary}" )
-#""" + "\n".join([
-#            # Do not quote the {arg}. The values are already quoted. Adding the
-#            # quotes here will ruin the Bash substitution.
-#            """cmd+=( {arg} )""".format(arg = arg)
-#            for arg in quoted_args
-#        ]) + """
-
-## Add any args that were passed to this invocation
-#[[ $# > 0 ]] && cmd+=( "${@}" )
-
-## Execute the binary with its args
-#"${cmd[@]}"
-#""",
-#    )
-
-#    # The file_arguments attribute shows up as a dict under ctx.attr.file_arguments and
-#    # as a list under ctx.files.file_arguments
-#    runfiles = ctx.runfiles(files = ctx.files.data + ctx.files.file_arguments)
-#    runfiles = runfiles.merge(bin_runfiles)
-
-#    # Check if any of the file_arguments have runfiles and add them as well.
-#    for target in ctx.attr.file_arguments:
-#        if DefaultInfo in target:
-#            runfiles = runfiles.merge(target[DefaultInfo].default_runfiles)
-
-#    return DefaultInfo(executable = out, runfiles = runfiles)
 
 execute_binary = rule(
     implementation = _execute_binary_impl,

--- a/shlib/rules/private/execute_binary.bzl
+++ b/shlib/rules/private/execute_binary.bzl
@@ -1,30 +1,28 @@
-load("@bazel_skylib//lib:paths.bzl", "paths")
+load(":execute_binary_utils.bzl", "execute_binary_utils")
 
-def file_placeholder(key):
-    """Returns a placeholder string that is suitable for inclusion in the args for `execute_binary`.
+file_placeholder = execute_binary_utils.file_placeholder
 
-    Args:
-        key: The name for the placeholder as a `string`.
+# def file_placeholder(key):
+#     """Returns a placeholder string that is suitable for inclusion in the args for `execute_binary`.
 
-    Returns:
-        A `string` that can be added to the arguments of `execute_binary`.
-    """
-    return "{%s}" % (key)
+#     Args:
+#         key: The name for the placeholder as a `string`.
+
+#     Returns:
+#         A `string` that can be added to the arguments of `execute_binary`.
+#     """
+#     return "{%s}" % (key)
+
+# def _substitute_placehodlers(ctx, placeholder_dict, value):
+#     new_value = value
+#     for key, file in placeholder_dict.items():
+#         p_str = file_placeholder(key)
+#         path = paths.join("${RUNFILES_DIR}", ctx.workspace_name, file.short_path)
+#         new_value = new_value.replace(p_str, path)
+#     return new_value
 
 def _create_file_args_placeholder_dict(ctx):
     return {p: fa.files.to_list()[0] for fa, p in ctx.attr.file_arguments.items()}
-
-def _substitute_placehodlers(ctx, placeholder_dict, value):
-    new_value = value
-    for key, file in placeholder_dict.items():
-        p_str = file_placeholder(key)
-
-        path = paths.join("${RUNFILES_DIR}", ctx.workspace_name, file.short_path)
-        new_value = new_value.replace(p_str, path)
-    return new_value
-
-# def write_execute_binary(actions, out, binary_executable, binary_default_info, workspace_name):
-#     pass
 
 def _execute_binary_impl(ctx):
     if len(ctx.attr.args) > 0:
@@ -32,77 +30,104 @@ def _execute_binary_impl(ctx):
 The args attribute is not supported for execute_binary. Use the arguments instead.\
 """)
 
-    bin_path = ctx.executable.binary.short_path
-    bin_runfiles = ctx.attr.binary[DefaultInfo].default_runfiles
-
     placeholder_dict = _create_file_args_placeholder_dict(ctx)
-    quoted_args = []
-    for arg in ctx.attr.arguments:
-        arg = _substitute_placehodlers(ctx, placeholder_dict, arg)
-        if arg.startswith("\"") and arg.endswith("\""):
-            quoted_args.append(arg)
-        else:
-            quoted_args.append("\"%s\"" % (arg))
-
     out = ctx.actions.declare_file(ctx.label.name + ".sh")
-    ctx.actions.write(
-        output = out,
-        is_executable = True,
-        content = """\
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-# Set the RUNFILES_DIR. If an embedded binary is a sh_binary, it has trouble 
-# finding the runfiles directory. So, we help.
-[[ -z "${RUNFILES_DIR:-}" ]] && \
-  [[ -f "${PWD}/../MANIFEST" ]] && \
-  export RUNFILES_DIR="${PWD}/.."
-
-[[ -z "${RUNFILES_DIR:-}" ]] && \
-  echo >&2 "The RUNFILES_DIR for $(basename "${BASH_SOURCE[0]}") could not be found."
-
-""" + """\
-workspace_name="{workspace_name}"
-bin_path="{bin_path}"
-""".format(bin_path = bin_path, workspace_name = ctx.workspace_name) + """\
-
-# If the bin_path can be found relative to the current directory, use it.
-# Otherwise, look for it under the runfiles directory.
-if [[ -f "${bin_path}" ]]; then
-  binary="${bin_path}"
-else
-  binary="${RUNFILES_DIR}/${workspace_name}/${bin_path}"
-fi
-
-# Construct the command (binary plus args).
-cmd=( "${binary}" )
-""" + "\n".join([
-            # Do not quote the {arg}. The values are already quoted. Adding the
-            # quotes here will ruin the Bash substitution.
-            """cmd+=( {arg} )""".format(arg = arg)
-            for arg in quoted_args
-        ]) + """
-
-# Add any args that were passed to this invocation
-[[ $# > 0 ]] && cmd+=( "${@}" )
-
-# Execute the binary with its args
-"${cmd[@]}"
-""",
+    execute_binary_utils.write_execute_binary(
+        write_file = ctx.actions.write,
+        out = out,
+        bin_path = ctx.executable.binary.short_path,
+        arguments = ctx.attr.arguments,
+        placeholder_dict = placeholder_dict,
+        workspace_name = ctx.workspace_name,
     )
 
     # The file_arguments attribute shows up as a dict under ctx.attr.file_arguments and
     # as a list under ctx.files.file_arguments
     runfiles = ctx.runfiles(files = ctx.files.data + ctx.files.file_arguments)
-    runfiles = runfiles.merge(bin_runfiles)
-
-    # Check if any of the file_arguments have runfiles and add them as well.
-    for target in ctx.attr.file_arguments:
-        if DefaultInfo in target:
-            runfiles = runfiles.merge(target[DefaultInfo].default_runfiles)
+    runfiles = execute_binary_utils.collect_runfiles(
+        runfiles,
+        [ctx.attr.binary] + ctx.attr.file_arguments.keys(),
+    )
 
     return DefaultInfo(executable = out, runfiles = runfiles)
+
+#def _execute_binary_impl(ctx):
+#    if len(ctx.attr.args) > 0:
+#        fail("""\
+#The args attribute is not supported for execute_binary. Use the arguments instead.\
+#""")
+
+#    bin_path = ctx.executable.binary.short_path
+#    bin_runfiles = ctx.attr.binary[DefaultInfo].default_runfiles
+
+#    placeholder_dict = _create_file_args_placeholder_dict(ctx)
+#    quoted_args = []
+#    for arg in ctx.attr.arguments:
+#        arg = _substitute_placehodlers(ctx, placeholder_dict, arg)
+#        if arg.startswith("\"") and arg.endswith("\""):
+#            quoted_args.append(arg)
+#        else:
+#            quoted_args.append("\"%s\"" % (arg))
+
+#    out = ctx.actions.declare_file(ctx.label.name + ".sh")
+#    ctx.actions.write(
+#        output = out,
+#        is_executable = True,
+#        content = """\
+##!/usr/bin/env bash
+
+#set -euo pipefail
+
+## Set the RUNFILES_DIR. If an embedded binary is a sh_binary, it has trouble
+## finding the runfiles directory. So, we help.
+#[[ -z "${RUNFILES_DIR:-}" ]] && \
+#  [[ -f "${PWD}/../MANIFEST" ]] && \
+#  export RUNFILES_DIR="${PWD}/.."
+
+#[[ -z "${RUNFILES_DIR:-}" ]] && \
+#  echo >&2 "The RUNFILES_DIR for $(basename "${BASH_SOURCE[0]}") could not be found."
+
+#""" + """\
+#workspace_name="{workspace_name}"
+#bin_path="{bin_path}"
+#""".format(bin_path = bin_path, workspace_name = ctx.workspace_name) + """\
+
+## If the bin_path can be found relative to the current directory, use it.
+## Otherwise, look for it under the runfiles directory.
+#if [[ -f "${bin_path}" ]]; then
+#  binary="${bin_path}"
+#else
+#  binary="${RUNFILES_DIR}/${workspace_name}/${bin_path}"
+#fi
+
+## Construct the command (binary plus args).
+#cmd=( "${binary}" )
+#""" + "\n".join([
+#            # Do not quote the {arg}. The values are already quoted. Adding the
+#            # quotes here will ruin the Bash substitution.
+#            """cmd+=( {arg} )""".format(arg = arg)
+#            for arg in quoted_args
+#        ]) + """
+
+## Add any args that were passed to this invocation
+#[[ $# > 0 ]] && cmd+=( "${@}" )
+
+## Execute the binary with its args
+#"${cmd[@]}"
+#""",
+#    )
+
+#    # The file_arguments attribute shows up as a dict under ctx.attr.file_arguments and
+#    # as a list under ctx.files.file_arguments
+#    runfiles = ctx.runfiles(files = ctx.files.data + ctx.files.file_arguments)
+#    runfiles = runfiles.merge(bin_runfiles)
+
+#    # Check if any of the file_arguments have runfiles and add them as well.
+#    for target in ctx.attr.file_arguments:
+#        if DefaultInfo in target:
+#            runfiles = runfiles.merge(target[DefaultInfo].default_runfiles)
+
+#    return DefaultInfo(executable = out, runfiles = runfiles)
 
 execute_binary = rule(
     implementation = _execute_binary_impl,

--- a/shlib/rules/private/execute_binary.bzl
+++ b/shlib/rules/private/execute_binary.bzl
@@ -23,6 +23,9 @@ def _substitute_placehodlers(ctx, placeholder_dict, value):
         new_value = new_value.replace(p_str, path)
     return new_value
 
+# def write_execute_binary(actions, out, binary_executable, binary_default_info, workspace_name):
+#     pass
+
 def _execute_binary_impl(ctx):
     if len(ctx.attr.args) > 0:
         fail("""\

--- a/shlib/rules/private/execute_binary.bzl
+++ b/shlib/rules/private/execute_binary.bzl
@@ -13,7 +13,7 @@ The args attribute is not supported for execute_binary. Use the arguments instea
 
     placeholder_dict = _create_file_args_placeholder_dict(ctx)
     out = ctx.actions.declare_file(ctx.label.name + ".sh")
-    execute_binary_utils.write_execute_binary(
+    execute_binary_utils.write_execute_binary_script(
         write_file = ctx.actions.write,
         out = out,
         bin_path = ctx.executable.binary.short_path,

--- a/shlib/rules/private/execute_binary_utils.bzl
+++ b/shlib/rules/private/execute_binary_utils.bzl
@@ -1,33 +1,33 @@
-# def _create_file_args_placeholder_dict(file_arguments):
-#     """Creates a `dict` with the key being the placeholder name and the value is the file.
-    
-#     Args:
-#         file_arguments: A label-keyed string `dict` mapping (key: label/file, 
-#                         value: placeholder name).
-    
-#     Returns:
-#         A ``
-#     """
-#     return {p: fa.files.to_list()[0] for fa, p in file_arguments.items()}
+load("@bazel_skylib//lib:paths.bzl", "paths")
+
+def _file_placeholder(key):
+    """Returns a placeholder string that is suitable for inclusion in the args for `execute_binary`.
+
+    Args:
+        key: The name for the placeholder as a `string`.
+
+    Returns:
+        A `string` that can be added to the arguments of `execute_binary`.
+    """
+    return "{%s}" % (key)
 
 def _substitute_placehodlers(workspace_name, placeholder_dict, value):
     new_value = value
     for key, file in placeholder_dict.items():
-        p_str = file_placeholder(key)
-
+        p_str = _file_placeholder(key)
         path = paths.join("${RUNFILES_DIR}", workspace_name, file.short_path)
         new_value = new_value.replace(p_str, path)
     return new_value
 
 def _prepare_arguments(arguments, workspace_name, placeholder_dict):
     """Prepares arguments by resolving file placeholders with actual values and adding double quotes.
-    
+
     Args:
         arguments: A `list` of arguments (`string` values) to prepare.
         workspace_name: The name of the workspace.
         placeholder_dict: A `dict` where the key is the placeholder name and
                           the value is the actual `File`.
-    
+
     Returns:
         A `list` of `string` values suitable to be substituted into a Bash script.
     """
@@ -40,8 +40,14 @@ def _prepare_arguments(arguments, workspace_name, placeholder_dict):
             quoted_args.append("\"%s\"" % (arg))
     return quoted_args
 
-
-def _write_execute_binary_script(write_file, create_runfiles, out, arguments, placeholder_dict):
+def _write_execute_binary_script(
+        write_file,
+        out,
+        bin_path,
+        arguments,
+        placeholder_dict,
+        workspace_name):
+    quoted_args = _prepare_arguments(arguments, workspace_name, placeholder_dict)
     write_file(
         output = out,
         is_executable = True,
@@ -62,7 +68,7 @@ set -euo pipefail
 """ + """\
 workspace_name="{workspace_name}"
 bin_path="{bin_path}"
-""".format(bin_path = bin_path, workspace_name = ctx.workspace_name) + """\
+""".format(bin_path = bin_path, workspace_name = workspace_name) + """\
 
 # If the bin_path can be found relative to the current directory, use it.
 # Otherwise, look for it under the runfiles directory.
@@ -89,7 +95,24 @@ cmd=( "${binary}" )
 """,
     )
 
+def _collect_runfiles(runfiles, targets):
+    """Interrogates the targets for `DefaultInfo` and merges any `default_runfiles` into the provided runfiles.
+
+    Args:
+        runfiles: A `runfiles` container as provided by `ctx.runfiles`.
+        targets: A `list` of attributes/targets that may provide `DefaultInfo`
+                 providers.
+
+    Returns:
+        A `runfiles` container wth all of the `default_runfiles` merged together.
+    """
+    for target in targets:
+        if DefaultInfo in target:
+            runfiles = runfiles.merge(target[DefaultInfo].default_runfiles)
+    return runfiles
+
 execute_binary_utils = struct(
-    # prepare_arguments = _prepare_arguments,
+    file_placeholder = _file_placeholder,
     write_execute_binary = _write_execute_binary_script,
+    collect_runfiles = _collect_runfiles,
 )

--- a/shlib/rules/private/execute_binary_utils.bzl
+++ b/shlib/rules/private/execute_binary_utils.bzl
@@ -1,3 +1,5 @@
+"""Utilties to aid in the writing of scripts that encapsualte the arguments to call a binary."""
+
 load("@bazel_skylib//lib:paths.bzl", "paths")
 
 def _file_placeholder(key):

--- a/shlib/rules/private/execute_binary_utils.bzl
+++ b/shlib/rules/private/execute_binary_utils.bzl
@@ -45,8 +45,8 @@ def _write_execute_binary_script(
         out,
         bin_path,
         arguments,
-        placeholder_dict,
-        workspace_name):
+        workspace_name,
+        placeholder_dict = {}):
     quoted_args = _prepare_arguments(arguments, workspace_name, placeholder_dict)
     write_file(
         output = out,
@@ -113,6 +113,6 @@ def _collect_runfiles(runfiles, targets):
 
 execute_binary_utils = struct(
     file_placeholder = _file_placeholder,
-    write_execute_binary = _write_execute_binary_script,
+    write_execute_binary_script = _write_execute_binary_script,
     collect_runfiles = _collect_runfiles,
 )

--- a/shlib/rules/private/execute_binary_utils.bzl
+++ b/shlib/rules/private/execute_binary_utils.bzl
@@ -1,0 +1,95 @@
+# def _create_file_args_placeholder_dict(file_arguments):
+#     """Creates a `dict` with the key being the placeholder name and the value is the file.
+    
+#     Args:
+#         file_arguments: A label-keyed string `dict` mapping (key: label/file, 
+#                         value: placeholder name).
+    
+#     Returns:
+#         A ``
+#     """
+#     return {p: fa.files.to_list()[0] for fa, p in file_arguments.items()}
+
+def _substitute_placehodlers(workspace_name, placeholder_dict, value):
+    new_value = value
+    for key, file in placeholder_dict.items():
+        p_str = file_placeholder(key)
+
+        path = paths.join("${RUNFILES_DIR}", workspace_name, file.short_path)
+        new_value = new_value.replace(p_str, path)
+    return new_value
+
+def _prepare_arguments(arguments, workspace_name, placeholder_dict):
+    """Prepares arguments by resolving file placeholders with actual values and adding double quotes.
+    
+    Args:
+        arguments: A `list` of arguments (`string` values) to prepare.
+        workspace_name: The name of the workspace.
+        placeholder_dict: A `dict` where the key is the placeholder name and
+                          the value is the actual `File`.
+    
+    Returns:
+        A `list` of `string` values suitable to be substituted into a Bash script.
+    """
+    quoted_args = []
+    for arg in arguments:
+        arg = _substitute_placehodlers(workspace_name, placeholder_dict, arg)
+        if arg.startswith("\"") and arg.endswith("\""):
+            quoted_args.append(arg)
+        else:
+            quoted_args.append("\"%s\"" % (arg))
+    return quoted_args
+
+
+def _write_execute_binary_script(write_file, create_runfiles, out, arguments, placeholder_dict):
+    write_file(
+        output = out,
+        is_executable = True,
+        content = """\
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Set the RUNFILES_DIR. If an embedded binary is a sh_binary, it has trouble 
+# finding the runfiles directory. So, we help.
+[[ -z "${RUNFILES_DIR:-}" ]] && \
+  [[ -f "${PWD}/../MANIFEST" ]] && \
+  export RUNFILES_DIR="${PWD}/.."
+
+[[ -z "${RUNFILES_DIR:-}" ]] && \
+  echo >&2 "The RUNFILES_DIR for $(basename "${BASH_SOURCE[0]}") could not be found."
+
+""" + """\
+workspace_name="{workspace_name}"
+bin_path="{bin_path}"
+""".format(bin_path = bin_path, workspace_name = ctx.workspace_name) + """\
+
+# If the bin_path can be found relative to the current directory, use it.
+# Otherwise, look for it under the runfiles directory.
+if [[ -f "${bin_path}" ]]; then
+  binary="${bin_path}"
+else
+  binary="${RUNFILES_DIR}/${workspace_name}/${bin_path}"
+fi
+
+# Construct the command (binary plus args).
+cmd=( "${binary}" )
+""" + "\n".join([
+            # Do not quote the {arg}. The values are already quoted. Adding the
+            # quotes here will ruin the Bash substitution.
+            """cmd+=( {arg} )""".format(arg = arg)
+            for arg in quoted_args
+        ]) + """
+
+# Add any args that were passed to this invocation
+[[ $# > 0 ]] && cmd+=( "${@}" )
+
+# Execute the binary with its args
+"${cmd[@]}"
+""",
+    )
+
+execute_binary_utils = struct(
+    # prepare_arguments = _prepare_arguments,
+    write_execute_binary = _write_execute_binary_script,
+)

--- a/tests/bzlformat_tests/BUILD.bazel
+++ b/tests/bzlformat_tests/BUILD.bazel
@@ -1,8 +1,11 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
-load("//bzlformat:defs.bzl", "bzlformat_format")
+load("//bzlformat:defs.bzl", "bzlformat_format", "bzlformat_lint_test")
 load("//bzllib/rules:defs.bzl", "filter_srcs")
+
+# NOTE: We are purposefully not using bzlformat_pkg in this package. We want to
+# test the bundled functionality separately.
 
 build_test(
     name = "public_api",
@@ -90,3 +93,10 @@ bzlformat_format(
     )
     for fi in _FORMAT_INFOS
 ]
+
+# MARK: - bzlformat_lint_test Tests
+
+bzlformat_lint_test(
+    name = "bzlformat_lint_test",
+    srcs = ["BUILD.bazel"],
+)

--- a/tests/bzllib_tests/rules_tests/filter_srcs_tests.bzl
+++ b/tests/bzllib_tests/rules_tests/filter_srcs_tests.bzl
@@ -1,3 +1,5 @@
+"""Tests for filter_srcs Rule"""
+
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("//bzllib/rules:defs.bzl", "filter_srcs")
@@ -140,7 +142,9 @@ def _test_expected_count_failure():
 
 # MARK: - Test Suite
 
+# buildifier: disable=unnamed-macro
 def filter_srcs_test_suite():
+    """Test Suite for filter_srcs tests"""
     _setup_src_file_targets()
     _test_filename_ends_with()
     _test_fail_if_no_criteria()

--- a/tests/bzllib_tests/rules_tests/src_utils_tests.bzl
+++ b/tests/bzllib_tests/rules_tests/src_utils_tests.bzl
@@ -1,3 +1,5 @@
+"""Tests for src_utils Utilities"""
+
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//bzllib/rules:defs.bzl", "src_utils")
 

--- a/tests/integration_test_common.bzl
+++ b/tests/integration_test_common.bzl
@@ -1,3 +1,5 @@
+"""Constants for Integration Tests"""
+
 INTEGRATION_TEST_TAGS = [
     "exclusive",
     "manual",

--- a/tests/toolchains_tests/lib_tests/assets_tests.bzl
+++ b/tests/toolchains_tests/lib_tests/assets_tests.bzl
@@ -1,3 +1,5 @@
+"""Tests for assets utilities."""
+
 load("@bazel_skylib//lib:new_sets.bzl", "sets")
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//toolchains/lib:assets.bzl", "assets")

--- a/tests/updatesrc_tests/workspace/diff_and_update_test/with_defaults/BUILD.bazel
+++ b/tests/updatesrc_tests/workspace/diff_and_update_test/with_defaults/BUILD.bazel
@@ -24,6 +24,7 @@ cat $(location {src}) > $@
 ]
 
 updatesrc_diff_and_update(
+    name = "update",
     srcs = srcs,
     outs = outs,
     diff_test_visibility = ["//diff_and_update_test:__pkg__"],

--- a/toolchains/lib/assets.bzl
+++ b/toolchains/lib/assets.bzl
@@ -1,3 +1,5 @@
+"""Utility functions for managing asset structs."""
+
 load("@bazel_skylib//lib:types.bzl", "types")
 
 _TYPICAL_PLATFORMS = ["darwin", "linux"]
@@ -5,6 +7,7 @@ _TYPICAL_ARCHES = ["amd64", "arm64"]
 
 def _create(name, platform, arch, version, sha256 = None):
     """Create a `struct` representing a buildtools asset.
+
     Args:
         name: The name of the asset (e.g. `buildifier`, `buildozer`) as a
               `string`.
@@ -12,6 +15,7 @@ def _create(name, platform, arch, version, sha256 = None):
         arch: The arch as a `string`. (e.g. `amd64`, `arm64`)
         version: The version as a `string`. (e.g. `4.2.3`)
         sha256: Optional. The sha256 as a `string`.
+
     Returns:
         A `struct` representing the asset to be downloaded.
     """
@@ -34,11 +38,13 @@ def _create(name, platform, arch, version, sha256 = None):
 
 def _create_unique_name(asset = None, name = None, platform = None, arch = None):
     """Create a unique name from an asset or from a name/platform/arch.
+
     Args:
         asset: An asset `struct` as returned by `buildtools.create_asset`.
         name: A tool name (e.g. buildifier) as `string`.
         platform: A platform as `string`.
         arch: An arch as `string`.
+
     Returns:
         A `string` suitable for use as identifying an asset.
     """
@@ -57,8 +63,10 @@ def _create_unique_name(asset = None, name = None, platform = None, arch = None)
 
 def _to_json(asset):
     """Returns the JSON representation for an asset `struct` or a `list` of asset `struct` values.
+
     Args:
         asset: An asset `struct` as returned by `buildtools.create_asset`.
+
     Returns:
         Returns a JSON `string` representation of the provided value.
     """
@@ -66,8 +74,10 @@ def _to_json(asset):
 
 def _from_json(json_str):
     """Returns an asset `struct` or a `list` of asset `struct` values as represented by the JSON `string`.
+
     Args:
         json_str: A JSON `string` representing an asset or a list of assets.
+
     Returns:
         An asset `struct` or a `list` of asset `struct` values.
     """
@@ -80,11 +90,14 @@ def _from_json(json_str):
 
 def _create_assets(version, names, platforms = _TYPICAL_PLATFORMS, arches = _TYPICAL_ARCHES, sha256_values = {}):
     """Create a `list` of asset `struct` values.
+
     Args:
         version: The buildtools version string.
         names: Optional. A `list` of tools to include.
         platforms: Optional. A `list` of platforms to include.
         arches: Optional. A `list` of arches to include.
+        sha256_values: Optional. A `dict` mapping asset name to SHA256 value.
+
     Returns:
         A `list` of buildtools assets.
     """

--- a/updatesrc/defs.bzl
+++ b/updatesrc/defs.bzl
@@ -1,3 +1,5 @@
+"""Public API for updatesrc."""
+
 load(
     "//updatesrc/private:providers.bzl",
     _UpdateSrcsInfo = "UpdateSrcsInfo",

--- a/updatesrc/private/providers.bzl
+++ b/updatesrc/private/providers.bzl
@@ -1,3 +1,5 @@
+"""Providers for updatesrc."""
+
 UpdateSrcsInfo = provider(
     doc = """\
 Information about files that should be copied from the output to the workspace.\

--- a/updatesrc/private/update_srcs.bzl
+++ b/updatesrc/private/update_srcs.bzl
@@ -1,3 +1,5 @@
+"""Utilities related to udpatesrc project."""
+
 def _create(src, out):
     """Creates a `struct` specifying a source file and an output file that should be used to update it.
 

--- a/updatesrc/private/updatesrc_diff_and_update.bzl
+++ b/updatesrc/private/updatesrc_diff_and_update.bzl
@@ -6,7 +6,7 @@ load(":updatesrc_update.bzl", "updatesrc_update")
 def updatesrc_diff_and_update(
         srcs,
         outs,
-        update_name = "update",
+        name = "update",
         diff_test_prefix = "",
         diff_test_suffix = "_difftest",
         update_visibility = None,
@@ -21,7 +21,7 @@ def updatesrc_diff_and_update(
         outs: Output files that will be used to update the files listed in the
               `srcs` attribute. Every file listed in the `outs` attribute must
               have a corresponding source file list in the `srcs` attribute.
-        update_name: Optional. The name of the `updatesrc_update` target.
+        name: Optional. The name of the `updatesrc_update` target.
         diff_test_prefix: Optional. The prefix to be used for the `diff_test`
                           target names.
         diff_test_suffix: Optional. The suffix to be used for the `diff_test`
@@ -50,7 +50,7 @@ def updatesrc_diff_and_update(
 
     # Define the update target
     updatesrc_update(
-        name = update_name,
+        name = name,
         srcs = srcs,
         outs = outs,
         visibility = update_visibility,

--- a/updatesrc/private/updatesrc_diff_and_update.bzl
+++ b/updatesrc/private/updatesrc_diff_and_update.bzl
@@ -1,3 +1,5 @@
+"""Definition for updatesrc_diff_and_update macro."""
+
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load(":updatesrc_update.bzl", "updatesrc_update")
 

--- a/updatesrc/private/updatesrc_diff_and_update.bzl
+++ b/updatesrc/private/updatesrc_diff_and_update.bzl
@@ -6,7 +6,8 @@ load(":updatesrc_update.bzl", "updatesrc_update")
 def updatesrc_diff_and_update(
         srcs,
         outs,
-        name = "update",
+        name = None,
+        update_name = "update",
         diff_test_prefix = "",
         diff_test_suffix = "_difftest",
         update_visibility = None,
@@ -22,6 +23,7 @@ def updatesrc_diff_and_update(
               `srcs` attribute. Every file listed in the `outs` attribute must
               have a corresponding source file list in the `srcs` attribute.
         name: Optional. The name of the `updatesrc_update` target.
+        update_name: Deprecated. The name of the `updatesrc_update` target.
         diff_test_prefix: Optional. The prefix to be used for the `diff_test`
                           target names.
         diff_test_suffix: Optional. The suffix to be used for the `diff_test`
@@ -47,6 +49,12 @@ def updatesrc_diff_and_update(
             file2 = out,
             visibility = diff_test_visibility,
         )
+
+    if name == None:
+        if update_name == None:
+            fail("Please specify a value for the name attribute.")
+        else:
+            name = update_name
 
     # Define the update target
     updatesrc_update(

--- a/updatesrc/private/updatesrc_update.bzl
+++ b/updatesrc/private/updatesrc_update.bzl
@@ -1,9 +1,7 @@
+"""Definition for updatesrc_update rule."""
+
 load(":providers.bzl", "UpdateSrcsInfo")
 load(":update_srcs.bzl", "update_srcs")
-
-"""A binary rule that updates the specified source files using the specified \
-output files.\
-"""
 
 def _updatesrc_update_impl(ctx):
     srcs_len = len(ctx.files.srcs)

--- a/updatesrc/private/updatesrc_update_test.bzl
+++ b/updatesrc/private/updatesrc_update_test.bzl
@@ -1,3 +1,5 @@
+"""Definition for updatesrc_update_test rule."""
+
 def _updatesrc_update_test_impl(ctx):
     srcs_len = len(ctx.files.srcs)
     outs_len = len(ctx.files.outs)


### PR DESCRIPTION
Closes #126.

- Refactored `execute_binary` rule creating utilities to aid in the writing of scripts for other rules.
- Implemented `bzlformat_lint_test` rule leveraging the `execute_binary_utils`.
- Updated Starlark files to address lint warnings.