### PR TITLE
Upgrade markdown-link-check 3.10.0

### DIFF
--- a/markdown/private/README.md
+++ b/markdown/private/README.md
@@ -1,0 +1,12 @@
+# Manage Javascript Dependencies
+
+## Upgrade Dependencies to Latest
+
+```sh
+# Change to this directory
+cd markdown/private
+
+# Upgrade all deps to their latest
+bazel run @yarn//:yarn -- upgrade
+```
+

--- a/markdown/private/README.md
+++ b/markdown/private/README.md
@@ -1,6 +1,9 @@
 # Manage Javascript Dependencies
 
+
 ## Upgrade Dependencies to Latest
+
+If you just want the latest upgrades, do the following:
 
 ```sh
 # Change to this directory
@@ -10,3 +13,13 @@ cd markdown/private
 bazel run @yarn//:yarn -- upgrade
 ```
 
+If you want to change the declared minimum version in `package.json`, update `package.json` and then
+do the following:
+
+```sh
+# Change to this directory
+cd markdown/private
+
+# Upgrade all deps to their latest
+bazel run @yarn//:yarn -- install
+```

--- a/markdown/private/package.json
+++ b/markdown/private/package.json
@@ -6,6 +6,6 @@
   "author": "Chuck Grindel <chuck@chuckgrindel.com>",
   "license": "Apache 2.0",
   "dependencies": {
-    "markdown-link-check": "^3.9.3"
+    "markdown-link-check": "^3.10.0"
   }
 }

--- a/markdown/private/yarn.lock
+++ b/markdown/private/yarn.lock
@@ -92,7 +92,7 @@ lodash@^4.17.21:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-markdown-link-check@^3.9.3:
+markdown-link-check@^3.10.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/markdown-link-check/-/markdown-link-check-3.10.0.tgz#9b5892257f56d5546e341c482341c081786ecf30"
   integrity sha512-P2WeISLd669q4yxmX3rU6zoGcmAXdvvRK8paXxLvOlTjtxY6cObpMv0blVtampmJGMeE7QcF4Q/9YT/wfXUNaw==

--- a/markdown/private/yarn.lock
+++ b/markdown/private/yarn.lock
@@ -77,10 +77,10 @@ isemail@^3.2.0:
   dependencies:
     punycode "2.x.x"
 
-link-check@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/link-check/-/link-check-5.0.2.tgz#f9d79a27e6298e5ed133399d1770b2086b8a7883"
-  integrity sha512-F7k7HzOFY3lh11o3nQTCfi3HTrUMbn/0LQ5aBU7vgronoh8HWGZfRC4Jh0ghuQDbtTGNO4u4is6AoqK0hsYDJg==
+link-check@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/link-check/-/link-check-5.1.0.tgz#2e61363124db32484d6ef5b00eb7eda15e60ba7c"
+  integrity sha512-FHq/9tVnIE/3EVEPb91GcbD+K/Pv5K5DYqb7vXi3TTKIViMYPOWxYFVVENZ0rq63zfaGXGvLgPT9U6jOFc5JBw==
   dependencies:
     is-relative-url "^3.0.0"
     isemail "^3.2.0"
@@ -93,27 +93,27 @@ lodash@^4.17.21:
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 markdown-link-check@^3.9.3:
-  version "3.9.3"
-  resolved "https://registry.yarnpkg.com/markdown-link-check/-/markdown-link-check-3.9.3.tgz#806fa80d34efe14f77fbe53f950f971b9635be84"
-  integrity sha512-eXW4jTs0z7MBnTnpgaM+jRNtEwBjKCW3yldNCE4v7kHqpm4BTGPaBbXqzt/Kdz1/fZl91hIXgBE/21yps1PtIQ==
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/markdown-link-check/-/markdown-link-check-3.10.0.tgz#9b5892257f56d5546e341c482341c081786ecf30"
+  integrity sha512-P2WeISLd669q4yxmX3rU6zoGcmAXdvvRK8paXxLvOlTjtxY6cObpMv0blVtampmJGMeE7QcF4Q/9YT/wfXUNaw==
   dependencies:
     async "^3.2.3"
     chalk "^4.1.2"
     commander "^6.2.0"
-    link-check "^5.0.2"
+    link-check "^5.1.0"
     lodash "^4.17.21"
-    markdown-link-extractor "^1.3.1"
+    markdown-link-extractor "^2.0.1"
     needle "^3.0.0"
     progress "^2.0.3"
 
-markdown-link-extractor@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/markdown-link-extractor/-/markdown-link-extractor-1.3.1.tgz#b21e797baa9247ab107a32439287afbc64eae24a"
-  integrity sha512-IosNBtHXplzEq2n9WoSi83LNLCWgLnb+8Xq379Ct5xrLLzmqPUtc+A1oqo6Sd32YfKus9uLedFNSwFK1sCzoNQ==
+markdown-link-extractor@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/markdown-link-extractor/-/markdown-link-extractor-2.0.1.tgz#10184cd6892ea657a724d1835b783cfb2520f9f9"
+  integrity sha512-Qy5AcoW7CDfIAB3I6cz2QFGHoLQYSH15lmfEqRgPvC/DEEMhb/EK0yeXmpIk+GSuJveYxLvkpXVFEZhgvubxTw==
   dependencies:
-    marked "^4.0.10"
+    marked "^4.0.12"
 
-marked@^4.0.10:
+marked@^4.0.12:
   version "4.0.12"
   resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.12.tgz#2262a4e6fd1afd2f13557726238b69a48b982f7d"
   integrity sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==


### PR DESCRIPTION
- Added `README.md` describing how to perform the updates.
- Updated the declared version for `markdown-link-check` to 3.10.0.