### PR TITLE
feat: support running `execute_binary` in the workspace directory

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -5,6 +5,7 @@ load(
     "bzlformat_missing_pkgs",
     "bzlformat_pkg",
 )
+load("//shlib/rules:execute_binary.bzl", "execute_binary")
 load("//tests:integration_test_common.bzl", "INTEGRATION_TEST_TAGS")
 load("//updatesrc:defs.bzl", "updatesrc_update_all")
 
@@ -49,6 +50,8 @@ updatesrc_update_all(
     targets_to_run = [
         "@contrib_rules_bazel_integration_test//tools:update_deleted_packages",
         ":bzlformat_missing_pkgs_fix",
+        # Run go mod tidy before we gazelle_update_repos
+        ":go_mod_tidy",
         ":gazelle_update_repos",
         ":gazelle",
     ],
@@ -57,6 +60,18 @@ updatesrc_update_all(
 alias(
     name = "tidy",
     actual = ":update_all",
+)
+
+# MARK: - Golang
+
+execute_binary(
+    name = "go_mod_tidy",
+    arguments = [
+        "mod",
+        "tidy",
+    ],
+    binary = "@go_sdk//:bin/go",
+    execute_in_workspace = True,
 )
 
 # MARK: - Markdown Files

--- a/doc/shlib/execute_binary.md
+++ b/doc/shlib/execute_binary.md
@@ -7,7 +7,7 @@
 ## execute_binary
 
 <pre>
-execute_binary(<a href="#execute_binary-name">name</a>, <a href="#execute_binary-arguments">arguments</a>, <a href="#execute_binary-binary">binary</a>, <a href="#execute_binary-data">data</a>, <a href="#execute_binary-file_arguments">file_arguments</a>)
+execute_binary(<a href="#execute_binary-name">name</a>, <a href="#execute_binary-arguments">arguments</a>, <a href="#execute_binary-binary">binary</a>, <a href="#execute_binary-data">data</a>, <a href="#execute_binary-execute_in_workspace">execute_in_workspace</a>, <a href="#execute_binary-file_arguments">file_arguments</a>)
 </pre>
 
 This rule executes a binary target with the specified arguments. It generates a Bash script that contains a call to the binary with the arguments embedded in the script. This is useful in the following situations:
@@ -30,6 +30,7 @@ You can use a macro which encapsulates the details of the xxx_binary declaration
 | <a id="execute_binary-arguments"></a>arguments |  The list of arguments that will be embedded into the resulting executable. <br><br>NOTE: Use this attribute instead of <code>args</code>. The <code>args</code> attribute is not processed for file arguments and is not preserved in the resulting script.   | List of strings | optional | <code>[]</code> |
 | <a id="execute_binary-binary"></a>binary |  The binary to be executed.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 | <a id="execute_binary-data"></a>data |  Files needed by the binary at runtime.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
+| <a id="execute_binary-execute_in_workspace"></a>execute_in_workspace |  If true, the binary will be executed in the Bazel workspace (i.e., source) directory.   | Boolean | optional | <code>False</code> |
 | <a id="execute_binary-file_arguments"></a>file_arguments |  A <code>dict</code> mapping of file labels to placeholder names. If any of the specified <code>arguments</code> for <code>execute_binary</code> are paths to files, add an entry in this attribute where the key is the filename or label referencing the file and the value is a placeholder name. Use the <code>file_placeholder</code> function to create a suitable placeholder string for the arguments.<br><br>Example<br><br><pre><code> execute_binary(     name = "do_something",     arguments = [         "--input",         file_placeholder("foo"),         "--input",         file_placeholder("bar"),     ],     file_arguments = {         # The key is the path          "foo.txt": "foo",         ":bar":  "bar",     }, ) </code></pre>   | <a href="https://bazel.build/rules/lib/dict">Dictionary: Label -> String</a> | optional | <code>{}</code> |
 
 

--- a/shlib/rules/private/execute_binary.bzl
+++ b/shlib/rules/private/execute_binary.bzl
@@ -27,7 +27,7 @@ The args attribute is not supported for execute_binary. Use the arguments instea
 
     # The file_arguments attribute shows up as a dict under ctx.attr.file_arguments and
     # as a list under ctx.files.file_arguments
-    runfiles = ctx.runfiles(files = ctx.files.data + ctx.files.file_arguments)
+    runfiles = ctx.runfiles(files = ctx.files.data + ctx.files.file_arguments + ctx.files.binary)
     runfiles = execute_binary_utils.collect_runfiles(
         runfiles,
         [ctx.attr.binary] + ctx.attr.file_arguments.keys(),
@@ -47,6 +47,7 @@ processed for file arguments and is not preserved in the resulting script.
 """,
         ),
         "binary": attr.label(
+            allow_files = True,
             executable = True,
             mandatory = True,
             cfg = "target",

--- a/shlib/rules/private/execute_binary.bzl
+++ b/shlib/rules/private/execute_binary.bzl
@@ -22,6 +22,7 @@ The args attribute is not supported for execute_binary. Use the arguments instea
         arguments = ctx.attr.arguments,
         placeholder_dict = placeholder_dict,
         workspace_name = ctx.workspace_name,
+        execute_in_workspace = ctx.attr.execute_in_workspace,
     )
 
     # The file_arguments attribute shows up as a dict under ctx.attr.file_arguments and
@@ -54,6 +55,11 @@ processed for file arguments and is not preserved in the resulting script.
         "data": attr.label_list(
             allow_files = True,
             doc = "Files needed by the binary at runtime.",
+        ),
+        "execute_in_workspace": attr.bool(
+            doc = """\
+If true, the binary will be executed in the Bazel workspace (i.e., source) directory.\
+""",
         ),
         "file_arguments": attr.label_keyed_string_dict(
             allow_files = True,

--- a/shlib/rules/private/execute_binary_utils.bzl
+++ b/shlib/rules/private/execute_binary_utils.bzl
@@ -75,7 +75,7 @@ execute_in_workspace="{execute_in_workspace}"
 """.format(
             bin_path = bin_path,
             workspace_name = workspace_name,
-            execute_in_workspace = str(execute_in_workspace),
+            execute_in_workspace = "true" if execute_in_workspace else "false",
         ) + """\
 
 # If the bin_path can be found relative to the current directory, use it.
@@ -84,10 +84,6 @@ if [[ -f "${bin_path}" ]]; then
   binary="${PWD}/${bin_path}"
 else
   binary="${RUNFILES_DIR}/${workspace_name}/${bin_path}"
-fi
-
-if [[ "${execute_in_workspace}" == "true" ]]; then
-  cd "${BUILD_WORKSPACE_DIRECTORY}"
 fi
 
 # Construct the command (binary plus args).
@@ -101,6 +97,11 @@ cmd=( "${binary}" )
 
 # Add any args that were passed to this invocation
 [[ $# > 0 ]] && cmd+=( "${@}" )
+
+# Change to the workspace directory if configured to do so
+if [[ "${execute_in_workspace}" == "true" ]]; then
+  cd "${BUILD_WORKSPACE_DIRECTORY}"
+fi
 
 # Execute the binary with its args
 "${cmd[@]}"

--- a/shlib/rules/private/execute_binary_utils.bzl
+++ b/shlib/rules/private/execute_binary_utils.bzl
@@ -48,6 +48,7 @@ def _write_execute_binary_script(
         bin_path,
         arguments,
         workspace_name,
+        execute_in_workspace = False,
         placeholder_dict = {}):
     quoted_args = _prepare_arguments(arguments, workspace_name, placeholder_dict)
     write_file(
@@ -70,14 +71,23 @@ set -euo pipefail
 """ + """\
 workspace_name="{workspace_name}"
 bin_path="{bin_path}"
-""".format(bin_path = bin_path, workspace_name = workspace_name) + """\
+execute_in_workspace="{execute_in_workspace}"
+""".format(
+            bin_path = bin_path,
+            workspace_name = workspace_name,
+            execute_in_workspace = str(execute_in_workspace),
+        ) + """\
 
 # If the bin_path can be found relative to the current directory, use it.
 # Otherwise, look for it under the runfiles directory.
 if [[ -f "${bin_path}" ]]; then
-  binary="${bin_path}"
+  binary="${PWD}/${bin_path}"
 else
   binary="${RUNFILES_DIR}/${workspace_name}/${bin_path}"
+fi
+
+if [[ "${execute_in_workspace}" == "true" ]]; then
+  cd "${BUILD_WORKSPACE_DIRECTORY}"
 fi
 
 # Construct the command (binary plus args).

--- a/tests/shlib_tests/rules_tests/execute_binary_tests/BUILD.bazel
+++ b/tests/shlib_tests/rules_tests/execute_binary_tests/BUILD.bazel
@@ -139,3 +139,28 @@ sh_test(
         "@bazel_tools//tools/bash/runfiles",
     ],
 )
+
+# MARK: - Test execute_binary with execute_in_workspace
+
+sh_binary(
+    name = "find_workspace",
+    srcs = ["find_workspace.sh"],
+)
+
+execute_binary(
+    name = "find_workspace_eb",
+    binary = ":find_workspace",
+    execute_in_workspace = True,
+)
+
+sh_test(
+    name = "find_workspace_eb_test",
+    srcs = ["find_workspace_eb_test.sh"],
+    data = [
+        ":find_workspace_eb",
+    ],
+    deps = [
+        "@bazel_tools//tools/bash/runfiles",
+        "@cgrindel_bazel_starlib//shlib/lib:assertions",
+    ],
+)

--- a/tests/shlib_tests/rules_tests/execute_binary_tests/find_workspace.sh
+++ b/tests/shlib_tests/rules_tests/execute_binary_tests/find_workspace.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# This utility expects to be run at the root of a Bazel workspace. It fails if
+# it is not.
+
+[[ -f "WORKSPACE" ]] || (echo >&2 "WORKSPACE not found." ; exit 1)

--- a/tests/shlib_tests/rules_tests/execute_binary_tests/find_workspace_eb_test.sh
+++ b/tests/shlib_tests/rules_tests/execute_binary_tests/find_workspace_eb_test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -o nounset -o pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+# shellcheck disable=SC1090
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -o errexit
+# --- end runfiles.bash initialization v2 ---
+
+# MARK - Locate Deps
+
+assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
+assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+  (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
+source "${assertions_sh}"
+
+# tests/shlib_tests/rules_tests/execute_binary_tests
+find_workspace_eb_location=cgrindel_bazel_starlib/tests/shlib_tests/rules_tests/execute_binary_tests/find_workspace_eb.sh
+find_workspace_eb="$(rlocation "${find_workspace_eb_location}")" || \
+  (echo >&2 "Failed to locate ${find_workspace_eb_location}" && exit 1)
+
+# MARK - Test
+
+# Create a workspace directory
+workspace_dir="${PWD}/workspace"
+mkdir -p "${workspace_dir}"
+touch "${workspace_dir}/WORKSPACE"
+export BUILD_WORKSPACE_DIRECTORY="${workspace_dir}"
+
+# If the execute succeeds, then the test succeeds
+"${find_workspace_eb}"


### PR DESCRIPTION
- Add `execute_in_workspace` attribute to `execute_binary`. If true, the current directory is changed to the `BUILD_WORKSPACE_DIRECTORY` before executing the command.
- Add `//:go_mod_tidy` runnable command.
- Add `//:go_mod_tidy` to `update_all` run list.