### PR TITLE
feat(`bazel_labels`): produce shortcut label string values when possible

### DIFF
--- a/bzllib/private/bazel_labels.bzl
+++ b/bzllib/private/bazel_labels.bzl
@@ -115,6 +115,13 @@ def make_bazel_labels(workspace_name_resolvers = workspace_name_resolvers):
         else:
             fail("Unrecognized type for bazel_labels.normalize.", value)
 
+        pkg_parts = parts.package.split("/")
+        if pkg_parts[-1] == parts.name:
+            return "{repo_name}//{package}".format(
+                repo_name = parts.repository_name,
+                package = parts.package,
+            )
+
         return "{repo_name}//{package}:{name}".format(
             repo_name = parts.repository_name,
             package = parts.package,

--- a/tests/bzllib_tests/bazel_labels_tests/BUILD.bazel
+++ b/tests/bzllib_tests/bazel_labels_tests/BUILD.bazel
@@ -1,8 +1,11 @@
 load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
+load(":new_tests.bzl", "new_test_suite")
 load(":normalize_tests.bzl", "normalize_test_suite")
 load(":parse_tests.bzl", "parse_test_suite")
 
 bzlformat_pkg(name = "bzlformat")
+
+new_test_suite(name = "new_tests")
 
 normalize_test_suite(name = "normalize_tests")
 

--- a/tests/bzllib_tests/bazel_labels_tests/new_tests.bzl
+++ b/tests/bzllib_tests/bazel_labels_tests/new_tests.bzl
@@ -1,0 +1,100 @@
+"""Tests for `bazel_labels.new`."""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+
+# buildifier: disable=bzl-visibility
+load("//bzllib/private:bazel_labels.bzl", "make_bazel_labels")
+
+# buildifier: disable=bzl-visibility
+load(
+    "//bzllib/private:workspace_name_resolvers.bzl",
+    "make_stub_workspace_name_resolvers",
+)
+
+bazel_labels = make_bazel_labels(
+    workspace_name_resolvers = make_stub_workspace_name_resolvers(
+        repo_name = "@cool_repo",
+        pkg_name = "Sources/Bar",
+    ),
+)
+
+def _all_params_provied_test(ctx):
+    env = unittest.begin(ctx)
+
+    actual = bazel_labels.new(
+        repository_name = "another_repo",
+        package = "Sources/Foo",
+        name = "chicken",
+    )
+    expected = struct(
+        repository_name = "@another_repo",
+        package = "Sources/Foo",
+        name = "chicken",
+    )
+    asserts.equals(env, expected, actual)
+
+    return unittest.end(env)
+
+all_params_provied_test = unittest.make(_all_params_provied_test)
+
+def _package_and_name_provided_test(ctx):
+    env = unittest.begin(ctx)
+
+    actual = bazel_labels.new(
+        package = "Sources/Foo",
+        name = "chicken",
+    )
+    expected = struct(
+        repository_name = "@cool_repo",
+        package = "Sources/Foo",
+        name = "chicken",
+    )
+    asserts.equals(env, expected, actual)
+
+    return unittest.end(env)
+
+package_and_name_provided_test = unittest.make(_package_and_name_provided_test)
+
+def _workspace_and_name_provided_test(ctx):
+    env = unittest.begin(ctx)
+
+    actual = bazel_labels.new(
+        repository_name = "another_repo",
+        name = "chicken",
+    )
+    expected = struct(
+        repository_name = "@another_repo",
+        package = "Sources/Bar",
+        name = "chicken",
+    )
+    asserts.equals(env, expected, actual)
+
+    return unittest.end(env)
+
+workspace_and_name_provided_test = unittest.make(_workspace_and_name_provided_test)
+
+def _name_provided_test(ctx):
+    env = unittest.begin(ctx)
+
+    actual = bazel_labels.new(
+        name = "chicken",
+    )
+    expected = struct(
+        repository_name = "@cool_repo",
+        package = "Sources/Bar",
+        name = "chicken",
+    )
+    asserts.equals(env, expected, actual)
+
+    return unittest.end(env)
+
+name_provided_test = unittest.make(_name_provided_test)
+
+def new_test_suite(name):
+    return unittest.suite(
+        name,
+        all_params_provied_test,
+        package_and_name_provided_test,
+        workspace_and_name_provided_test,
+        name_provided_test,
+    )

--- a/tests/bzllib_tests/bazel_labels_tests/normalize_tests.bzl
+++ b/tests/bzllib_tests/bazel_labels_tests/normalize_tests.bzl
@@ -54,10 +54,28 @@ def _absolute_label_without_repo_name_test(ctx):
 
 absolute_label_without_repo_name_test = unittest.make(_absolute_label_without_repo_name_test)
 
+def _package_mathes_name_test(ctx):
+    env = unittest.begin(ctx)
+
+    value = "//Sources/Foo:Foo"
+    actual = bazel_labels.normalize(value)
+    expected = "@//Sources/Foo"
+    asserts.equals(env, expected, actual)
+
+    value = "//Foo:Foo"
+    actual = bazel_labels.normalize(value)
+    expected = "@//Foo"
+    asserts.equals(env, expected, actual)
+
+    return unittest.end(env)
+
+package_mathes_name_test = unittest.make(_package_mathes_name_test)
+
 def normalize_test_suite(name):
     return unittest.suite(
         name,
         relative_label_test,
         absolute_label_with_repo_name_test,
         absolute_label_without_repo_name_test,
+        package_mathes_name_test,
     )

--- a/tests/bzllib_tests/bazel_labels_tests/normalize_tests.bzl
+++ b/tests/bzllib_tests/bazel_labels_tests/normalize_tests.bzl
@@ -54,7 +54,7 @@ def _absolute_label_without_repo_name_test(ctx):
 
 absolute_label_without_repo_name_test = unittest.make(_absolute_label_without_repo_name_test)
 
-def _package_mathes_name_test(ctx):
+def _package_matches_name_test(ctx):
     env = unittest.begin(ctx)
 
     value = "//Sources/Foo:Foo"
@@ -69,7 +69,7 @@ def _package_mathes_name_test(ctx):
 
     return unittest.end(env)
 
-package_mathes_name_test = unittest.make(_package_mathes_name_test)
+package_matches_name_test = unittest.make(_package_matches_name_test)
 
 def normalize_test_suite(name):
     return unittest.suite(
@@ -77,5 +77,5 @@ def normalize_test_suite(name):
         relative_label_test,
         absolute_label_with_repo_name_test,
         absolute_label_without_repo_name_test,
-        package_mathes_name_test,
+        package_matches_name_test,
     )

--- a/tests/bzllib_tests/bazel_labels_tests/parse_tests.bzl
+++ b/tests/bzllib_tests/bazel_labels_tests/parse_tests.bzl
@@ -11,21 +11,24 @@ load(
     "make_stub_workspace_name_resolvers",
 )
 
+_repo_name = "@example_cool_repo"
+_pkg_name = "Sources/Foo"
+
 bazel_labels = make_bazel_labels(
     workspace_name_resolvers = make_stub_workspace_name_resolvers(
-        repo_name = "@",
-        pkg_name = "Sources/Foo",
+        repo_name = _repo_name,
+        pkg_name = _pkg_name,
     ),
 )
 
 def _absolute_label_without_repo_name_test(ctx):
     env = unittest.begin(ctx)
 
-    value = "//Sources/Foo:chicken"
+    value = "//Sources/Bar:chicken"
     actual = bazel_labels.parse(value)
     expected = bazel_labels.new(
-        repository_name = "@",
-        package = "Sources/Foo",
+        repository_name = _repo_name,
+        package = "Sources/Bar",
         name = "chicken",
     )
     asserts.equals(env, expected, actual)
@@ -37,11 +40,11 @@ absolute_label_without_repo_name_test = unittest.make(_absolute_label_without_re
 def _absolute_label_with_repo_name_test(ctx):
     env = unittest.begin(ctx)
 
-    value = "@my_dep//Sources/Foo:chicken"
+    value = "@my_dep//Sources/Bar:chicken"
     actual = bazel_labels.parse(value)
     expected = bazel_labels.new(
         repository_name = "@my_dep",
-        package = "Sources/Foo",
+        package = "Sources/Bar",
         name = "chicken",
     )
     asserts.equals(env, expected, actual)
@@ -53,12 +56,12 @@ absolute_label_with_repo_name_test = unittest.make(_absolute_label_with_repo_nam
 def _absolute_label_without_explicit_name_test(ctx):
     env = unittest.begin(ctx)
 
-    value = "//Sources/Foo"
+    value = "//Sources/Bar"
     actual = bazel_labels.parse(value)
     expected = bazel_labels.new(
-        repository_name = "@",
-        package = "Sources/Foo",
-        name = "Foo",
+        repository_name = _repo_name,
+        package = "Sources/Bar",
+        name = "Bar",
     )
     asserts.equals(env, expected, actual)
 
@@ -72,8 +75,8 @@ def _relative_label_with_colon_test(ctx):
     value = ":chicken"
     actual = bazel_labels.parse(value)
     expected = bazel_labels.new(
-        repository_name = "@",
-        package = "Sources/Foo",
+        repository_name = _repo_name,
+        package = _pkg_name,
         name = "chicken",
     )
     asserts.equals(env, expected, actual)
@@ -88,8 +91,8 @@ def _relative_label_without_colon_test(ctx):
     value = "chicken"
     actual = bazel_labels.parse(value)
     expected = bazel_labels.new(
-        repository_name = "@",
-        package = "Sources/Foo",
+        repository_name = _repo_name,
+        package = _pkg_name,
         name = "chicken",
     )
     asserts.equals(env, expected, actual)


### PR DESCRIPTION
- Produce shortcut labels (e.g., `//Sources/Foo:Foo` => `//Sources/Foo`).
- Moved workspace name and package name resolution to `bazel_labels.new()`.