### PR TITLE
chore: point to `gha_create_release@v2`

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -43,7 +43,7 @@ jobs:
         app_id: ${{ secrets.APP_ID }}
         private_key: ${{ secrets.APP_PRIVATE_KEY }}
     - uses: cgrindel/gha_configure_git_user@v1
-    - uses: cgrindel/gha_create_release@support_release_artifact_upload
+    - uses: cgrindel/gha_create_release@v2
       with:
         release_tag: ${{  github.event.inputs.release_tag }}
         reset_tag: ${{  github.event.inputs.reset_tag }}

--- a/bazel_versions.bzl
+++ b/bazel_versions.bzl
@@ -3,8 +3,7 @@
 CURRENT_BAZEL_VERSION = "//:.bazelversion"
 
 OTHER_BAZEL_VERSIONS = [
-    "6.0.0-pre.20221020.1",
-    "7.0.0-pre.20221026.2",
+    "5.4.0",
 ]
 
 SUPPORTED_BAZEL_VERSIONS = [

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -22,8 +22,7 @@ filegroup(
 
 generate_workspace_snippet(
     name = "generate_workspace_snippet",
-    # TODO(chuck): FIX ME!
-    # sha256_file = ":archive_sha256",
+    sha256_file = ":archive_sha256",
     template = "workspace_snippet.tmpl",
 )
 


### PR DESCRIPTION
- Update `bazel_versions.bzl`.
- Fix release workspace snippet to use the archive SHA256.

Related to #200.