### PR TITLE
feat: introduce `release_archive` rule

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -161,6 +161,7 @@ filegroup(
     ],
     visibility = [
         ":integration_test_visibility",
+        "//:__subpackages__",
     ],
 )
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@bazel_gazelle//:def.bzl", "DEFAULT_LANGUAGES", "gazelle", "gazelle_binary")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 load(
     "//bzlformat:defs.bzl",
     "bzlformat_missing_pkgs",
@@ -115,12 +114,6 @@ filegroup(
     visibility = ["//:__subpackages__"],
 )
 
-pkg_files(
-    name = "release_files",
-    srcs = [":all_files"],
-    visibility = ["//:__subpackages__"],
-)
-
 # All of the packages that should be included in the release archive and made
 # available to the child workspaces.
 _RUNTIME_PKGS = [
@@ -161,17 +154,6 @@ filegroup(
     ],
     visibility = [
         ":integration_test_visibility",
-        "//:__subpackages__",
-    ],
-)
-
-pkg_filegroup(
-    name = "release_filegroup",
-    srcs = [
-        pkg + ":release_files"
-        for pkg in _RUNTIME_PKGS
-    ],
-    visibility = [
         "//:__subpackages__",
     ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -26,10 +26,6 @@ load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
 
 stardoc_repositories()
 
-load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
-
-rules_pkg_dependencies()
-
 # MARK: - Prebuilt Buildtools Deps
 
 load("@buildifier_prebuilt//:deps.bzl", "buildifier_prebuilt_deps")

--- a/bazeldoc/BUILD.bazel
+++ b/bazeldoc/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 package(default_visibility = ["//visibility:public"])
@@ -28,12 +27,5 @@ bzl_library(
 filegroup(
     name = "all_files",
     srcs = glob(["*"]),
-    visibility = ["//:__subpackages__"],
-)
-
-pkg_files(
-    name = "release_files",
-    srcs = [":all_files"],
-    prefix = package_name(),
     visibility = ["//:__subpackages__"],
 )

--- a/bazeldoc/private/BUILD.bazel
+++ b/bazeldoc/private/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 package(default_visibility = ["//bazeldoc:__subpackages__"])
@@ -54,13 +53,6 @@ bzl_library(
 filegroup(
     name = "all_files",
     srcs = glob(["*"]),
-    visibility = ["//:__subpackages__"],
-)
-
-pkg_files(
-    name = "release_files",
-    srcs = [":all_files"],
-    prefix = package_name(),
     visibility = ["//:__subpackages__"],
 )
 

--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -1,19 +1,11 @@
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 
 bzlformat_pkg(name = "bzlformat")
 
 filegroup(
     name = "all_files",
     srcs = glob(["*"]),
-    visibility = ["//:__subpackages__"],
-)
-
-pkg_files(
-    name = "release_files",
-    srcs = [":all_files"],
-    prefix = package_name(),
     visibility = ["//:__subpackages__"],
 )
 

--- a/bzlformat/BUILD.bazel
+++ b/bzlformat/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("//bzlformat/private:bzlformat_pkg.bzl", "bzlformat_pkg")
 
 package(default_visibility = ["//visibility:public"])
@@ -28,12 +27,5 @@ bzl_library(
 filegroup(
     name = "all_files",
     srcs = glob(["*"]),
-    visibility = ["//:__subpackages__"],
-)
-
-pkg_files(
-    name = "release_files",
-    srcs = [":all_files"],
-    prefix = package_name(),
     visibility = ["//:__subpackages__"],
 )

--- a/bzlformat/private/BUILD.bazel
+++ b/bzlformat/private/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load(":bzlformat_pkg.bzl", "bzlformat_pkg")
 
 package(default_visibility = ["//bzlformat:__subpackages__"])
@@ -50,12 +49,5 @@ bzl_library(
 filegroup(
     name = "all_files",
     srcs = glob(["*"]),
-    visibility = ["//:__subpackages__"],
-)
-
-pkg_files(
-    name = "release_files",
-    srcs = [":all_files"],
-    prefix = package_name(),
     visibility = ["//:__subpackages__"],
 )

--- a/bzlformat/tools/BUILD.bazel
+++ b/bzlformat/tools/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 # MARK: - Binaries
@@ -22,12 +21,5 @@ bzlformat_pkg(name = "bzlformat")
 filegroup(
     name = "all_files",
     srcs = glob(["*"]),
-    visibility = ["//:__subpackages__"],
-)
-
-pkg_files(
-    name = "release_files",
-    srcs = [":all_files"],
-    prefix = package_name(),
     visibility = ["//:__subpackages__"],
 )

--- a/bzlformat/tools/missing_pkgs/BUILD.bazel
+++ b/bzlformat/tools/missing_pkgs/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 bzlformat_pkg(name = "bzlformat")
@@ -44,12 +43,5 @@ sh_binary(
 filegroup(
     name = "all_files",
     srcs = glob(["*"]),
-    visibility = ["//:__subpackages__"],
-)
-
-pkg_files(
-    name = "release_files",
-    srcs = [":all_files"],
-    prefix = package_name(),
     visibility = ["//:__subpackages__"],
 )

--- a/bzllib/BUILD.bazel
+++ b/bzllib/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 package(default_visibility = ["//visibility:public"])
@@ -29,12 +28,5 @@ bzl_library(
 filegroup(
     name = "all_files",
     srcs = glob(["*"]),
-    visibility = ["//:__subpackages__"],
-)
-
-pkg_files(
-    name = "release_files",
-    srcs = [":all_files"],
-    prefix = package_name(),
     visibility = ["//:__subpackages__"],
 )

--- a/bzllib/private/BUILD.bazel
+++ b/bzllib/private/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 package(default_visibility = ["//bzllib:__subpackages__"])
@@ -11,13 +10,6 @@ bzlformat_pkg(name = "bzlformat")
 filegroup(
     name = "all_files",
     srcs = glob(["*"]),
-    visibility = ["//:__subpackages__"],
-)
-
-pkg_files(
-    name = "release_files",
-    srcs = [":all_files"],
-    prefix = package_name(),
     visibility = ["//:__subpackages__"],
 )
 

--- a/bzlrelease/BUILD.bazel
+++ b/bzlrelease/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 package(default_visibility = ["//visibility:public"])
@@ -30,12 +29,5 @@ bzl_library(
 filegroup(
     name = "all_files",
     srcs = glob(["*"]),
-    visibility = ["//:__subpackages__"],
-)
-
-pkg_files(
-    name = "release_files",
-    srcs = [":all_files"],
-    prefix = package_name(),
     visibility = ["//:__subpackages__"],
 )

--- a/bzlrelease/BUILD.bazel
+++ b/bzlrelease/BUILD.bazel
@@ -20,6 +20,7 @@ bzl_library(
         "//bzlrelease/private:generate_release_notes",
         "//bzlrelease/private:generate_workspace_snippet",
         "//bzlrelease/private:hash_sha256",
+        "//bzlrelease/private:release_archive",
         "//bzlrelease/private:update_readme",
     ],
 )

--- a/bzlrelease/defs.bzl
+++ b/bzlrelease/defs.bzl
@@ -14,6 +14,10 @@ load(
 )
 load("//bzlrelease/private:hash_sha256.bzl", _hash_sha256 = "hash_sha256")
 load(
+    "//bzlrelease/private:release_archive.bzl",
+    _release_archive = "release_archive",
+)
+load(
     "//bzlrelease/private:update_readme.bzl",
     _update_readme = "update_readme",
 )
@@ -27,3 +31,5 @@ generate_release_notes = _generate_release_notes
 hash_sha256 = _hash_sha256
 
 update_readme = _update_readme
+
+release_archive = _release_archive

--- a/bzlrelease/private/BUILD.bazel
+++ b/bzlrelease/private/BUILD.bazel
@@ -57,3 +57,8 @@ bzl_library(
     name = "hash_sha256",
     srcs = ["hash_sha256.bzl"],
 )
+
+bzl_library(
+    name = "release_archive",
+    srcs = ["release_archive.bzl"],
+)

--- a/bzlrelease/private/BUILD.bazel
+++ b/bzlrelease/private/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 package(default_visibility = ["//bzlrelease:__subpackages__"])
@@ -43,13 +42,6 @@ bzl_library(
 filegroup(
     name = "all_files",
     srcs = glob(["*"]),
-    visibility = ["//:__subpackages__"],
-)
-
-pkg_files(
-    name = "release_files",
-    srcs = [":all_files"],
-    prefix = package_name(),
     visibility = ["//:__subpackages__"],
 )
 

--- a/bzlrelease/private/release_archive.bzl
+++ b/bzlrelease/private/release_archive.bzl
@@ -1,0 +1,40 @@
+def _release_archive_impl(ctx):
+    out_basename = ctx.attr.out
+    if out_basename == "":
+        out_basename = "{name}{ext}".format(
+            name = ctx.label.name,
+            ext = ctx.attr.ext,
+        )
+    out = ctx.actions.declare_file(out_basename)
+    args = ctx.actions.args()
+    args.add(out)
+    args.add_all(ctx.files.srcs)
+    ctx.actions.run_shell(
+        outputs = [out],
+        inputs = ctx.files.srcs,
+        arguments = [args],
+        command = """\
+archive="$1"
+shift 1
+tar -Lczvf "$archive" "$@"
+""",
+    )
+    return DefaultInfo(files = depset([out]))
+
+release_archive = rule(
+    implementation = _release_archive_impl,
+    attrs = {
+        "ext": attr.string(
+            default = ".tar.gz",
+            doc = "The extension for the archive.",
+        ),
+        "out": attr.string(
+            doc = "The name of the output file.",
+        ),
+        "srcs": attr.label_list(
+            allow_files = True,
+            mandatory = True,
+        ),
+    },
+    doc = "",
+)

--- a/bzlrelease/private/release_archive.bzl
+++ b/bzlrelease/private/release_archive.bzl
@@ -1,3 +1,5 @@
+"""Definition for `release_archive` rule."""
+
 def _release_archive_impl(ctx):
     out_basename = ctx.attr.out
     if out_basename == "":
@@ -16,10 +18,13 @@ def _release_archive_impl(ctx):
         command = """\
 archive="$1"
 shift 1
-tar -Lczvf "$archive" "$@"
+tar -Lczvf "$archive" "$@" 2>/dev/null
 """,
     )
-    return DefaultInfo(files = depset([out]))
+    return DefaultInfo(
+        files = depset([out]),
+        runfiles = ctx.runfiles(files = [out]),
+    )
 
 release_archive = rule(
     implementation = _release_archive_impl,
@@ -36,5 +41,5 @@ release_archive = rule(
             mandatory = True,
         ),
     },
-    doc = "",
+    doc = "Create a source release archive.",
 )

--- a/bzlrelease/private/release_archive.bzl
+++ b/bzlrelease/private/release_archive.bzl
@@ -41,5 +41,11 @@ release_archive = rule(
             mandatory = True,
         ),
     },
-    doc = "Create a source release archive.",
+    doc = """\
+Create a source release archive.
+
+This rule uses `tar` to collect and compress files into an archive file \
+suitable for use as a release artifact. Any permissions on the source files \
+will be preserved.
+""",
 )

--- a/bzlrelease/private/release_archive.bzl
+++ b/bzlrelease/private/release_archive.bzl
@@ -30,8 +30,7 @@ def _release_archive_impl(ctx):
 archive="$1"
 file_list="$2"
 shift 1
-# tar -Lczvf "$archive" "$@" 2>/dev/null
-tar -Lczvf "$archive" -T "${file_list}" 2>/dev/null
+tar 2>/dev/null -hczvf "$archive" -T "${file_list}"
 """,
     )
     return DefaultInfo(

--- a/bzlrelease/tools/BUILD.bazel
+++ b/bzlrelease/tools/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 bzlformat_pkg(name = "bzlformat")
@@ -113,12 +112,5 @@ sh_binary(
 filegroup(
     name = "all_files",
     srcs = glob(["*"]),
-    visibility = ["//:__subpackages__"],
-)
-
-pkg_files(
-    name = "release_files",
-    srcs = [":all_files"],
-    prefix = package_name(),
     visibility = ["//:__subpackages__"],
 )

--- a/bzlrelease/tools/generate_sha256.sh
+++ b/bzlrelease/tools/generate_sha256.sh
@@ -69,7 +69,8 @@ case "${utility}" in
   openssl)
     function sumsha256() {
       # On Ubuntu, we can see a prefix of '(stdin)= '
-      openssl dgst -sha256 | sed -E 's|^\(stdin\)= (.*)|\1|g'
+      # 2023-02-01:  This has recently changed to be 'SHA2-256(stdin)='.
+      openssl dgst -sha256 | sed -E 's|^.*\(stdin\)= (.*)|\1|g'
     }
     ;;
   *)

--- a/bzltidy/BUILD.bazel
+++ b/bzltidy/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -24,12 +23,5 @@ filegroup(
 filegroup(
     name = "all_files",
     srcs = glob(["*"]),
-    visibility = ["//:__subpackages__"],
-)
-
-pkg_files(
-    name = "release_files",
-    srcs = [":all_files"],
-    prefix = package_name(),
     visibility = ["//:__subpackages__"],
 )

--- a/bzltidy/private/BUILD.bazel
+++ b/bzltidy/private/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 
 exports_files([
     "tidy.sh",
@@ -14,13 +13,6 @@ bzlformat_pkg(name = "bzlformat")
 filegroup(
     name = "all_files",
     srcs = glob(["*"]),
-    visibility = ["//:__subpackages__"],
-)
-
-pkg_files(
-    name = "release_files",
-    srcs = [":all_files"],
-    prefix = package_name(),
     visibility = ["//:__subpackages__"],
 )
 

--- a/deps.bzl
+++ b/deps.bzl
@@ -108,16 +108,6 @@ def bazel_starlib_dependencies(
         ],
     )
 
-    maybe(
-        http_archive,
-        name = "rules_pkg",
-        urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.8.0/rules_pkg-0.8.0.tar.gz",
-            "https://github.com/bazelbuild/rules_pkg/releases/download/0.8.0/rules_pkg-0.8.0.tar.gz",
-        ],
-        sha256 = "eea0f59c28a9241156a47d7a8e32db9122f3d50b505fae0f33de6ce4d9b61834",
-    )
-
     if use_bazeldoc:
         _bazeldoc_dependencies()
 

--- a/doc/bzlrelease/BUILD.bazel
+++ b/doc/bzlrelease/BUILD.bazel
@@ -22,6 +22,7 @@ _RULE_NAMES = [
     "generate_release_notes",
     "generate_workspace_snippet",
     "hash_sha256",
+    "release_archive",
     "update_readme",
 ]
 

--- a/doc/bzlrelease/release_archive.md
+++ b/doc/bzlrelease/release_archive.md
@@ -1,0 +1,28 @@
+<!-- Generated with Stardoc, Do Not Edit! -->
+# `release_archive` Rule
+
+
+<a id="release_archive"></a>
+
+## release_archive
+
+<pre>
+release_archive(<a href="#release_archive-name">name</a>, <a href="#release_archive-ext">ext</a>, <a href="#release_archive-out">out</a>, <a href="#release_archive-srcs">srcs</a>)
+</pre>
+
+Create a source release archive.
+
+This rule uses `tar` to collect and compress files into an archive file suitable for use as a release artifact. Any permissions on the source files will be preserved.
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="release_archive-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="release_archive-ext"></a>ext |  The extension for the archive.   | String | optional | <code>".tar.gz"</code> |
+| <a id="release_archive-out"></a>out |  The name of the output file.   | String | optional | <code>""</code> |
+| <a id="release_archive-srcs"></a>srcs |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
+
+

--- a/doc/bzlrelease/rules.md
+++ b/doc/bzlrelease/rules.md
@@ -7,5 +7,6 @@ The rules listed below are available in this repository.
   * [generate_release_notes](/doc/bzlrelease/generate_release_notes.md)
   * [generate_workspace_snippet](/doc/bzlrelease/generate_workspace_snippet.md)
   * [hash_sha256](/doc/bzlrelease/hash_sha256.md)
+  * [release_archive](/doc/bzlrelease/release_archive.md)
   * [update_readme](/doc/bzlrelease/update_readme.md)
 

--- a/markdown/BUILD.bazel
+++ b/markdown/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 package(default_visibility = ["//visibility:public"])
@@ -9,13 +8,6 @@ bzlformat_pkg(name = "bzlformat")
 filegroup(
     name = "all_files",
     srcs = glob(["*"]),
-    visibility = ["//:__subpackages__"],
-)
-
-pkg_files(
-    name = "release_files",
-    srcs = [":all_files"],
-    prefix = package_name(),
     visibility = ["//:__subpackages__"],
 )
 

--- a/markdown/private/BUILD.bazel
+++ b/markdown/private/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 bzlformat_pkg(name = "bzlformat")
@@ -7,13 +6,6 @@ bzlformat_pkg(name = "bzlformat")
 filegroup(
     name = "all_files",
     srcs = glob(["*"]),
-    visibility = ["//:__subpackages__"],
-)
-
-pkg_files(
-    name = "release_files",
-    srcs = [":all_files"],
-    prefix = package_name(),
     visibility = ["//:__subpackages__"],
 )
 

--- a/markdown/tools/BUILD.bazel
+++ b/markdown/tools/BUILD.bazel
@@ -1,18 +1,10 @@
 load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 
 bzlformat_pkg(name = "bzlformat")
 
 filegroup(
     name = "all_files",
     srcs = glob(["*"]),
-    visibility = ["//:__subpackages__"],
-)
-
-pkg_files(
-    name = "release_files",
-    srcs = [":all_files"],
-    prefix = package_name(),
     visibility = ["//:__subpackages__"],
 )
 

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -41,13 +41,6 @@ create_release(
     workflow_name = "Create Release",
 )
 
-# pkg_tar(
-#     name = "archive",
-#     srcs = ["//:release_filegroup"],
-#     out = "bazel-starlib.tar.gz",
-#     extension = ".tar.gz",
-# )
-
 release_archive(
     name = "archive",
     srcs = ["//:local_repository_files"],

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//bzlformat:defs.bzl", "bzlformat_pkg")
 load(
     "//bzlrelease:defs.bzl",
@@ -7,6 +6,7 @@ load(
     "generate_release_notes",
     "generate_workspace_snippet",
     "hash_sha256",
+    "release_archive",
     "update_readme",
 )
 
@@ -41,11 +41,17 @@ create_release(
     workflow_name = "Create Release",
 )
 
-pkg_tar(
+# pkg_tar(
+#     name = "archive",
+#     srcs = ["//:release_filegroup"],
+#     out = "bazel-starlib.tar.gz",
+#     extension = ".tar.gz",
+# )
+
+release_archive(
     name = "archive",
-    srcs = ["//:release_filegroup"],
+    srcs = ["//:local_repository_files"],
     out = "bazel-starlib.tar.gz",
-    extension = ".tar.gz",
 )
 
 hash_sha256(

--- a/shlib/lib/BUILD.bazel
+++ b/shlib/lib/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 package(default_visibility = ["//visibility:public"])
@@ -60,12 +59,5 @@ sh_library(
 filegroup(
     name = "all_files",
     srcs = glob(["*"]),
-    visibility = ["//:__subpackages__"],
-)
-
-pkg_files(
-    name = "release_files",
-    srcs = [":all_files"],
-    prefix = package_name(),
     visibility = ["//:__subpackages__"],
 )

--- a/shlib/rules/BUILD.bazel
+++ b/shlib/rules/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 package(default_visibility = ["//visibility:public"])
@@ -28,12 +27,5 @@ bzl_library(
 filegroup(
     name = "all_files",
     srcs = glob(["*"]),
-    visibility = ["//:__subpackages__"],
-)
-
-pkg_files(
-    name = "release_files",
-    srcs = [":all_files"],
-    prefix = package_name(),
     visibility = ["//:__subpackages__"],
 )

--- a/shlib/rules/private/BUILD.bazel
+++ b/shlib/rules/private/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 package(default_visibility = ["//shlib/rules:__pkg__"])
@@ -37,12 +36,5 @@ bzl_library(
 filegroup(
     name = "all_files",
     srcs = glob(["*"]),
-    visibility = ["//:__subpackages__"],
-)
-
-pkg_files(
-    name = "release_files",
-    srcs = [":all_files"],
-    prefix = package_name(),
     visibility = ["//:__subpackages__"],
 )

--- a/shlib/tools/BUILD.bazel
+++ b/shlib/tools/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 bzlformat_pkg(name = "bzlformat")
@@ -17,12 +16,5 @@ sh_binary(
 filegroup(
     name = "all_files",
     srcs = glob(["*"]),
-    visibility = ["//:__subpackages__"],
-)
-
-pkg_files(
-    name = "release_files",
-    srcs = [":all_files"],
-    prefix = package_name(),
     visibility = ["//:__subpackages__"],
 )

--- a/tests/bzlrelease_tests/rules_tests/generate_workspace_snippet_tests/BUILD.bazel
+++ b/tests/bzlrelease_tests/rules_tests/generate_workspace_snippet_tests/BUILD.bazel
@@ -1,7 +1,6 @@
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//bzlformat:defs.bzl", "bzlformat_pkg")
-load("//bzlrelease:defs.bzl", "generate_workspace_snippet", "hash_sha256")
+load("//bzlrelease:defs.bzl", "generate_workspace_snippet", "hash_sha256", "release_archive")
 load("//tests:integration_test_common.bzl", "GH_ENV_INHERIT", "INTEGRATION_TEST_TAGS")
 
 bzlformat_pkg(name = "bzlformat")
@@ -21,7 +20,7 @@ write_file(
     content = ["Hello, World!"],
 )
 
-pkg_tar(
+release_archive(
     name = "archive",
     srcs = [":src_file"],
 )

--- a/tests/bzlrelease_tests/rules_tests/release_artifact_tests/BUILD.bazel
+++ b/tests/bzlrelease_tests/rules_tests/release_artifact_tests/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
+load("//bzlrelease:defs.bzl", "release_archive")
+
+bzlformat_pkg(name = "bzlformat")
+
+release_archive(
+    name = "archive",
+    srcs = [
+        "//bzlrelease:all_files",
+        "//bzlrelease/private:all_files",
+        "//bzlrelease/tools:all_files",
+    ],
+)
+
+sh_test(
+    name = "archive_test",
+    srcs = ["archive_test.sh"],
+    data = [":archive"],
+    deps = [
+        "@bazel_tools//tools/bash/runfiles",
+        "@cgrindel_bazel_starlib//shlib/lib:assertions",
+    ],
+)

--- a/tests/bzlrelease_tests/rules_tests/release_artifact_tests/archive_test.sh
+++ b/tests/bzlrelease_tests/rules_tests/release_artifact_tests/archive_test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -o nounset -o pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+# shellcheck disable=SC1090
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -o errexit
+# --- end runfiles.bash initialization v2 ---
+
+# MARK - Locate Deps
+
+assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
+assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+  (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
+source "${assertions_sh}"
+
+archive_tar_gz_location=cgrindel_bazel_starlib/tests/bzlrelease_tests/rules_tests/release_artifact_tests/archive.tar.gz
+archive_tar_gz="$(rlocation "${archive_tar_gz_location}")" || \
+  (echo >&2 "Failed to locate ${archive_tar_gz_location}" && exit 1)
+
+# MARK - Test
+
+contents="$(tar -tf "${archive_tar_gz}")"
+assert_match "bzlrelease/" "${contents}" 
+assert_match "bzlrelease/private/" "${contents}" 
+assert_match "bzlrelease/tools/" "${contents}" 

--- a/updatesrc/BUILD.bazel
+++ b/updatesrc/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 package(default_visibility = ["//visibility:public"])
@@ -28,12 +27,5 @@ bzl_library(
 filegroup(
     name = "all_files",
     srcs = glob(["*"]),
-    visibility = ["//:__subpackages__"],
-)
-
-pkg_files(
-    name = "release_files",
-    srcs = [":all_files"],
-    prefix = package_name(),
     visibility = ["//:__subpackages__"],
 )

--- a/updatesrc/private/BUILD.bazel
+++ b/updatesrc/private/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
 package(default_visibility = ["//updatesrc:__subpackages__"])
@@ -31,13 +30,6 @@ bzl_library(
 filegroup(
     name = "all_files",
     srcs = glob(["*"]),
-    visibility = ["//:__subpackages__"],
-)
-
-pkg_files(
-    name = "release_files",
-    srcs = [":all_files"],
-    prefix = package_name(),
     visibility = ["//:__subpackages__"],
 )
 


### PR DESCRIPTION
- The `release_archive` rule produces an archive file that preserves the permissions on the provided files. The `pkg_tar` rule does not.
- Remove `rules_pkg`.
- Update `bazel-starlib` release to use `release_archive`.

Related to #200.