### PR TITLE
fix: add links to `bzltidy` documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ the implementation of Bazel projects.
 | bzlformat | Format Bazel Starlark files using [Buildifier](https://github.com/bazelbuild/buildtools/tree/master/buildifier), test that the formatted files exist in the workspace directory, and copy formatted files to the workspace directory. Formerly hosted as [rules_bzlformat](https://github.com/cgrindel/rules_bzlformat). | [API](/doc/bzlformat/), [How-to](/bzlformat/), [Examples](/examples/bzlformat/) |
 | bzllib | Collection of Starlark libraries. | [API](/doc/bzllib/), [How-to](/bzllib/) |
 | bzlrelease | Automate and customize the generation of releases using GitHub Actions. | [API](/doc/bzlrelease/), [How-to](/bzlrelease/) |
-| bzltidy | Collect Bazel actions that keep your source files up-to-date. | [API](/doc/bztidy/, [How-to](/bzltidy/)) |
+| bzltidy | Collect Bazel actions that keep your source files up-to-date. | [API](/doc/bztidy/), [How-to](/bzltidy/) |
 | markdown | Maintain markdown files. | [API](/doc/markdown/), [How-to](/markdown/), [Examples](/examples/markdown/) |
 | shlib | Collection of libraries useful when implementing shell binaries, libraries, and tests. Formerly hosted as [bazel_shlib](https://github.com/cgrindel/bazel_shlib). | [API](/doc/shlib/), [How-to](/shlib/) |
 | updatesrc | Copy files from the Bazel output directories to the workspace directory. Formerly hosted as [rules_updatesrc](https://github.com/cgrindel/rules_updatesrc) | [API](/doc/updatesrc/), [How-to](/updatesrc/), [Examples](/examples/updatesrc/) |

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ the implementation of Bazel projects.
 | bzlformat | Format Bazel Starlark files using [Buildifier](https://github.com/bazelbuild/buildtools/tree/master/buildifier), test that the formatted files exist in the workspace directory, and copy formatted files to the workspace directory. Formerly hosted as [rules_bzlformat](https://github.com/cgrindel/rules_bzlformat). | [API](/doc/bzlformat/), [How-to](/bzlformat/), [Examples](/examples/bzlformat/) |
 | bzllib | Collection of Starlark libraries. | [API](/doc/bzllib/), [How-to](/bzllib/) |
 | bzlrelease | Automate and customize the generation of releases using GitHub Actions. | [API](/doc/bzlrelease/), [How-to](/bzlrelease/) |
+| bzltidy | Collect Bazel actions that keep your source files up-to-date. | [API](/doc/bztidy/) |
 | markdown | Maintain markdown files. | [API](/doc/markdown/), [How-to](/markdown/), [Examples](/examples/markdown/) |
 | shlib | Collection of libraries useful when implementing shell binaries, libraries, and tests. Formerly hosted as [bazel_shlib](https://github.com/cgrindel/bazel_shlib). | [API](/doc/shlib/), [How-to](/shlib/) |
 | updatesrc | Copy files from the Bazel output directories to the workspace directory. Formerly hosted as [rules_updatesrc](https://github.com/cgrindel/rules_updatesrc) | [API](/doc/updatesrc/), [How-to](/updatesrc/), [Examples](/examples/updatesrc/) |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ the implementation of Bazel projects.
 | bzlformat | Format Bazel Starlark files using [Buildifier](https://github.com/bazelbuild/buildtools/tree/master/buildifier), test that the formatted files exist in the workspace directory, and copy formatted files to the workspace directory. Formerly hosted as [rules_bzlformat](https://github.com/cgrindel/rules_bzlformat). | [API](/doc/bzlformat/), [How-to](/bzlformat/), [Examples](/examples/bzlformat/) |
 | bzllib | Collection of Starlark libraries. | [API](/doc/bzllib/), [How-to](/bzllib/) |
 | bzlrelease | Automate and customize the generation of releases using GitHub Actions. | [API](/doc/bzlrelease/), [How-to](/bzlrelease/) |
-| bzltidy | Collect Bazel actions that keep your source files up-to-date. | [API](/doc/bztidy/) |
+| bzltidy | Collect Bazel actions that keep your source files up-to-date. | [API](/doc/bztidy/, [How-to](/bzltidy/)) |
 | markdown | Maintain markdown files. | [API](/doc/markdown/), [How-to](/markdown/), [Examples](/examples/markdown/) |
 | shlib | Collection of libraries useful when implementing shell binaries, libraries, and tests. Formerly hosted as [bazel_shlib](https://github.com/cgrindel/bazel_shlib). | [API](/doc/shlib/), [How-to](/shlib/) |
 | updatesrc | Copy files from the Bazel output directories to the workspace directory. Formerly hosted as [rules_updatesrc](https://github.com/cgrindel/rules_updatesrc) | [API](/doc/updatesrc/), [How-to](/updatesrc/), [Examples](/examples/updatesrc/) |

--- a/doc/README.md
+++ b/doc/README.md
@@ -6,6 +6,7 @@
 | bzlformat | Format Bazel Starlark files using [Buildifier](https://github.com/bazelbuild/buildtools/tree/master/buildifier), test that the formatted files exist in the workspace directory, and copy formatted files to the workspace directory. Formerly hosted as [rules_bzlformat](https://github.com/cgrindel/rules_bzlformat). | [API](/doc/bzlformat/), [How-to](/bzlformat/), [Examples](/examples/bzlformat/) |
 | bzllib | Collection of Starlark libraries. | [API](/doc/bzllib/), [How-to](/bzllib/) |
 | bzlrelease | Automate and customize the generation of releases using GitHub Actions. | [API](/doc/bzlrelease/) |
+| bzltidy | Collect Bazel actions that keep your source files up-to-date. | [API](/doc/bztidy/) |
 | shlib | Collection of libraries useful when implementing shell binaries, libraries, and tests. Formerly hosted as [bazel_shlib](https://github.com/cgrindel/bazel_shlib). | [API](/doc/shlib/), [How-to](/shlib/) |
 | updatesrc | Copy files from the Bazel output directories to the workspace directory. Formerly hosted as [rules_updatesrc](https://github.com/cgrindel/rules_updatesrc) | [API](/doc/updatesrc/), [How-to](/updatesrc/), [Examples](/examples/updatesrc/) |
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -6,7 +6,7 @@
 | bzlformat | Format Bazel Starlark files using [Buildifier](https://github.com/bazelbuild/buildtools/tree/master/buildifier), test that the formatted files exist in the workspace directory, and copy formatted files to the workspace directory. Formerly hosted as [rules_bzlformat](https://github.com/cgrindel/rules_bzlformat). | [API](/doc/bzlformat/), [How-to](/bzlformat/), [Examples](/examples/bzlformat/) |
 | bzllib | Collection of Starlark libraries. | [API](/doc/bzllib/), [How-to](/bzllib/) |
 | bzlrelease | Automate and customize the generation of releases using GitHub Actions. | [API](/doc/bzlrelease/) |
-| bzltidy | Collect Bazel actions that keep your source files up-to-date. | [API](/doc/bztidy/) |
+| bzltidy | Collect Bazel actions that keep your source files up-to-date. | [API](/doc/bztidy/, [How-to](/bzltidy/)) |
 | shlib | Collection of libraries useful when implementing shell binaries, libraries, and tests. Formerly hosted as [bazel_shlib](https://github.com/cgrindel/bazel_shlib). | [API](/doc/shlib/), [How-to](/shlib/) |
 | updatesrc | Copy files from the Bazel output directories to the workspace directory. Formerly hosted as [rules_updatesrc](https://github.com/cgrindel/rules_updatesrc) | [API](/doc/updatesrc/), [How-to](/updatesrc/), [Examples](/examples/updatesrc/) |
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -6,7 +6,7 @@
 | bzlformat | Format Bazel Starlark files using [Buildifier](https://github.com/bazelbuild/buildtools/tree/master/buildifier), test that the formatted files exist in the workspace directory, and copy formatted files to the workspace directory. Formerly hosted as [rules_bzlformat](https://github.com/cgrindel/rules_bzlformat). | [API](/doc/bzlformat/), [How-to](/bzlformat/), [Examples](/examples/bzlformat/) |
 | bzllib | Collection of Starlark libraries. | [API](/doc/bzllib/), [How-to](/bzllib/) |
 | bzlrelease | Automate and customize the generation of releases using GitHub Actions. | [API](/doc/bzlrelease/) |
-| bzltidy | Collect Bazel actions that keep your source files up-to-date. | [API](/doc/bztidy/, [How-to](/bzltidy/)) |
+| bzltidy | Collect Bazel actions that keep your source files up-to-date. | [API](/doc/bztidy/), [How-to](/bzltidy/) |
 | shlib | Collection of libraries useful when implementing shell binaries, libraries, and tests. Formerly hosted as [bazel_shlib](https://github.com/cgrindel/bazel_shlib). | [API](/doc/shlib/), [How-to](/shlib/) |
 | updatesrc | Copy files from the Bazel output directories to the workspace directory. Formerly hosted as [rules_updatesrc](https://github.com/cgrindel/rules_updatesrc) | [API](/doc/updatesrc/), [How-to](/updatesrc/), [Examples](/examples/updatesrc/) |
 

--- a/release/README.md
+++ b/release/README.md
@@ -19,10 +19,11 @@ This will launch the [release workflow](.github/workflows/create_release.yml). T
 the following steps:
 
 1. Creates the specified tag at the HEAD of the main branch.
-2. Generates release notes.
-3. Creates a GitHub release.
-4. Updates the `README.md` with the latest workspace snippet information.
-5. Creates a PR with the updated `README.md` configured to auto-merge if all the checks pass.
+2. Builds a release archive.
+3. Generates release notes.
+4. Creates a GitHub release.
+5. Updates the `README.md` with the latest workspace snippet information.
+6. Creates a PR with the updated `README.md` configured to auto-merge if all the checks pass.
 
 There are two ways that this process could fail. First, if an improperly formatted release tag is
 specified, the release workflow will fail. Be sure to prefix the release tag with `v`. Second, the


### PR DESCRIPTION
- Add TOC entries for `bzltidy`.
- Update release doc mentioning the creation of the release archive.
