### PR TITLE
chore: introduce strict bzlmod by adding `WORKSPACE.bzlmod`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,16 @@ jobs:
       fail-fast: false
       matrix:
         runner: [macos-12, ubuntu-22.04]
+        enable_bzlmod: [true, false]
     runs-on: ${{ matrix.runner }}
     steps:
     - uses: actions/checkout@v3
     - uses: cgrindel/gha_set_up_bazel@v1
       with:
         repo_name: bazel-starlib
+    - uses: ./.github/actions/configure_bzlmod
+      with:
+        enabled: ${{ matrix.enable_bzlmod }}
     - uses: ./.github/actions/tidy_and_test
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,6 +17,7 @@ bazel_dep(
 bazel_dep(
     name = "gazelle",
     version = "0.29.0",
+    repo_name = "bazel_gazelle",
 )
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(
@@ -28,8 +29,13 @@ bazel_dep(
     name = "buildifier_prebuilt",
     version = "6.0.0.1",
 )
+bazel_dep(name = "platforms", version = "0.0.6")
 
-go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.download(name = "go_sdk")
+use_repo(go_sdk, "go_sdk")
+
+go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
 
 # NOTE: We are not loading the Go modules from go.mod, because we are doing
 # something a little weird in that we are building an executable from another

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,3 +1,6 @@
+# This file marks the root of the Bazel workspace.
+# See MODULE.bazel for dependencies and setup.
+
 workspace(name = "cgrindel_bazel_starlib")
 
 load("//:deps.bzl", "bazel_starlib_dependencies")

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -1,0 +1,23 @@
+# workspace(name = "cgrindel_bazel_starlib")
+
+# MARK: - Integration Testing
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "contrib_rules_bazel_integration_test",
+    sha256 = "6263b8d85a125e1877c463bf4d692bebc2b6479c924f64a3d45c81fbfbc495df",
+    strip_prefix = "rules_bazel_integration_test-0.10.3",
+    urls = [
+        "http://github.com/bazel-contrib/rules_bazel_integration_test/archive/v0.10.3.tar.gz",
+    ],
+)
+
+load("@contrib_rules_bazel_integration_test//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
+
+bazel_integration_test_rules_dependencies()
+
+load("@contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl", "bazel_binaries")
+load("//:bazel_versions.bzl", "SUPPORTED_BAZEL_VERSIONS")
+
+bazel_binaries(versions = SUPPORTED_BAZEL_VERSIONS)

--- a/doc/bazeldoc/BUILD.bazel
+++ b/doc/bazeldoc/BUILD.bazel
@@ -1,115 +1,117 @@
-load(
-    "//bazeldoc:defs.bzl",
-    "doc_for_provs",
-    "write_file_list",
-    "write_header",
-    doc_providers = "providers",
-)
-load("//bzlformat:defs.bzl", "bzlformat_pkg")
+# GH195: Enable once stardoc supports repo mapping.
 
-bzlformat_pkg(name = "bzlformat")
+# load(
+#     "//bazeldoc:defs.bzl",
+#     "doc_for_provs",
+#     "write_file_list",
+#     "write_header",
+#     doc_providers = "providers",
+# )
+# load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
-filegroup(
-    name = "doc_files",
-    srcs = glob(["*.md"]) + [
-        # A doc file has a reference to this file.
-        "BUILD.bazel",
-    ],
-    visibility = ["//:markdown_test_visibility"],
-)
+# bzlformat_pkg(name = "bzlformat")
 
-# Lovingly inspired by
-# https://github.com/bazelbuild/rules_swift/blob/021c11b1d578ffba547140eb24854cdfe74c794f/doc/BUILD.bazel#L3
+# filegroup(
+#     name = "doc_files",
+#     srcs = glob(["*.md"]) + [
+#         # A doc file has a reference to this file.
+#         "BUILD.bazel",
+#     ],
+#     visibility = ["//:markdown_test_visibility"],
+# )
 
-# MARK: - Documentation Declarations
+# # Lovingly inspired by
+# # https://github.com/bazelbuild/rules_swift/blob/021c11b1d578ffba547140eb24854cdfe74c794f/doc/BUILD.bazel#L3
 
-_API_SRCS = [
-    "doc_utilities",
-    "providers",
-]
+# # MARK: - Documentation Declarations
 
-_STARDOC_INPUT = "//bazeldoc:defs.bzl"
+# _API_SRCS = [
+#     "doc_utilities",
+#     "providers",
+# ]
 
-_DOC_DEPS = [
-    "//bazeldoc:defs",
-]
+# _STARDOC_INPUT = "//bazeldoc:defs.bzl"
 
-_API_DOC_PROVIDERS = [
-    doc_providers.create(
-        name = name,
-        stardoc_input = _STARDOC_INPUT,
-        symbols = [name],
-        deps = _DOC_DEPS,
-    )
-    for name in _API_SRCS
-]
+# _DOC_DEPS = [
+#     "//bazeldoc:defs",
+# ]
 
-_BUILD_RULES_PROV = doc_providers.create(
-    name = "build_rules_overview",
-    stardoc_input = _STARDOC_INPUT,
-    symbols = [
-        "doc_for_provs",
-        "stardoc_for_prov",
-        "stardoc_for_provs",
-        "write_doc",
-        "write_file_list",
-        "write_header",
-    ],
-    deps = _DOC_DEPS,
-)
+# _API_DOC_PROVIDERS = [
+#     doc_providers.create(
+#         name = name,
+#         stardoc_input = _STARDOC_INPUT,
+#         symbols = [name],
+#         deps = _DOC_DEPS,
+#     )
+#     for name in _API_SRCS
+# ]
 
-_ALL_DOC_PROVIDERS = [
-    _BUILD_RULES_PROV,
-    doc_providers.create(
-        name = "api",
-        is_stardoc = False,
-        stardoc_input = _STARDOC_INPUT,
-        deps = _DOC_DEPS,
-    ),
-] + _API_DOC_PROVIDERS
+# _BUILD_RULES_PROV = doc_providers.create(
+#     name = "build_rules_overview",
+#     stardoc_input = _STARDOC_INPUT,
+#     symbols = [
+#         "doc_for_provs",
+#         "stardoc_for_prov",
+#         "stardoc_for_provs",
+#         "write_doc",
+#         "write_file_list",
+#         "write_header",
+#     ],
+#     deps = _DOC_DEPS,
+# )
 
-# MARK: - Special Case api.md
+# _ALL_DOC_PROVIDERS = [
+#     _BUILD_RULES_PROV,
+#     doc_providers.create(
+#         name = "api",
+#         is_stardoc = False,
+#         stardoc_input = _STARDOC_INPUT,
+#         deps = _DOC_DEPS,
+#     ),
+# ] + _API_DOC_PROVIDERS
 
-write_file_list(
-    name = "api_doc",
-    out = "api.md_",
-    doc_provs = _API_DOC_PROVIDERS,
-    header_content = [
-        "# Documentation API",
-        "",
-        "The APIs described below are used by ",
-        "[the build rules](build_rules_overview.md) to facilitate the ",
-        "generation of the Starlark documentation.",
-        "",
-    ],
-)
+# # MARK: - Special Case api.md
 
-# MARK: - Headers
+# write_file_list(
+#     name = "api_doc",
+#     out = "api.md_",
+#     doc_provs = _API_DOC_PROVIDERS,
+#     header_content = [
+#         "# Documentation API",
+#         "",
+#         "The APIs described below are used by ",
+#         "[the build rules](build_rules_overview.md) to facilitate the ",
+#         "generation of the Starlark documentation.",
+#         "",
+#     ],
+# )
 
-write_header(
-    name = "build_rules_overview_header",
-    header_content = [
-        "# Build Rules",
-        "",
-        "The macros described below are used to generate, test and copy ",
-        "Starlark documentation.",
-    ],
-    symbols = _BUILD_RULES_PROV.symbols,
-)
+# # MARK: - Headers
 
-# Write the API headers
-[
-    write_header(
-        name = doc_prov.header_label,
-        out = doc_prov.header_basename,
-        header_content = [
-            "# `{name}` API".format(name = doc_prov.name),
-        ],
-    )
-    for doc_prov in _API_DOC_PROVIDERS
-    if doc_prov.is_stardoc
-]
+# write_header(
+#     name = "build_rules_overview_header",
+#     header_content = [
+#         "# Build Rules",
+#         "",
+#         "The macros described below are used to generate, test and copy ",
+#         "Starlark documentation.",
+#     ],
+#     symbols = _BUILD_RULES_PROV.symbols,
+# )
 
-doc_for_provs(
-    doc_provs = _ALL_DOC_PROVIDERS,
-)
+# # Write the API headers
+# [
+#     write_header(
+#         name = doc_prov.header_label,
+#         out = doc_prov.header_basename,
+#         header_content = [
+#             "# `{name}` API".format(name = doc_prov.name),
+#         ],
+#     )
+#     for doc_prov in _API_DOC_PROVIDERS
+#     if doc_prov.is_stardoc
+# ]
+
+# doc_for_provs(
+#     doc_provs = _ALL_DOC_PROVIDERS,
+# )

--- a/doc/bzlformat/BUILD.bazel
+++ b/doc/bzlformat/BUILD.bazel
@@ -1,59 +1,61 @@
-load(
-    "//bazeldoc:defs.bzl",
-    "doc_for_provs",
-    "write_header",
-    doc_providers = "providers",
-)
-load("//bzlformat:defs.bzl", "bzlformat_pkg")
+# GH195: Enable once stardoc supports repo mapping.
 
-bzlformat_pkg(name = "bzlformat")
+# load(
+#     "//bazeldoc:defs.bzl",
+#     "doc_for_provs",
+#     "write_header",
+#     doc_providers = "providers",
+# )
+# load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
-filegroup(
-    name = "doc_files",
-    srcs = glob(["*.md"]) + [
-        # A doc file has a reference to this file.
-        "BUILD.bazel",
-    ],
-    visibility = ["//:markdown_test_visibility"],
-)
+# bzlformat_pkg(name = "bzlformat")
 
-# MARK: - Documentation Providers
+# filegroup(
+#     name = "doc_files",
+#     srcs = glob(["*.md"]) + [
+#         # A doc file has a reference to this file.
+#         "BUILD.bazel",
+#     ],
+#     visibility = ["//:markdown_test_visibility"],
+# )
 
-_STARDOC_INPUT = "//bzlformat:defs.bzl"
+# # MARK: - Documentation Providers
 
-_DOC_DEPS = ["//bzlformat:defs"]
+# _STARDOC_INPUT = "//bzlformat:defs.bzl"
 
-_RULES_AND_MACROS_DOC_PROVIDER = doc_providers.create(
-    name = "rules_and_macros_overview",
-    stardoc_input = _STARDOC_INPUT,
-    symbols = [
-        "bzlformat_format",
-        "bzlformat_pkg",
-        "bzlformat_missing_pkgs",
-        "bzlformat_lint_test",
-    ],
-    deps = _DOC_DEPS,
-)
+# _DOC_DEPS = ["//bzlformat:defs"]
 
-_ALL_DOC_PROVIDERS = [
-    _RULES_AND_MACROS_DOC_PROVIDER,
-]
+# _RULES_AND_MACROS_DOC_PROVIDER = doc_providers.create(
+#     name = "rules_and_macros_overview",
+#     stardoc_input = _STARDOC_INPUT,
+#     symbols = [
+#         "bzlformat_format",
+#         "bzlformat_pkg",
+#         "bzlformat_missing_pkgs",
+#         "bzlformat_lint_test",
+#     ],
+#     deps = _DOC_DEPS,
+# )
 
-# MARK: - Headers
+# _ALL_DOC_PROVIDERS = [
+#     _RULES_AND_MACROS_DOC_PROVIDER,
+# ]
 
-write_header(
-    name = _RULES_AND_MACROS_DOC_PROVIDER.header_label,
-    header_content = [
-        "# Rules and Macros",
-        "",
-        "The rules and macros described below are used to format, test and ",
-        "copy Starlark source files.",
-    ],
-    symbols = _RULES_AND_MACROS_DOC_PROVIDER.symbols,
-)
+# # MARK: - Headers
 
-# MARK: - Generate Documentation from Providers
+# write_header(
+#     name = _RULES_AND_MACROS_DOC_PROVIDER.header_label,
+#     header_content = [
+#         "# Rules and Macros",
+#         "",
+#         "The rules and macros described below are used to format, test and ",
+#         "copy Starlark source files.",
+#     ],
+#     symbols = _RULES_AND_MACROS_DOC_PROVIDER.symbols,
+# )
 
-doc_for_provs(
-    doc_provs = _ALL_DOC_PROVIDERS,
-)
+# # MARK: - Generate Documentation from Providers
+
+# doc_for_provs(
+#     doc_provs = _ALL_DOC_PROVIDERS,
+# )

--- a/doc/bzllib/BUILD.bazel
+++ b/doc/bzllib/BUILD.bazel
@@ -1,131 +1,133 @@
-load(
-    "//bazeldoc:defs.bzl",
-    "doc_for_provs",
-    "write_file_list",
-    "write_header",
-    doc_providers = "providers",
-)
-load("//bzlformat:defs.bzl", "bzlformat_pkg")
+# GH195: Enable once stardoc supports repo mapping.
 
-bzlformat_pkg(name = "bzlformat")
+# load(
+#     "//bazeldoc:defs.bzl",
+#     "doc_for_provs",
+#     "write_file_list",
+#     "write_header",
+#     doc_providers = "providers",
+# )
+# load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
-filegroup(
-    name = "doc_files",
-    srcs = glob(["*.md"]),
-    visibility = ["//:markdown_test_visibility"],
-)
+# bzlformat_pkg(name = "bzlformat")
 
-# MARK: - Documentation Providers
+# filegroup(
+#     name = "doc_files",
+#     srcs = glob(["*.md"]),
+#     visibility = ["//:markdown_test_visibility"],
+# )
 
-_STARDOC_INPUT = "//bzllib:defs.bzl"
+# # MARK: - Documentation Providers
 
-_DOC_DEPS = [
-    "//bzllib:defs",
-]
+# _STARDOC_INPUT = "//bzllib:defs.bzl"
 
-_RULE_NAMES = [
-    "filter_srcs",
-]
+# _DOC_DEPS = [
+#     "//bzllib:defs",
+# ]
 
-_RULE_DOC_PROVIDERS = [
-    doc_providers.create(
-        name = rule,
-        stardoc_input = _STARDOC_INPUT,
-        symbols = [rule],
-        deps = _DOC_DEPS,
-    )
-    for rule in _RULE_NAMES
-]
+# _RULE_NAMES = [
+#     "filter_srcs",
+# ]
 
-_API_SRCS = [
-    "bazel_labels",
-    "lists",
-    "src_utils",
-]
+# _RULE_DOC_PROVIDERS = [
+#     doc_providers.create(
+#         name = rule,
+#         stardoc_input = _STARDOC_INPUT,
+#         symbols = [rule],
+#         deps = _DOC_DEPS,
+#     )
+#     for rule in _RULE_NAMES
+# ]
 
-_API_DOC_PROVIDERS = [
-    doc_providers.create(
-        name = name,
-        stardoc_input = _STARDOC_INPUT,
-        symbols = [name],
-        deps = _DOC_DEPS,
-    )
-    for name in _API_SRCS
-]
+# _API_SRCS = [
+#     "bazel_labels",
+#     "lists",
+#     "src_utils",
+# ]
 
-_ALL_DOC_PROVIDERS = [
-    doc_providers.create(
-        name = "api",
-        is_stardoc = False,
-        stardoc_input = "",
-        deps = [],
-    ),
-    doc_providers.create(
-        name = "rules",
-        is_stardoc = False,
-        stardoc_input = "",
-        deps = [],
-    ),
-] + _RULE_DOC_PROVIDERS + _API_DOC_PROVIDERS
+# _API_DOC_PROVIDERS = [
+#     doc_providers.create(
+#         name = name,
+#         stardoc_input = _STARDOC_INPUT,
+#         symbols = [name],
+#         deps = _DOC_DEPS,
+#     )
+#     for name in _API_SRCS
+# ]
 
-# MARK: - Headers
+# _ALL_DOC_PROVIDERS = [
+#     doc_providers.create(
+#         name = "api",
+#         is_stardoc = False,
+#         stardoc_input = "",
+#         deps = [],
+#     ),
+#     doc_providers.create(
+#         name = "rules",
+#         is_stardoc = False,
+#         stardoc_input = "",
+#         deps = [],
+#     ),
+# ] + _RULE_DOC_PROVIDERS + _API_DOC_PROVIDERS
 
-# Write rule headers
-[
-    write_header(
-        name = doc_prov.header_label,
-        out = doc_prov.header_basename,
-        header_content = [
-            "# `{name}` Rule".format(name = doc_prov.name),
-        ],
-    )
-    for doc_prov in _RULE_DOC_PROVIDERS
-    if doc_prov.is_stardoc
-]
+# # MARK: - Headers
 
-# Write the API headers
-[
-    write_header(
-        name = doc_prov.header_label,
-        out = doc_prov.header_basename,
-        header_content = [
-            "# `{name}` API".format(name = doc_prov.name),
-        ],
-    )
-    for doc_prov in _API_DOC_PROVIDERS
-    if doc_prov.is_stardoc
-]
+# # Write rule headers
+# [
+#     write_header(
+#         name = doc_prov.header_label,
+#         out = doc_prov.header_basename,
+#         header_content = [
+#             "# `{name}` Rule".format(name = doc_prov.name),
+#         ],
+#     )
+#     for doc_prov in _RULE_DOC_PROVIDERS
+#     if doc_prov.is_stardoc
+# ]
 
-# MARK: - Special Case api.md
+# # Write the API headers
+# [
+#     write_header(
+#         name = doc_prov.header_label,
+#         out = doc_prov.header_basename,
+#         header_content = [
+#             "# `{name}` API".format(name = doc_prov.name),
+#         ],
+#     )
+#     for doc_prov in _API_DOC_PROVIDERS
+#     if doc_prov.is_stardoc
+# ]
 
-# Write the api.md_ file as a special case.
-write_file_list(
-    name = "api_doc",
-    out = "api.md_",
-    doc_provs = _API_DOC_PROVIDERS,
-    header_content = [
-        "# Build API",
-        "",
-        "The APIs listed below are available in this repository.",
-        "",
-    ],
-)
+# # MARK: - Special Case api.md
 
-# Write the rules.md_ file as a special case.
-write_file_list(
-    name = "rules_doc",
-    out = "rules.md_",
-    doc_provs = _RULE_DOC_PROVIDERS,
-    header_content = [
-        "# Rules",
-        "",
-        "The rules listed below are available in this repository.",
-        "",
-    ],
-)
+# # Write the api.md_ file as a special case.
+# write_file_list(
+#     name = "api_doc",
+#     out = "api.md_",
+#     doc_provs = _API_DOC_PROVIDERS,
+#     header_content = [
+#         "# Build API",
+#         "",
+#         "The APIs listed below are available in this repository.",
+#         "",
+#     ],
+# )
 
-# MARK: - Generate Documentation from Providers
+# # Write the rules.md_ file as a special case.
+# write_file_list(
+#     name = "rules_doc",
+#     out = "rules.md_",
+#     doc_provs = _RULE_DOC_PROVIDERS,
+#     header_content = [
+#         "# Rules",
+#         "",
+#         "The rules listed below are available in this repository.",
+#         "",
+#     ],
+# )
 
-doc_for_provs(
-    doc_provs = _ALL_DOC_PROVIDERS,
-)
+# # MARK: - Generate Documentation from Providers
+
+# doc_for_provs(
+#     doc_provs = _ALL_DOC_PROVIDERS,
+# )

--- a/doc/bzlrelease/BUILD.bazel
+++ b/doc/bzlrelease/BUILD.bazel
@@ -1,116 +1,118 @@
-load(
-    "//bazeldoc:defs.bzl",
-    "doc_for_provs",
-    "write_file_list",
-    "write_header",
-    doc_providers = "providers",
-)
-load("//bzlformat:defs.bzl", "bzlformat_pkg")
+# GH195: Enable once stardoc supports repo mapping.
 
-bzlformat_pkg(name = "bzlformat")
+# load(
+#     "//bazeldoc:defs.bzl",
+#     "doc_for_provs",
+#     "write_file_list",
+#     "write_header",
+#     doc_providers = "providers",
+# )
+# load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
-filegroup(
-    name = "doc_files",
-    srcs = glob(["*.md"]),
-    visibility = ["//:markdown_test_visibility"],
-)
+# bzlformat_pkg(name = "bzlformat")
 
-# MARK: - Documentation Providers
+# filegroup(
+#     name = "doc_files",
+#     srcs = glob(["*.md"]),
+#     visibility = ["//:markdown_test_visibility"],
+# )
 
-_RULE_NAMES = [
-    "create_release",
-    "generate_release_notes",
-    "generate_workspace_snippet",
-    "hash_sha256",
-    "release_archive",
-    "update_readme",
-]
+# # MARK: - Documentation Providers
 
-_RULE_DOC_PROVIDERS = [
-    doc_providers.create(
-        name = rule,
-        stardoc_input = "//bzlrelease:defs.bzl",
-        symbols = [rule],
-        deps = ["//bzlrelease:defs"],
-    )
-    for rule in _RULE_NAMES
-]
+# _RULE_NAMES = [
+#     "create_release",
+#     "generate_release_notes",
+#     "generate_workspace_snippet",
+#     "hash_sha256",
+#     "release_archive",
+#     "update_readme",
+# ]
 
-_API_DOC_PROVIDERS = []
+# _RULE_DOC_PROVIDERS = [
+#     doc_providers.create(
+#         name = rule,
+#         stardoc_input = "//bzlrelease:defs.bzl",
+#         symbols = [rule],
+#         deps = ["//bzlrelease:defs"],
+#     )
+#     for rule in _RULE_NAMES
+# ]
 
-_ALL_DOC_PROVIDERS = [
-    doc_providers.create(
-        name = "api",
-        is_stardoc = False,
-        stardoc_input = "",
-        deps = [],
-    ),
-    doc_providers.create(
-        name = "rules",
-        is_stardoc = False,
-        stardoc_input = "",
-        deps = [],
-    ),
-] + _RULE_DOC_PROVIDERS + _API_DOC_PROVIDERS
+# _API_DOC_PROVIDERS = []
 
-# MARK: - Headers
+# _ALL_DOC_PROVIDERS = [
+#     doc_providers.create(
+#         name = "api",
+#         is_stardoc = False,
+#         stardoc_input = "",
+#         deps = [],
+#     ),
+#     doc_providers.create(
+#         name = "rules",
+#         is_stardoc = False,
+#         stardoc_input = "",
+#         deps = [],
+#     ),
+# ] + _RULE_DOC_PROVIDERS + _API_DOC_PROVIDERS
 
-# Write rule headers
-[
-    write_header(
-        name = doc_prov.header_label,
-        out = doc_prov.header_basename,
-        header_content = [
-            "# `{name}` Rule".format(name = doc_prov.name),
-        ],
-    )
-    for doc_prov in _RULE_DOC_PROVIDERS
-    if doc_prov.is_stardoc
-]
+# # MARK: - Headers
 
-# Write the API headers
-[
-    write_header(
-        name = doc_prov.header_label,
-        out = doc_prov.header_basename,
-        header_content = [
-            "# `{name}` API".format(name = doc_prov.name),
-        ],
-    )
-    for doc_prov in _API_DOC_PROVIDERS
-    if doc_prov.is_stardoc
-]
+# # Write rule headers
+# [
+#     write_header(
+#         name = doc_prov.header_label,
+#         out = doc_prov.header_basename,
+#         header_content = [
+#             "# `{name}` Rule".format(name = doc_prov.name),
+#         ],
+#     )
+#     for doc_prov in _RULE_DOC_PROVIDERS
+#     if doc_prov.is_stardoc
+# ]
 
-# MARK: - Special Case api.md
+# # Write the API headers
+# [
+#     write_header(
+#         name = doc_prov.header_label,
+#         out = doc_prov.header_basename,
+#         header_content = [
+#             "# `{name}` API".format(name = doc_prov.name),
+#         ],
+#     )
+#     for doc_prov in _API_DOC_PROVIDERS
+#     if doc_prov.is_stardoc
+# ]
 
-# Write the api.md_ file as a special case.
-write_file_list(
-    name = "api_doc",
-    out = "api.md_",
-    doc_provs = _API_DOC_PROVIDERS,
-    header_content = [
-        "# Build API",
-        "",
-        "The APIs listed below are available in this repository.",
-        "",
-    ],
-)
+# # MARK: - Special Case api.md
 
-# Write the rules.md_ file as a special case.
-write_file_list(
-    name = "rules_doc",
-    out = "rules.md_",
-    doc_provs = _RULE_DOC_PROVIDERS,
-    header_content = [
-        "# Rules",
-        "",
-        "The rules listed below are available in this repository.",
-        "",
-    ],
-)
+# # Write the api.md_ file as a special case.
+# write_file_list(
+#     name = "api_doc",
+#     out = "api.md_",
+#     doc_provs = _API_DOC_PROVIDERS,
+#     header_content = [
+#         "# Build API",
+#         "",
+#         "The APIs listed below are available in this repository.",
+#         "",
+#     ],
+# )
 
-# MARK: - Generate Documentation from Providers
+# # Write the rules.md_ file as a special case.
+# write_file_list(
+#     name = "rules_doc",
+#     out = "rules.md_",
+#     doc_provs = _RULE_DOC_PROVIDERS,
+#     header_content = [
+#         "# Rules",
+#         "",
+#         "The rules listed below are available in this repository.",
+#         "",
+#     ],
+# )
 
-doc_for_provs(
-    doc_provs = _ALL_DOC_PROVIDERS,
-)
+# # MARK: - Generate Documentation from Providers
+
+# doc_for_provs(
+#     doc_provs = _ALL_DOC_PROVIDERS,
+# )

--- a/doc/bzltidy/BUILD.bazel
+++ b/doc/bzltidy/BUILD.bazel
@@ -1,56 +1,58 @@
-load(
-    "//bazeldoc:defs.bzl",
-    "doc_for_provs",
-    "write_header",
-    doc_providers = "providers",
-)
-load("//bzlformat:defs.bzl", "bzlformat_pkg")
+# GH195: Enable once stardoc supports repo mapping.
 
-bzlformat_pkg(name = "bzlformat")
+# load(
+#     "//bazeldoc:defs.bzl",
+#     "doc_for_provs",
+#     "write_header",
+#     doc_providers = "providers",
+# )
+# load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
-filegroup(
-    name = "doc_files",
-    srcs = glob(["*.md"]) + [
-        # A doc file has a reference to this file.
-        "BUILD.bazel",
-    ],
-    visibility = ["//:markdown_test_visibility"],
-)
+# bzlformat_pkg(name = "bzlformat")
 
-# MARK: - Documentation Providers
+# filegroup(
+#     name = "doc_files",
+#     srcs = glob(["*.md"]) + [
+#         # A doc file has a reference to this file.
+#         "BUILD.bazel",
+#     ],
+#     visibility = ["//:markdown_test_visibility"],
+# )
 
-_STARDOC_INPUT = "//bzltidy:defs.bzl"
+# # MARK: - Documentation Providers
 
-_DOC_DEPS = ["//bzltidy:defs"]
+# _STARDOC_INPUT = "//bzltidy:defs.bzl"
 
-_RULES_AND_MACROS_DOC_PROVIDER = doc_providers.create(
-    name = "rules_and_macros_overview",
-    stardoc_input = _STARDOC_INPUT,
-    symbols = [
-        "tidy",
-    ],
-    deps = _DOC_DEPS,
-)
+# _DOC_DEPS = ["//bzltidy:defs"]
 
-_ALL_DOC_PROVIDERS = [
-    _RULES_AND_MACROS_DOC_PROVIDER,
-]
+# _RULES_AND_MACROS_DOC_PROVIDER = doc_providers.create(
+#     name = "rules_and_macros_overview",
+#     stardoc_input = _STARDOC_INPUT,
+#     symbols = [
+#         "tidy",
+#     ],
+#     deps = _DOC_DEPS,
+# )
 
-# MARK: - Headers
+# _ALL_DOC_PROVIDERS = [
+#     _RULES_AND_MACROS_DOC_PROVIDER,
+# ]
 
-write_header(
-    name = _RULES_AND_MACROS_DOC_PROVIDER.header_label,
-    header_content = [
-        "# Rules and Macros",
-        "",
-        "The rules and macros described below are used to help keep your ",
-        "workspace source files up-to-date.",
-    ],
-    symbols = _RULES_AND_MACROS_DOC_PROVIDER.symbols,
-)
+# # MARK: - Headers
 
-# MARK: - Generate Documentation from Providers
+# write_header(
+#     name = _RULES_AND_MACROS_DOC_PROVIDER.header_label,
+#     header_content = [
+#         "# Rules and Macros",
+#         "",
+#         "The rules and macros described below are used to help keep your ",
+#         "workspace source files up-to-date.",
+#     ],
+#     symbols = _RULES_AND_MACROS_DOC_PROVIDER.symbols,
+# )
 
-doc_for_provs(
-    doc_provs = _ALL_DOC_PROVIDERS,
-)
+# # MARK: - Generate Documentation from Providers
+
+# doc_for_provs(
+#     doc_provs = _ALL_DOC_PROVIDERS,
+# )

--- a/doc/shlib/BUILD.bazel
+++ b/doc/shlib/BUILD.bazel
@@ -1,121 +1,123 @@
-load(
-    "//bazeldoc:defs.bzl",
-    "doc_for_provs",
-    "write_file_list",
-    "write_header",
-    doc_providers = "providers",
-)
-load("//bzlformat:defs.bzl", "bzlformat_pkg")
+# GH195: Enable once stardoc supports repo mapping.
 
-bzlformat_pkg(name = "bzlformat")
+# load(
+#     "//bazeldoc:defs.bzl",
+#     "doc_for_provs",
+#     "write_file_list",
+#     "write_header",
+#     doc_providers = "providers",
+# )
+# load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
-filegroup(
-    name = "doc_files",
-    srcs = glob(["*.md"]),
-    visibility = ["//:markdown_test_visibility"],
-)
+# bzlformat_pkg(name = "bzlformat")
 
-# MARK: - Documentation Providers
+# filegroup(
+#     name = "doc_files",
+#     srcs = glob(["*.md"]),
+#     visibility = ["//:markdown_test_visibility"],
+# )
 
-_RULE_NAMES = [
-    "execute_binary",
-]
+# # MARK: - Documentation Providers
 
-_RULE_DOC_PROVIDERS = [
-    doc_providers.create(
-        name = rule,
-        stardoc_input = "//shlib/rules:{rule}.bzl".format(rule = rule),
-        symbols = [rule],
-        deps = ["//shlib/rules:{rule}".format(rule = rule)],
-    )
-    for rule in _RULE_NAMES
-]
+# _RULE_NAMES = [
+#     "execute_binary",
+# ]
 
-_API_SRCS = []
+# _RULE_DOC_PROVIDERS = [
+#     doc_providers.create(
+#         name = rule,
+#         stardoc_input = "//shlib/rules:{rule}.bzl".format(rule = rule),
+#         symbols = [rule],
+#         deps = ["//shlib/rules:{rule}".format(rule = rule)],
+#     )
+#     for rule in _RULE_NAMES
+# ]
 
-_API_DOC_PROVIDERS = [
-    doc_providers.create(
-        name = name,
-        stardoc_input = "//shlib/lib:{name}.bzl".format(name = name),
-        symbols = [name],
-        deps = ["//shlib/lib:{name}".format(name = name)],
-    )
-    for name in _API_SRCS
-]
+# _API_SRCS = []
 
-_ALL_DOC_PROVIDERS = [
-    doc_providers.create(
-        name = "api",
-        is_stardoc = False,
-        stardoc_input = "",
-        deps = [],
-    ),
-    doc_providers.create(
-        name = "rules",
-        is_stardoc = False,
-        stardoc_input = "",
-        deps = [],
-    ),
-] + _RULE_DOC_PROVIDERS + _API_DOC_PROVIDERS
+# _API_DOC_PROVIDERS = [
+#     doc_providers.create(
+#         name = name,
+#         stardoc_input = "//shlib/lib:{name}.bzl".format(name = name),
+#         symbols = [name],
+#         deps = ["//shlib/lib:{name}".format(name = name)],
+#     )
+#     for name in _API_SRCS
+# ]
 
-# MARK: - Headers
+# _ALL_DOC_PROVIDERS = [
+#     doc_providers.create(
+#         name = "api",
+#         is_stardoc = False,
+#         stardoc_input = "",
+#         deps = [],
+#     ),
+#     doc_providers.create(
+#         name = "rules",
+#         is_stardoc = False,
+#         stardoc_input = "",
+#         deps = [],
+#     ),
+# ] + _RULE_DOC_PROVIDERS + _API_DOC_PROVIDERS
 
-# Write rule headers
-[
-    write_header(
-        name = doc_prov.header_label,
-        out = doc_prov.header_basename,
-        header_content = [
-            "# `{name}` Rule".format(name = doc_prov.name),
-        ],
-    )
-    for doc_prov in _RULE_DOC_PROVIDERS
-    if doc_prov.is_stardoc
-]
+# # MARK: - Headers
 
-# Write the API headers
-[
-    write_header(
-        name = doc_prov.header_label,
-        out = doc_prov.header_basename,
-        header_content = [
-            "# `{name}` API".format(name = doc_prov.name),
-        ],
-    )
-    for doc_prov in _API_DOC_PROVIDERS
-    if doc_prov.is_stardoc
-]
+# # Write rule headers
+# [
+#     write_header(
+#         name = doc_prov.header_label,
+#         out = doc_prov.header_basename,
+#         header_content = [
+#             "# `{name}` Rule".format(name = doc_prov.name),
+#         ],
+#     )
+#     for doc_prov in _RULE_DOC_PROVIDERS
+#     if doc_prov.is_stardoc
+# ]
 
-# MARK: - Special Case api.md
+# # Write the API headers
+# [
+#     write_header(
+#         name = doc_prov.header_label,
+#         out = doc_prov.header_basename,
+#         header_content = [
+#             "# `{name}` API".format(name = doc_prov.name),
+#         ],
+#     )
+#     for doc_prov in _API_DOC_PROVIDERS
+#     if doc_prov.is_stardoc
+# ]
 
-# Write the api.md_ file as a special case.
-write_file_list(
-    name = "api_doc",
-    out = "api.md_",
-    doc_provs = _API_DOC_PROVIDERS,
-    header_content = [
-        "# Build API",
-        "",
-        "The APIs listed below are available in this repository.",
-        "",
-    ],
-)
+# # MARK: - Special Case api.md
 
-# Write the rules.md_ file as a special case.
-write_file_list(
-    name = "rules_doc",
-    out = "rules.md_",
-    doc_provs = _RULE_DOC_PROVIDERS,
-    header_content = [
-        "# Rules",
-        "",
-        "The rules listed below are available in this repository.",
-        "",
-    ],
-)
+# # Write the api.md_ file as a special case.
+# write_file_list(
+#     name = "api_doc",
+#     out = "api.md_",
+#     doc_provs = _API_DOC_PROVIDERS,
+#     header_content = [
+#         "# Build API",
+#         "",
+#         "The APIs listed below are available in this repository.",
+#         "",
+#     ],
+# )
 
-# MARK: - Generate Documentation from Providers
+# # Write the rules.md_ file as a special case.
+# write_file_list(
+#     name = "rules_doc",
+#     out = "rules.md_",
+#     doc_provs = _RULE_DOC_PROVIDERS,
+#     header_content = [
+#         "# Rules",
+#         "",
+#         "The rules listed below are available in this repository.",
+#         "",
+#     ],
+# )
 
-doc_for_provs(
-    doc_provs = _ALL_DOC_PROVIDERS,
-)
+# # MARK: - Generate Documentation from Providers
+
+# doc_for_provs(
+#     doc_provs = _ALL_DOC_PROVIDERS,
+# )

--- a/doc/updatesrc/BUILD.bazel
+++ b/doc/updatesrc/BUILD.bazel
@@ -1,126 +1,128 @@
-load(
-    "//bazeldoc:defs.bzl",
-    "doc_for_provs",
-    "write_file_list",
-    "write_header",
-    doc_providers = "providers",
-)
-load("//bzlformat:defs.bzl", "bzlformat_pkg")
+# GH195: Enable once stardoc supports repo mapping.
 
-bzlformat_pkg(name = "bzlformat")
+# load(
+#     "//bazeldoc:defs.bzl",
+#     "doc_for_provs",
+#     "write_file_list",
+#     "write_header",
+#     doc_providers = "providers",
+# )
+# load("//bzlformat:defs.bzl", "bzlformat_pkg")
 
-filegroup(
-    name = "doc_files",
-    srcs = glob(["*.md"]),
-    visibility = ["//:markdown_test_visibility"],
-)
+# bzlformat_pkg(name = "bzlformat")
 
-# MARK: - Documentation Providers
+# filegroup(
+#     name = "doc_files",
+#     srcs = glob(["*.md"]),
+#     visibility = ["//:markdown_test_visibility"],
+# )
 
-_STARDOC_INPUT = "//updatesrc:defs.bzl"
+# # MARK: - Documentation Providers
 
-_DOC_DEPS = ["//updatesrc:defs"]
+# _STARDOC_INPUT = "//updatesrc:defs.bzl"
 
-_PROVIDERS_DOC_PROVIDER = doc_providers.create(
-    name = "providers_overview",
-    stardoc_input = _STARDOC_INPUT,
-    symbols = [
-        "UpdateSrcsInfo",
-    ],
-    deps = _DOC_DEPS,
-)
+# _DOC_DEPS = ["//updatesrc:defs"]
 
-_RULES_AND_MACROS_DOC_PROVIDER = doc_providers.create(
-    name = "rules_and_macros_overview",
-    stardoc_input = _STARDOC_INPUT,
-    symbols = [
-        "updatesrc_diff_and_update",
-        "updatesrc_update",
-        "updatesrc_update_all",
-        "updatesrc_update_and_test",
-    ],
-    deps = _DOC_DEPS,
-)
+# _PROVIDERS_DOC_PROVIDER = doc_providers.create(
+#     name = "providers_overview",
+#     stardoc_input = _STARDOC_INPUT,
+#     symbols = [
+#         "UpdateSrcsInfo",
+#     ],
+#     deps = _DOC_DEPS,
+# )
 
-_API_SRCS = [
-    "update_srcs",
-]
+# _RULES_AND_MACROS_DOC_PROVIDER = doc_providers.create(
+#     name = "rules_and_macros_overview",
+#     stardoc_input = _STARDOC_INPUT,
+#     symbols = [
+#         "updatesrc_diff_and_update",
+#         "updatesrc_update",
+#         "updatesrc_update_all",
+#         "updatesrc_update_and_test",
+#     ],
+#     deps = _DOC_DEPS,
+# )
 
-_API_DOC_PROVIDERS = [
-    doc_providers.create(
-        name = name,
-        stardoc_input = _STARDOC_INPUT,
-        symbols = [name],
-        deps = _DOC_DEPS,
-    )
-    for name in _API_SRCS
-]
+# _API_SRCS = [
+#     "update_srcs",
+# ]
 
-_ALL_DOC_PROVIDERS = [
-    _RULES_AND_MACROS_DOC_PROVIDER,
-    _PROVIDERS_DOC_PROVIDER,
-    doc_providers.create(
-        name = "api",
-        is_stardoc = False,
-        stardoc_input = _STARDOC_INPUT,
-        deps = _DOC_DEPS,
-    ),
-] + _API_DOC_PROVIDERS
+# _API_DOC_PROVIDERS = [
+#     doc_providers.create(
+#         name = name,
+#         stardoc_input = _STARDOC_INPUT,
+#         symbols = [name],
+#         deps = _DOC_DEPS,
+#     )
+#     for name in _API_SRCS
+# ]
 
-# MARK: - Headers
+# _ALL_DOC_PROVIDERS = [
+#     _RULES_AND_MACROS_DOC_PROVIDER,
+#     _PROVIDERS_DOC_PROVIDER,
+#     doc_providers.create(
+#         name = "api",
+#         is_stardoc = False,
+#         stardoc_input = _STARDOC_INPUT,
+#         deps = _DOC_DEPS,
+#     ),
+# ] + _API_DOC_PROVIDERS
 
-write_header(
-    name = _PROVIDERS_DOC_PROVIDER.header_label,
-    header_content = [
-        "# Providers",
-        "",
-        "The providers described below are used by [the rules](/doc/updatesrc/rules_and_macros_overview.md) to",
-        "pass along information about the source files to be updated.",
-    ],
-    symbols = _PROVIDERS_DOC_PROVIDER.symbols,
-)
+# # MARK: - Headers
 
-write_header(
-    name = _RULES_AND_MACROS_DOC_PROVIDER.header_label,
-    header_content = [
-        "# Rules and Macros",
-        "",
-        "The rules and macros described below are used to update source files",
-        "from output files.",
-    ],
-    symbols = _RULES_AND_MACROS_DOC_PROVIDER.symbols,
-)
+# write_header(
+#     name = _PROVIDERS_DOC_PROVIDER.header_label,
+#     header_content = [
+#         "# Providers",
+#         "",
+#         "The providers described below are used by [the rules](/doc/updatesrc/rules_and_macros_overview.md) to",
+#         "pass along information about the source files to be updated.",
+#     ],
+#     symbols = _PROVIDERS_DOC_PROVIDER.symbols,
+# )
 
-# Write the API headers
-[
-    write_header(
-        name = doc_prov.header_label,
-        out = doc_prov.header_basename,
-        header_content = [
-            "# `{name}` API".format(name = doc_prov.name),
-        ],
-    )
-    for doc_prov in _API_DOC_PROVIDERS
-    if doc_prov.is_stardoc
-]
+# write_header(
+#     name = _RULES_AND_MACROS_DOC_PROVIDER.header_label,
+#     header_content = [
+#         "# Rules and Macros",
+#         "",
+#         "The rules and macros described below are used to update source files",
+#         "from output files.",
+#     ],
+#     symbols = _RULES_AND_MACROS_DOC_PROVIDER.symbols,
+# )
 
-# MARK: - Special Case api.md
+# # Write the API headers
+# [
+#     write_header(
+#         name = doc_prov.header_label,
+#         out = doc_prov.header_basename,
+#         header_content = [
+#             "# `{name}` API".format(name = doc_prov.name),
+#         ],
+#     )
+#     for doc_prov in _API_DOC_PROVIDERS
+#     if doc_prov.is_stardoc
+# ]
 
-# Write the api.md_ file as a special case.
-write_file_list(
-    name = "api_doc",
-    out = "api.md_",
-    doc_provs = _API_DOC_PROVIDERS,
-    header_content = [
-        "# Build API",
-        "",
-        "The APIs list below are used by updatesrc.",
-        "",
-    ],
-)
+# # MARK: - Special Case api.md
 
-# MARK: - Generate Documentation from Providers
+# # Write the api.md_ file as a special case.
+# write_file_list(
+#     name = "api_doc",
+#     out = "api.md_",
+#     doc_provs = _API_DOC_PROVIDERS,
+#     header_content = [
+#         "# Build API",
+#         "",
+#         "The APIs list below are used by updatesrc.",
+#         "",
+#     ],
+# )
 
-doc_for_provs(
-    doc_provs = _ALL_DOC_PROVIDERS,
-)
+# # MARK: - Generate Documentation from Providers
+
+# doc_for_provs(
+#     doc_provs = _ALL_DOC_PROVIDERS,
+# )

--- a/examples/bzlformat/simple/WORKSPACE.bzlmod
+++ b/examples/bzlformat/simple/WORKSPACE.bzlmod
@@ -1,0 +1,2 @@
+# Intentionally blank
+# This exists to force Bazel in bzlmod mode to be strict.

--- a/examples/bzlmod_e2e/WORKSPACE.bzlmod
+++ b/examples/bzlmod_e2e/WORKSPACE.bzlmod
@@ -1,0 +1,2 @@
+# Intentionally blank
+# This exists to force Bazel in bzlmod mode to be strict.

--- a/examples/markdown/simple/WORKSPACE.bzlmod
+++ b/examples/markdown/simple/WORKSPACE.bzlmod
@@ -1,0 +1,2 @@
+# Intentionally blank
+# This exists to force Bazel in bzlmod mode to be strict.

--- a/examples/updatesrc/simple/MODULE.bazel
+++ b/examples/updatesrc/simple/MODULE.bazel
@@ -1,3 +1,8 @@
+module(
+    name = "simple_example",
+    version = "0.0.0",
+)
+
 bazel_dep(name = "cgrindel_bazel_starlib")
 local_path_override(
     module_name = "cgrindel_bazel_starlib",

--- a/examples/updatesrc/simple/WORKSPACE.bzlmod
+++ b/examples/updatesrc/simple/WORKSPACE.bzlmod
@@ -1,0 +1,2 @@
+# Intentionally blank
+# This exists to force Bazel in bzlmod mode to be strict.

--- a/tests/bzlformat_tests/tools_tests/missing_pkgs_tests/workspace/.bazelrc
+++ b/tests/bzlformat_tests/tools_tests/missing_pkgs_tests/workspace/.bazelrc
@@ -1,0 +1,11 @@
+# Import Shared settings
+import %workspace%/../../../../../shared.bazelrc
+
+# Import CI settings.
+import %workspace%/../../../../../ci.bazelrc
+
+# Try to import a local.rc file; typically, written by CI
+try-import %workspace%/../../../../../local.bazelrc
+
+# Explicitly enable bzlmod
+common --enable_bzlmod

--- a/tests/bzlformat_tests/tools_tests/missing_pkgs_tests/workspace/MODULE.bazel
+++ b/tests/bzlformat_tests/tools_tests/missing_pkgs_tests/workspace/MODULE.bazel
@@ -1,0 +1,12 @@
+module(
+    name = "missing_pkgs",
+    version = "0.0.0",
+)
+
+bazel_dep(name = "cgrindel_bazel_starlib", version = "0.0.0")
+local_path_override(
+    module_name = "cgrindel_bazel_starlib",
+    path = "../../../../..",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.4.1")

--- a/tests/bzlformat_tests/tools_tests/missing_pkgs_tests/workspace/WORKSPACE.bzlmod
+++ b/tests/bzlformat_tests/tools_tests/missing_pkgs_tests/workspace/WORKSPACE.bzlmod
@@ -1,0 +1,2 @@
+# Intentionally blank
+# This exists to force Bazel in bzlmod mode to be strict.

--- a/tests/updatesrc_tests/workspace/MODULE.bazel
+++ b/tests/updatesrc_tests/workspace/MODULE.bazel
@@ -1,0 +1,12 @@
+module(
+    name = "updatesrc_test_workspace",
+    version = "0.0.0",
+)
+
+bazel_dep(name = "cgrindel_bazel_starlib")
+local_path_override(
+    module_name = "cgrindel_bazel_starlib",
+    path = "../../..",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.4.1")

--- a/tests/updatesrc_tests/workspace/WORKSPACE.bzlmod
+++ b/tests/updatesrc_tests/workspace/WORKSPACE.bzlmod
@@ -1,0 +1,2 @@
+# Intentionally blank
+# This exists to force Bazel in bzlmod mode to be strict.

--- a/tests/updatesrc_tests/workspace/diff_and_update_test/sorted_genquery.bzl
+++ b/tests/updatesrc_tests/workspace/diff_and_update_test/sorted_genquery.bzl
@@ -14,7 +14,7 @@ def sorted_genquery(name, expression, scope, testonly):
     native.genrule(
         name = name,
         srcs = [raw_query_name],
-        outs = [name],
+        outs = [name + ".out"],
         testonly = testonly,
         cmd = """\
 # cat $(location {src}) | sort > $@


### PR DESCRIPTION
- Add `WORKSPACE.bzlmod` to all workspaces to ensure that the strict bzlmod support was enabled.
- Disable all documentation generation and tests until bazelbuild/bazel#14140 is fixed.
- Update CI to execute tidy and test with and without bzlmod.
- Fix warning in `sorted_genquery.bzl`.

Related to #195.