### PR TITLE
fix: include `examples/bzlmod_e2e` in release archive

### DIFF
--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,5 +1,5 @@
 {
   "integrity": "",
-  "strip_prefix": "{REPO}-{VERSION}",
+  "strip_prefix": "",
   "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/bazel-starlib.{TAG}.tar.gz"
 }

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -111,7 +111,13 @@ filegroup(
 
 filegroup(
     name = "all_files",
-    srcs = glob(["*"]),
+    srcs = glob(
+        ["*"],
+        exclude = [
+            ".git",
+            ".gitignore",
+        ],
+    ),
     visibility = ["//:__subpackages__"],
 )
 
@@ -133,6 +139,7 @@ _RUNTIME_PKGS = [
     "//bzlrelease/tools",
     "//bzltidy",
     "//bzltidy/private",
+    "//examples",
     "//markdown",
     "//markdown/private",
     "//markdown/tools",

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -55,3 +55,11 @@ test_suite(
     ]),
     visibility = ["//:__subpackages__"],
 )
+
+# We do not want to pull everything into the release archive. We just need the
+# bzlmod_e2e workspace.
+filegroup(
+    name = "all_files",
+    srcs = glob(["bzlmod_e2e/**"]),
+    visibility = ["//:__subpackages__"],
+)


### PR DESCRIPTION
- Add the E2E test in the release archive.
- Set the `strip-prefix` to an empty string. We do not have a prefix to be stripped in our release archive.
- Remove git stuff.

Related to #195.