### PR TITLE
chore: add debug code to `buildifier.sh`

### DIFF
--- a/bzlformat/tools/buildifier.sh
+++ b/bzlformat/tools/buildifier.sh
@@ -11,6 +11,12 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
+# DEBUG BEGIN
+echo >&2 "CHUCK DEBUG BEGIN"
+find . | sort >&2
+echo >&2 "CHUCK DEBUG END"
+# DEBUG END
+
 # MARK - Locate Deps
 
 fail_sh_location=cgrindel_bazel_starlib/shlib/lib/fail.sh


### PR DESCRIPTION
Trying to debug [error on BCR CI machines](https://buildkite.com/bazel/bcr-presubmit/builds/1101#0186c91f-7ac0-4d98-8f29-2a9e4623948e).
Related to #195.