### PR TITLE
chore: enable doc generation with bzlmod enabled.

### DIFF
--- a/bazeldoc/private/stardoc_for_prov.bzl
+++ b/bazeldoc/private/stardoc_for_prov.bzl
@@ -2,21 +2,15 @@
 
 load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
 
-def stardoc_for_prov(doc_prov, **kwargs):
+def stardoc_for_prov(doc_prov):
     """Defines a `stardoc` target for a document provider.
 
     Args:
         doc_prov: A `struct` as returned from `providers.create()`.
-        **kwargs: Common attributes that are applied to the underlying rules.
 
     Returns:
         None.
     """
-    target_compatible_with = kwargs.pop("target_compatible_with", select({
-        "@cgrindel_bazel_starlib//bzlmod:is_enabled": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }))
-
     stardoc(
         name = doc_prov.name,
         out = doc_prov.out_basename,
@@ -24,7 +18,6 @@ def stardoc_for_prov(doc_prov, **kwargs):
         input = doc_prov.stardoc_input,
         symbol_names = doc_prov.symbols,
         deps = doc_prov.deps,
-        target_compatible_with = target_compatible_with,
     )
 
 def stardoc_for_provs(doc_provs):


### PR DESCRIPTION
I forgot to enable doc generation when I updated stardoc to 0.5.6.
