### PR TITLE
chore: remove obsolete go_sdk references

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -70,7 +70,7 @@ execute_binary(
         "mod",
         "tidy",
     ],
-    binary = "@go_sdk//:bin/go",
+    binary = "@io_bazel_rules_go//go",
     execute_in_workspace = True,
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -28,12 +28,6 @@ bazel_dep(
 )
 bazel_dep(name = "platforms", version = "0.0.6")
 
-go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
-use_repo(
-    go_sdk,
-    go_sdk = "go_default_sdk",
-)
-
 go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
 
 # NOTE: We are not loading the Go modules from go.mod, because we are doing

--- a/cmd/go_deps/README.md
+++ b/cmd/go_deps/README.md
@@ -14,7 +14,7 @@ Execute the following to update the go module files, resolve the Golang dependen
 Bazel build files.
 
 ```sh
-# bazel run @go_sdk//:bin/go -- mod tidy
+# bazel run //:go_mod_tidy
 $ bazel run //:gazelle_update_repos
 $ bazel run //:gazelle
 ```


### PR DESCRIPTION
[Related thread](https://github.com/bazelbuild/bazel-central-registry/pull/752#discussion_r1254980477)
`rules_go` now provides access to the Go binary at `@rules_go//go`.

cc: @fmeum