### PR TITLE
fix: failing tidy_all test failure in CI

### DIFF
--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -39,3 +39,6 @@ build --nolegacy_important_outputs
 build --bes_upload_mode=fully_async
 run --bes_backend=
 run --bes_results_url=
+
+# Easily run without caches
+common:no_cache --remote_cache= --disk_cache= --repository_cache=

--- a/tests/bzltidy_tests/tidy_all_test.sh
+++ b/tests/bzltidy_tests/tidy_all_test.sh
@@ -104,6 +104,13 @@ while IFS=$'\n' read -r line; do tidy_out_files+=("$line"); done < <(
   find_tidy_out_files "${scratch_dir}"
 )
 assert_equal 2 ${#tidy_out_files[@]} "${assert_msg}"
+# DEBUG BEGIN
+echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") -------------------" 
+echo >&2 "*** CHUCK  tidy_out_files:"
+for (( i = 0; i < ${#tidy_out_files[@]}; i++ )); do
+  echo >&2 "*** CHUCK   ${i}: ${tidy_out_files[${i}]}"
+done
+# DEBUG END
 assert_match parent\.tidy_out "${tidy_out_files[0]}" "${assert_msg}"
 assert_match child_workspaces/bar/bar\.tidy_out "${tidy_out_files[1]}" "${assert_msg}"
 assert_match \

--- a/tests/bzltidy_tests/tidy_all_test.sh
+++ b/tests/bzltidy_tests/tidy_all_test.sh
@@ -104,6 +104,14 @@ while IFS=$'\n' read -r line; do tidy_out_files+=("$line"); done < <(
   find_tidy_out_files "${scratch_dir}"
 )
 assert_equal 2 ${#tidy_out_files[@]} "${assert_msg}"
+# DEBUG BEGIN
+echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") -------------------" 
+echo >&2 "*** CHUCK  tidy_out_files:"
+for (( i = 0; i < ${#tidy_out_files[@]}; i++ )); do
+  echo >&2 "*** CHUCK   ${i}: ${tidy_out_files[${i}]}"
+done
+# DEBUG END
+
 assert_match parent\.tidy_out "${tidy_out_files[0]}" "${assert_msg}"
 assert_match child_workspaces/bar/bar\.tidy_out "${tidy_out_files[1]}" "${assert_msg}"
 assert_match \

--- a/tests/bzltidy_tests/tidy_all_test.sh
+++ b/tests/bzltidy_tests/tidy_all_test.sh
@@ -104,16 +104,8 @@ while IFS=$'\n' read -r line; do tidy_out_files+=("$line"); done < <(
   find_tidy_out_files "${scratch_dir}"
 )
 assert_equal 2 ${#tidy_out_files[@]} "${assert_msg}"
-# DEBUG BEGIN
-echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") -------------------" 
-echo >&2 "*** CHUCK  tidy_out_files:"
-for (( i = 0; i < ${#tidy_out_files[@]}; i++ )); do
-  echo >&2 "*** CHUCK   ${i}: ${tidy_out_files[${i}]}"
-done
-# DEBUG END
-
-assert_match parent\.tidy_out "${tidy_out_files[0]}" "${assert_msg}"
-assert_match child_workspaces/bar/bar\.tidy_out "${tidy_out_files[1]}" "${assert_msg}"
+assert_match child_workspaces/bar/bar\.tidy_out "${tidy_out_files[0]}" "${assert_msg}"
+assert_match parent\.tidy_out "${tidy_out_files[1]}" "${assert_msg}"
 assert_match \
   "${output_prefix_regex}"\ Running\ //:my_tidy\ in\ .*child_workspaces/bar \
   "${output}" "${assert_msg}"
@@ -127,6 +119,6 @@ while IFS=$'\n' read -r line; do tidy_out_files+=("$line"); done < <(
   find_tidy_out_files "${scratch_dir}"
 )
 assert_equal 2 ${#tidy_out_files[@]} "${assert_msg}"
-assert_match parent\.tidy_out "${tidy_out_files[0]}" "${assert_msg}"
-assert_match child_workspaces/bar/bar\.tidy_out "${tidy_out_files[1]}" "${assert_msg}"
+assert_match child_workspaces/bar/bar\.tidy_out "${tidy_out_files[0]}" "${assert_msg}"
+assert_match parent\.tidy_out "${tidy_out_files[1]}" "${assert_msg}"
 assert_match "${output_prefix_regex}"\ Skipping\ .*foo\. "${output}" "${assert_msg}"

--- a/tests/bzltidy_tests/tidy_all_test.sh
+++ b/tests/bzltidy_tests/tidy_all_test.sh
@@ -35,7 +35,7 @@ create_scratch_dir_sh="$(rlocation "${create_scratch_dir_sh_location}")" || \
 
 find_tidy_out_files() {
   local start_dir="$1"
-  find "${start_dir}" -name "*.tidy_out"
+  find "${start_dir}" -name "*.tidy_out" | sort -u
 }
 
 revert_changes() {
@@ -111,6 +111,7 @@ for (( i = 0; i < ${#tidy_out_files[@]}; i++ )); do
   echo >&2 "*** CHUCK   ${i}: ${tidy_out_files[${i}]}"
 done
 # DEBUG END
+
 assert_match parent\.tidy_out "${tidy_out_files[0]}" "${assert_msg}"
 assert_match child_workspaces/bar/bar\.tidy_out "${tidy_out_files[1]}" "${assert_msg}"
 assert_match \

--- a/tests/bzltidy_tests/tidy_all_test.sh
+++ b/tests/bzltidy_tests/tidy_all_test.sh
@@ -104,14 +104,6 @@ while IFS=$'\n' read -r line; do tidy_out_files+=("$line"); done < <(
   find_tidy_out_files "${scratch_dir}"
 )
 assert_equal 2 ${#tidy_out_files[@]} "${assert_msg}"
-# DEBUG BEGIN
-echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") -------------------" 
-echo >&2 "*** CHUCK  tidy_out_files:"
-for (( i = 0; i < ${#tidy_out_files[@]}; i++ )); do
-  echo >&2 "*** CHUCK   ${i}: ${tidy_out_files[${i}]}"
-done
-# DEBUG END
-
 assert_match parent\.tidy_out "${tidy_out_files[0]}" "${assert_msg}"
 assert_match child_workspaces/bar/bar\.tidy_out "${tidy_out_files[1]}" "${assert_msg}"
 assert_match \


### PR DESCRIPTION
- Sort the output of `find_tidy_out_files`.
- Update the expected positions for the tidy out files.