### PR TITLE
chore: remove bazelisk install from Renovate post upgrade commands

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,6 @@
   ],
   "postUpgradeTasks": {
     "commands": [
-      "npm install -g @bazel/bazelisk",
       "bazelisk run //:tidy_modified"
     ],
     "executionMode": "branch"


### PR DESCRIPTION
The self-hosted Renovate instance is running in a container that includes Bazelisk.