### PR TITLE
fix: use the correct Bazel binary

### DIFF
--- a/bzlformat/tools/missing_pkgs/find.sh
+++ b/bzlformat/tools/missing_pkgs/find.sh
@@ -11,6 +11,10 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v3 ---
 
+# Use the Bazel binary specified by the integration test. Otherise, fall back 
+# to bazel.
+bazel="${BIT_BAZEL_BINARY:-bazel}"
+
 arrays_lib="$(rlocation cgrindel_bazel_starlib/shlib/lib/arrays.sh)"
 # shellcheck source=SCRIPTDIR/../../../shlib/lib/arrays.sh
 source "${arrays_lib}"
@@ -25,7 +29,7 @@ query_for_pkgs() {
   local query="${1}"
   # We need to add a prefix here (//). Otherwise, the root package would be an 
   # empty string. Empty strings are easily lost in Bash.
-  bazel query "${query}" --output package | sed -e 's|^|//|'
+  "${bazel}" query "${query}" --output package | sed -e 's|^|//|'
 }
 
 fail_on_missing_pkgs=false

--- a/bzltidy/private/check_tidy.sh
+++ b/bzltidy/private/check_tidy.sh
@@ -5,6 +5,10 @@ set -o errexit -o nounset -o pipefail
 # Purposefully not using Bazel's Bash runfiles support. Running it here,
 # appears to mess up the execution of targets that also use it.
 
+# Use the Bazel binary specified by the integration test. Otherise, fall back 
+# to bazel.
+bazel="${BIT_BAZEL_BINARY:-bazel}"
+
 # MARK - Functions
 
 warn() {
@@ -125,7 +129,7 @@ before_diff="${before_dir}/diff"
 git_diff "${before_diff}"
 
 # Execute tidy
-bazel run "${tidy_target}"
+"${bazel}" run "${tidy_target}"
 
 # Capture after state
 after_status="${after_dir}/status"

--- a/bzltidy/private/tidy.sh
+++ b/bzltidy/private/tidy.sh
@@ -5,6 +5,10 @@ set -o errexit -o nounset -o pipefail
 # Purposefully not using Bazel's Bash runfiles support. Running it here,
 # appears to mess up the execution of targets that also use it.
 
+# Use the Bazel binary specified by the integration test. Otherise, fall back 
+# to bazel.
+bazel="${BIT_BAZEL_BINARY:-bazel}"
+
 # MARK - Functions
 
 warn() {
@@ -63,7 +67,7 @@ run_bazel_targets() {
   while (("$#")); do
     local target="${1}"
     if [[ -n "${target:-}" ]]; then
-      bazel run "${target}"
+      "${bazel}" run "${target}"
     fi
     shift 1
   done

--- a/bzltidy/private/tidy_all.sh
+++ b/bzltidy/private/tidy_all.sh
@@ -5,8 +5,11 @@ set -o errexit -o nounset -o pipefail
 # Purposefully not using Bazel's Bash runfiles support. Running it here,
 # appears to mess up the execution of targets that also use it.
 
-# MARK - Functions from Library
+# Use the Bazel binary specified by the integration test. Otherise, fall back 
+# to bazel.
+bazel="${BIT_BAZEL_BINARY:-bazel}"
 
+# MARK - Functions from Library
 
 warn() {
   if [[ $# -gt 0 ]]; then
@@ -191,7 +194,7 @@ find_workspaces_with_modifications() {
 
 target_exists() {
   local target="$1"
-  bazel query "${target}" &>/dev/null
+  "${bazel}" query "${target}" &>/dev/null
 }
 
 # MARK - Process Args
@@ -254,7 +257,7 @@ for workspace in "${workspaces[@]}" ; do
   cd "${workspace_dir}"
   if target_exists "${tidy_target}"; then
     info "Running ${tidy_target} in ${workspace_dir}."
-    bazel run "${tidy_target}" --experimental_convenience_symlinks=ignore
+    "${bazel}" run "${tidy_target}" --experimental_convenience_symlinks=ignore
   else
     info "Skipping ${workspace_dir}. ${tidy_target} does not exist."
   fi

--- a/updatesrc/private/update_all.sh
+++ b/updatesrc/private/update_all.sh
@@ -5,13 +5,17 @@
 
 set -o errexit -o nounset -o pipefail
 
+# Use the Bazel binary specified by the integration test. Otherise, fall back 
+# to bazel.
+bazel="${BIT_BAZEL_BINARY:-bazel}"
+
 # MARK - Functions
 
 run_bazel_targets() {
   while (("$#")); do
     local target="${1}"
     if [[ -n "${target:-}" ]]; then
-      bazel run "${target}"
+      "${bazel}" run "${target}"
     fi
     shift 1
   done
@@ -62,7 +66,7 @@ EOF
 bazel_query="kind(updatesrc_update, //...)"
 update_targets=()
 while IFS=$'\n' read -r line; do update_targets+=("$line"); done < <(
-  bazel cquery "${bazel_query}" \
+  "${bazel}" cquery "${bazel_query}" \
     --output=starlark \
     --starlark:file="${starlark_file}" \
     | sort


### PR DESCRIPTION
We could be executed in [Bazel integration tests](https://github.com/bazel-contrib/rules_bazel_integration_test). Be sure to use the Bazel binary specified by the tests, if it is present. Otherwise, use `bazel`. 