### PR TITLE
fix: only run bzltidy tests for a single Bazel version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,16 +148,10 @@ jobs:
           - test: '@@//tests/bzlrelease_tests/tools_tests:generate_workspace_snippet_test'
             runner: ubuntu-22.04
             enable_bzlmod: true
-          - test: '@@//tests/bzltidy_tests:tidy_all_test_bazel_.bazelversion'
+          - test: '@@//tests/bzltidy_tests:tidy_all_test'
             runner: ubuntu-22.04
             enable_bzlmod: true
-          - test: '@@//tests/bzltidy_tests:tidy_all_test_bazel_.bazelversion'
-            runner: macos-13
-            enable_bzlmod: true
-          - test: '@@//tests/bzltidy_tests:tidy_all_test_bazel_6_4_0'
-            runner: ubuntu-22.04
-            enable_bzlmod: true
-          - test: '@@//tests/bzltidy_tests:tidy_all_test_bazel_6_4_0'
+          - test: '@@//tests/bzltidy_tests:tidy_all_test'
             runner: macos-13
             enable_bzlmod: true
           - test: '@@//tests/shlib_tests/lib_tests/git_tests:git_integration_test'

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -6,7 +6,6 @@ load(
     "bzlformat_pkg",
 )
 load("//bzltidy:defs.bzl", "tidy", "tidy_all")
-load("//ci:defs.bzl", "ci_workflow")
 load("//shlib/rules:execute_binary.bzl", "execute_binary")
 load("//tests:integration_test_common.bzl", "INTEGRATION_TEST_TAGS")
 load("//updatesrc:defs.bzl", "updatesrc_update_all")
@@ -238,14 +237,15 @@ test_suite(
     visibility = ["//:__subpackages__"],
 )
 
-ci_workflow(
-    name = "ci_workflow",
-    test_params = [
-        "{}:all_test_params".format(pkg)
-        for pkg in _INTEGRATION_TEST_PKGS
-    ],
-    workflow_yml = ".github/workflows/ci.yml",
-)
+# GH368: Enable when this is generating the proper output
+# ci_workflow(
+#     name = "ci_workflow",
+#     test_params = [
+#         "{}:all_test_params".format(pkg)
+#         for pkg in _INTEGRATION_TEST_PKGS
+#     ],
+#     workflow_yml = ".github/workflows/ci.yml",
+# )
 
 bzl_library(
     name = "deps",

--- a/tests/bzltidy_tests/BUILD.bazel
+++ b/tests/bzltidy_tests/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@bazel_binaries//:defs.bzl", "bazel_binaries")
 load(
     "@rules_bazel_integration_test//bazel_integration_test:defs.bzl",
-    "bazel_integration_tests",
+    "bazel_integration_test",
     "integration_test_utils",
 )
 load("//bzlformat:defs.bzl", "bzlformat_pkg")
@@ -25,11 +25,15 @@ sh_binary(
     ],
 )
 
-bazel_integration_tests(
+# NOTE: The MODULE.bazel.lock file can change between Bazel versions. In other
+# words, the checked-in file can only be correct for a single version. Hence,
+# we will only run the integration test for the current Bazel version.
+
+bazel_integration_test(
     name = "tidy_all_test",
     timeout = "eternal",
     bazel_binaries = bazel_binaries,
-    bazel_versions = bazel_binaries.versions.all,
+    bazel_version = bazel_binaries.versions.current,
     tags = integration_test_utils.DEFAULT_INTEGRATION_TEST_TAGS + [
         # Avoid file permssion error when using disk and repository cache after
         # 7.0.0rc2 upgrade.
@@ -50,22 +54,14 @@ bazel_integration_tests(
 test_suite(
     name = "smoke_integration_tests",
     tags = integration_test_utils.DEFAULT_INTEGRATION_TEST_TAGS,
-    tests = [
-        integration_test_utils.bazel_integration_test_name(
-            ":tidy_all_test",
-            bazel_binaries.versions.current,
-        ),
-    ],
+    tests = [":tidy_all_test"],
     visibility = ["//:__subpackages__"],
 )
 
 test_suite(
     name = "all_integration_tests",
     tags = integration_test_utils.DEFAULT_INTEGRATION_TEST_TAGS,
-    tests = integration_test_utils.bazel_integration_test_names(
-        ":tidy_all_test",
-        bazel_binaries.versions.all,
-    ),
+    tests = [":tidy_all_test"],
     visibility = ["//:__subpackages__"],
 )
 

--- a/tests/bzltidy_tests/tidy_all_test.sh
+++ b/tests/bzltidy_tests/tidy_all_test.sh
@@ -44,6 +44,19 @@ revert_changes() {
   git clean -f
 }
 
+dump_modified_files() {
+  local title="${1}"
+  shift
+  if [[ $# -eq 0 ]]; then
+    return 0
+  fi
+  echo >&2 "${title}"
+  while (("$#")); do
+    echo >&2 "  ${1}"
+    shift 1
+  done
+}
+
 # MARK - Initialize Important Variables
 
 bazel="${BIT_BAZEL_BINARY:-}"
@@ -77,6 +90,7 @@ tidy_out_files=()
 while IFS=$'\n' read -r line; do tidy_out_files+=("$line"); done < <(
   find_tidy_out_files "${scratch_dir}"
 )
+dump_modified_files "Modified files for ${assert_msg}" "${tidy_out_files[@]:-}"
 assert_equal 0 ${#tidy_out_files[@]} "${assert_msg}"
 assert_match "${output_prefix_regex}"\ No\ workspaces\ to\ tidy\. "${output}" "${assert_msg}"
 

--- a/tests/bzltidy_tests/workspace/MODULE.bazel.lock
+++ b/tests/bzltidy_tests/workspace/MODULE.bazel.lock
@@ -995,7 +995,7 @@
     }
   },
   "moduleExtensions": {
-    "@apple_support~1.5.0//crosstool:setup.bzl%apple_cc_configure_extension": {
+    "@@apple_support~1.5.0//crosstool:setup.bzl%apple_cc_configure_extension": {
       "general": {
         "bzlTransitiveDigest": "pMLFCYaRPkgXPQ8vtuNkMfiHfPmRBy6QJfnid4sWfv0=",
         "accumulatedFileDigests": {},
@@ -1018,7 +1018,7 @@
         }
       }
     },
-    "@bazel_tools//tools/cpp:cc_configure.bzl%cc_configure_extension": {
+    "@@bazel_tools//tools/cpp:cc_configure.bzl%cc_configure_extension": {
       "general": {
         "bzlTransitiveDigest": "O9sf6ilKWU9Veed02jG9o2HM/xgV/UAyciuFBuxrFRY=",
         "accumulatedFileDigests": {},
@@ -1041,7 +1041,7 @@
         }
       }
     },
-    "@bazel_tools//tools/osx:xcode_configure.bzl%xcode_configure_extension": {
+    "@@bazel_tools//tools/osx:xcode_configure.bzl%xcode_configure_extension": {
       "general": {
         "bzlTransitiveDigest": "Qh2bWTU6QW6wkrd87qrU4YeY+SG37Nvw3A0PR4Y0L2Y=",
         "accumulatedFileDigests": {},
@@ -1059,7 +1059,7 @@
         }
       }
     },
-    "@bazel_tools//tools/sh:sh_configure.bzl%sh_configure_extension": {
+    "@@bazel_tools//tools/sh:sh_configure.bzl%sh_configure_extension": {
       "general": {
         "bzlTransitiveDigest": "hp4NgmNjEg5+xgvzfh6L83bt9/aiiWETuNpwNuF1MSU=",
         "accumulatedFileDigests": {},
@@ -1075,9 +1075,9 @@
         }
       }
     },
-    "@buildifier_prebuilt~6.0.0.1//:defs.bzl%buildifier_prebuilt_deps_extension": {
+    "@@buildifier_prebuilt~6.0.0.1//:defs.bzl%buildifier_prebuilt_deps_extension": {
       "general": {
-        "bzlTransitiveDigest": "YqU/p1evGwVfmjGWRWMh2A2ufdYX2RglvtJlMQW4aV0=",
+        "bzlTransitiveDigest": "rw0w83IFOd+utieoxefELpxmQT7CxmI9Bd1pKxwbgZE=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -1196,9 +1196,9 @@
         }
       }
     },
-    "@rules_go~0.41.0//go:extensions.bzl%go_sdk": {
+    "@@rules_go~0.41.0//go:extensions.bzl%go_sdk": {
       "general": {
-        "bzlTransitiveDigest": "AaWHRBD/gHkNT2tZ68M6uuVkR6o8sNfgmBp5kia672Y=",
+        "bzlTransitiveDigest": "QaU0mhA+aom4ENV5sBUAEDa9IQt53GtspLCjl89277c=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -1252,9 +1252,9 @@
         }
       }
     },
-    "@rules_java~7.1.0//java:extensions.bzl%toolchains": {
+    "@@rules_java~7.1.0//java:extensions.bzl%toolchains": {
       "general": {
-        "bzlTransitiveDigest": "EXsxSX2vQjCcI8jYez/O+Yb9H5reAMhLL3WXGPD6Scw=",
+        "bzlTransitiveDigest": "iUIRqCK7tkhvcDJCAfPPqSd06IHG0a8HQD0xeQyVAqw=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {

--- a/tests/bzltidy_tests/workspace/child_workspaces/bar/MODULE.bazel.lock
+++ b/tests/bzltidy_tests/workspace/child_workspaces/bar/MODULE.bazel.lock
@@ -995,7 +995,7 @@
     }
   },
   "moduleExtensions": {
-    "@apple_support~1.5.0//crosstool:setup.bzl%apple_cc_configure_extension": {
+    "@@apple_support~1.5.0//crosstool:setup.bzl%apple_cc_configure_extension": {
       "general": {
         "bzlTransitiveDigest": "pMLFCYaRPkgXPQ8vtuNkMfiHfPmRBy6QJfnid4sWfv0=",
         "accumulatedFileDigests": {},
@@ -1018,7 +1018,7 @@
         }
       }
     },
-    "@bazel_tools//tools/cpp:cc_configure.bzl%cc_configure_extension": {
+    "@@bazel_tools//tools/cpp:cc_configure.bzl%cc_configure_extension": {
       "general": {
         "bzlTransitiveDigest": "O9sf6ilKWU9Veed02jG9o2HM/xgV/UAyciuFBuxrFRY=",
         "accumulatedFileDigests": {},
@@ -1041,7 +1041,7 @@
         }
       }
     },
-    "@bazel_tools//tools/osx:xcode_configure.bzl%xcode_configure_extension": {
+    "@@bazel_tools//tools/osx:xcode_configure.bzl%xcode_configure_extension": {
       "general": {
         "bzlTransitiveDigest": "Qh2bWTU6QW6wkrd87qrU4YeY+SG37Nvw3A0PR4Y0L2Y=",
         "accumulatedFileDigests": {},
@@ -1059,7 +1059,7 @@
         }
       }
     },
-    "@bazel_tools//tools/sh:sh_configure.bzl%sh_configure_extension": {
+    "@@bazel_tools//tools/sh:sh_configure.bzl%sh_configure_extension": {
       "general": {
         "bzlTransitiveDigest": "hp4NgmNjEg5+xgvzfh6L83bt9/aiiWETuNpwNuF1MSU=",
         "accumulatedFileDigests": {},
@@ -1075,9 +1075,9 @@
         }
       }
     },
-    "@buildifier_prebuilt~6.0.0.1//:defs.bzl%buildifier_prebuilt_deps_extension": {
+    "@@buildifier_prebuilt~6.0.0.1//:defs.bzl%buildifier_prebuilt_deps_extension": {
       "general": {
-        "bzlTransitiveDigest": "YqU/p1evGwVfmjGWRWMh2A2ufdYX2RglvtJlMQW4aV0=",
+        "bzlTransitiveDigest": "rw0w83IFOd+utieoxefELpxmQT7CxmI9Bd1pKxwbgZE=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -1196,9 +1196,9 @@
         }
       }
     },
-    "@rules_go~0.41.0//go:extensions.bzl%go_sdk": {
+    "@@rules_go~0.41.0//go:extensions.bzl%go_sdk": {
       "general": {
-        "bzlTransitiveDigest": "AaWHRBD/gHkNT2tZ68M6uuVkR6o8sNfgmBp5kia672Y=",
+        "bzlTransitiveDigest": "QaU0mhA+aom4ENV5sBUAEDa9IQt53GtspLCjl89277c=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -1252,9 +1252,9 @@
         }
       }
     },
-    "@rules_java~7.1.0//java:extensions.bzl%toolchains": {
+    "@@rules_java~7.1.0//java:extensions.bzl%toolchains": {
       "general": {
-        "bzlTransitiveDigest": "EXsxSX2vQjCcI8jYez/O+Yb9H5reAMhLL3WXGPD6Scw=",
+        "bzlTransitiveDigest": "iUIRqCK7tkhvcDJCAfPPqSd06IHG0a8HQD0xeQyVAqw=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {

--- a/tests/bzltidy_tests/workspace/child_workspaces/foo/MODULE.bazel.lock
+++ b/tests/bzltidy_tests/workspace/child_workspaces/foo/MODULE.bazel.lock
@@ -995,7 +995,7 @@
     }
   },
   "moduleExtensions": {
-    "@apple_support~1.5.0//crosstool:setup.bzl%apple_cc_configure_extension": {
+    "@@apple_support~1.5.0//crosstool:setup.bzl%apple_cc_configure_extension": {
       "general": {
         "bzlTransitiveDigest": "pMLFCYaRPkgXPQ8vtuNkMfiHfPmRBy6QJfnid4sWfv0=",
         "accumulatedFileDigests": {},
@@ -1018,7 +1018,7 @@
         }
       }
     },
-    "@bazel_tools//tools/cpp:cc_configure.bzl%cc_configure_extension": {
+    "@@bazel_tools//tools/cpp:cc_configure.bzl%cc_configure_extension": {
       "general": {
         "bzlTransitiveDigest": "O9sf6ilKWU9Veed02jG9o2HM/xgV/UAyciuFBuxrFRY=",
         "accumulatedFileDigests": {},
@@ -1041,7 +1041,7 @@
         }
       }
     },
-    "@bazel_tools//tools/osx:xcode_configure.bzl%xcode_configure_extension": {
+    "@@bazel_tools//tools/osx:xcode_configure.bzl%xcode_configure_extension": {
       "general": {
         "bzlTransitiveDigest": "Qh2bWTU6QW6wkrd87qrU4YeY+SG37Nvw3A0PR4Y0L2Y=",
         "accumulatedFileDigests": {},
@@ -1059,7 +1059,7 @@
         }
       }
     },
-    "@bazel_tools//tools/sh:sh_configure.bzl%sh_configure_extension": {
+    "@@bazel_tools//tools/sh:sh_configure.bzl%sh_configure_extension": {
       "general": {
         "bzlTransitiveDigest": "hp4NgmNjEg5+xgvzfh6L83bt9/aiiWETuNpwNuF1MSU=",
         "accumulatedFileDigests": {},
@@ -1075,9 +1075,9 @@
         }
       }
     },
-    "@buildifier_prebuilt~6.0.0.1//:defs.bzl%buildifier_prebuilt_deps_extension": {
+    "@@buildifier_prebuilt~6.0.0.1//:defs.bzl%buildifier_prebuilt_deps_extension": {
       "general": {
-        "bzlTransitiveDigest": "YqU/p1evGwVfmjGWRWMh2A2ufdYX2RglvtJlMQW4aV0=",
+        "bzlTransitiveDigest": "rw0w83IFOd+utieoxefELpxmQT7CxmI9Bd1pKxwbgZE=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -1196,9 +1196,9 @@
         }
       }
     },
-    "@rules_go~0.41.0//go:extensions.bzl%go_sdk": {
+    "@@rules_go~0.41.0//go:extensions.bzl%go_sdk": {
       "general": {
-        "bzlTransitiveDigest": "AaWHRBD/gHkNT2tZ68M6uuVkR6o8sNfgmBp5kia672Y=",
+        "bzlTransitiveDigest": "QaU0mhA+aom4ENV5sBUAEDa9IQt53GtspLCjl89277c=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -1252,9 +1252,9 @@
         }
       }
     },
-    "@rules_java~7.1.0//java:extensions.bzl%toolchains": {
+    "@@rules_java~7.1.0//java:extensions.bzl%toolchains": {
       "general": {
-        "bzlTransitiveDigest": "EXsxSX2vQjCcI8jYez/O+Yb9H5reAMhLL3WXGPD6Scw=",
+        "bzlTransitiveDigest": "iUIRqCK7tkhvcDJCAfPPqSd06IHG0a8HQD0xeQyVAqw=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {


### PR DESCRIPTION
The `MODULE.bazel.lock` file can change between Bazel versions. Hence, the `:tidy_modified` test can only pass on a single Bazel version. The PR updates the test to work with 7.0.0.rc4.

Closes #371.