### PR TITLE
fix: generate release notes test

### DIFF
--- a/bzlrelease/tools/generate_release_notes.sh
+++ b/bzlrelease/tools/generate_release_notes.sh
@@ -90,6 +90,8 @@ if [[ -n "${generate_module_snippet:-}" ]]; then
 fi
 
 release_notes_md="$(cat <<-EOF
+## What Has Changed
+
 ${changelog_md}
 EOF
 )"

--- a/tests/bzlrelease_tests/tools_tests/generate_release_notes_test.sh
+++ b/tests/bzlrelease_tests/tools_tests/generate_release_notes_test.sh
@@ -99,7 +99,7 @@ actual="$(
     --generate_workspace_snippet "${generate_workspace_snippet_sh}" \
     "${tag}" 
 )"
-assert_match "## What's Changed" "${actual}"
+assert_match "## What Has Changed" "${actual}"
 assert_match "## Workspace Snippet" "${actual}"
 assert_match "WORKSPACE SNIPPET CONTENT" "${actual}"
 assert_no_match "## Bazel Module Snippet" "${actual}"
@@ -109,7 +109,7 @@ actual="$(
     --generate_module_snippet "${generate_module_snippet_sh}" \
     "${tag}" 
 )"
-assert_match "## What's Changed" "${actual}"
+assert_match "## What Has Changed" "${actual}"
 assert_match "## Bazel Module Snippet" "${actual}"
 assert_match "MODULE SNIPPET CONTENT" "${actual}"
 assert_no_match "## Workspace Snippet" "${actual}"


### PR DESCRIPTION
The output of the GitHub API changed. Updated the script to account for the changes.