### PR TITLE
fix: add Bazel version to the `run_tests` section of BCR presubmit

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -7,5 +7,6 @@ bcr_test_module:
     run_tests:
       name: "Run test module"
       platform: ${{ platform }}
+      bazel: ${{ bazel }}
       test_targets:
         - "//..."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ name: Continuous Integration
       - test_main
   schedule:
     - cron: 13 11 * * *
+  workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ name: Continuous Integration
       - test_main
   schedule:
     - cron: 13 11 * * *
-  workflow_dispatch:
+  workflow_dispatch: {}
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/ci/tools/generate_ci_workflow/internal/github/workflow.go
+++ b/ci/tools/generate_ci_workflow/internal/github/workflow.go
@@ -27,8 +27,9 @@ func NewWorkflowFromYAML(b []byte) (*Workflow, error) {
 
 // WorkflowTriggers represents the triggers for a workflow.
 type WorkflowTriggers struct {
-	PullRequest PullRequestEvent `yaml:"pull_request"`
-	Schedule    []Schedule       `yaml:"schedule,omitempty"`
+	PullRequest      PullRequestEvent `yaml:"pull_request"`
+	Schedule         []Schedule       `yaml:"schedule,omitempty"`
+	WorkflowDispatch WorkflowDispatch `yaml:"workflow_dispatch"`
 }
 
 // PullRequestEvent is a trigger event.
@@ -40,6 +41,8 @@ type PullRequestEvent struct {
 type Schedule struct {
 	Cron string `yaml:"cron"`
 }
+
+type WorkflowDispatch struct{}
 
 // Concurrency describes how concurrent workflows should be handled.
 type Concurrency struct {

--- a/tests/bzlrelease_tests/rules_tests/generate_release_notes_tests/generate_release_notes_test.sh
+++ b/tests/bzlrelease_tests/rules_tests/generate_release_notes_tests/generate_release_notes_test.sh
@@ -42,12 +42,12 @@ tag="v999.0.0"
 # Test with template
 actual="$( "${generate_release_notes_with_template_sh}" "${tag}" )"
 assert_match "name = \"cgrindel_bazel_starlib\"" "${actual}" "Did not find workspace name."
-assert_match "## What's Changed" "${actual}" "Did not find release notes header."
+assert_match "## What Has Changed" "${actual}" "Did not find release notes header."
 assert_match "bazel_starlib_dependencies()" "${actual}" "Did not find template content."
 
 # Test with workspace_name
 actual="$( "${generate_release_notes_with_workspace_name_sh}" "${tag}" )"
 assert_match "name = \"foo_bar\"" "${actual}" "Did not find workspace name."
-assert_match "## What's Changed" "${actual}" "Did not find release notes header."
+assert_match "## What Has Changed" "${actual}" "Did not find release notes header."
 assert_match "bazel_starlib_dependencies()" "${actual}" "Did not find template content."
 assert_match "bazel_dep\(" "${actual}" "Did not find module snippet"


### PR DESCRIPTION
- Apply the generate_release_notes_test fix again.
- Add `workflow_dispatch` to the CI workflow.