### PR TITLE
fix: windows issues

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -21,6 +21,13 @@ build:ci --//build:execution_env=ci
 common --enable_bzlmod
 build --@cgrindel_bazel_starlib//bzlmod:enabled
 
+# windows stuff
+startup --windows_enable_symlinks
+common --enable_runfiles
+common --override_module=bazel_skylib=d:\\workdir\\github\\bazel-skylib
+#common --override_module=aspect_bazel_lib=d:\\workdir\\bazel-lib2
+common --test_env=BAZEL_SH
+
 # Try to import a local.rc file; typically, written by CI
 try-import %workspace%/local.bazelrc
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -7,7 +7,7 @@ build --deleted_packages=examples/bzlformat/simple,examples/bzlformat/simple/moc
 query --deleted_packages=examples/bzlformat/simple,examples/bzlformat/simple/mockascript,examples/bzlformat/simple/mockascript/internal,examples/bzlmod_e2e,examples/bzlmod_e2e/header,examples/bzlmod_e2e/mockascript,examples/bzlmod_e2e/mockascript/internal,examples/bzlmod_e2e/srcs/Bar,examples/bzlmod_e2e/srcs/Foo,examples/markdown/simple,examples/markdown/simple/bar,examples/updatesrc/simple,examples/updatesrc/simple/header,examples/updatesrc/simple/srcs/Bar,examples/updatesrc/simple/srcs/Foo,tests/bzlformat_tests/tools_tests/missing_pkgs_tests/workspace,tests/bzlformat_tests/tools_tests/missing_pkgs_tests/workspace/foo,tests/bzlformat_tests/tools_tests/missing_pkgs_tests/workspace/foo/bar,tests/bzltidy_tests/workspace,tests/bzltidy_tests/workspace/child_workspaces/bar,tests/bzltidy_tests/workspace/child_workspaces/foo,tests/updatesrc_tests/workspace/diff_and_update_test,tests/updatesrc_tests/workspace/diff_and_update_test/with_custom_values,tests/updatesrc_tests/workspace/diff_and_update_test/with_defaults,tests/updatesrc_tests/workspace/letters
 
 # Import Shared settings
-import %workspace%/shared.bazelrc
+import %workspace%/shared.bazelrc#
 
 # Import CI settings.
 import %workspace%/ci.bazelrc
@@ -21,12 +21,8 @@ build:ci --//build:execution_env=ci
 common --enable_bzlmod
 build --@cgrindel_bazel_starlib//bzlmod:enabled
 
-# windows stuff
+# windows requires symlinks to work well
 startup --windows_enable_symlinks
-common --enable_runfiles
-common --override_module=bazel_skylib=d:\\workdir\\github\\bazel-skylib
-#common --override_module=aspect_bazel_lib=d:\\workdir\\bazel-lib2
-common --test_env=BAZEL_SH
 
 # Try to import a local.rc file; typically, written by CI
 try-import %workspace%/local.bazelrc

--- a/.bazelrc
+++ b/.bazelrc
@@ -7,7 +7,7 @@ build --deleted_packages=examples/bzlformat/simple,examples/bzlformat/simple/moc
 query --deleted_packages=examples/bzlformat/simple,examples/bzlformat/simple/mockascript,examples/bzlformat/simple/mockascript/internal,examples/bzlmod_e2e,examples/bzlmod_e2e/header,examples/bzlmod_e2e/mockascript,examples/bzlmod_e2e/mockascript/internal,examples/bzlmod_e2e/srcs/Bar,examples/bzlmod_e2e/srcs/Foo,examples/markdown/simple,examples/markdown/simple/bar,examples/updatesrc/simple,examples/updatesrc/simple/header,examples/updatesrc/simple/srcs/Bar,examples/updatesrc/simple/srcs/Foo,tests/bzlformat_tests/tools_tests/missing_pkgs_tests/workspace,tests/bzlformat_tests/tools_tests/missing_pkgs_tests/workspace/foo,tests/bzlformat_tests/tools_tests/missing_pkgs_tests/workspace/foo/bar,tests/bzltidy_tests/workspace,tests/bzltidy_tests/workspace/child_workspaces/bar,tests/bzltidy_tests/workspace/child_workspaces/foo,tests/updatesrc_tests/workspace/diff_and_update_test,tests/updatesrc_tests/workspace/diff_and_update_test/with_custom_values,tests/updatesrc_tests/workspace/diff_and_update_test/with_defaults,tests/updatesrc_tests/workspace/letters
 
 # Import Shared settings
-import %workspace%/shared.bazelrc#
+import %workspace%/shared.bazelrc
 
 # Import CI settings.
 import %workspace%/ci.bazelrc

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# The behavior of core.autocrlf=input is to force conversion to LF on addition
+# into the repository and not to perform any conversion on checkout; that is,
+# to always use LF endings regardless of the user's settings. This is set in 
+# .gitattributes as '* eol=lf'
+* eol=lf

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -24,9 +24,13 @@ bazel_dep(
 )
 bazel_dep(
     name = "buildifier_prebuilt",
-    version = "6.0.0.1",
+    version = "6.1.2",
 )
 bazel_dep(name = "platforms", version = "0.0.6")
+bazel_dep(
+    name = "aspect_bazel_lib", 
+    version = "2.0.1"
+)
 
 go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")

--- a/bzlformat/private/BUILD.bazel
+++ b/bzlformat/private/BUILD.bazel
@@ -20,6 +20,7 @@ bzl_library(
         ":bzlformat_format",
         "//bzllib:defs",
         "//updatesrc:defs",
+        "@aspect_bazel_lib//lib:windows_utils",
         "@bazel_skylib//rules:diff_test",
     ],
 )

--- a/tests/bzlformat_tests/BUILD.bazel
+++ b/tests/bzlformat_tests/BUILD.bazel
@@ -53,6 +53,7 @@ _FORMAT_INFOS = [
         name = fi[0] + "_bzl",
         out = fi[0] + ".bzl",
         content = fi[1],
+        newline = "unix",
     )
     for fi in _FORMAT_INFOS
 ]
@@ -64,11 +65,13 @@ bzlformat_format(
 )
 
 # Write the expected content
+# buildifier writes unix newlines; match that
 [
     write_file(
         name = fi[0] + "_bzl_expected",
         out = fi[0] + ".bzl.expected",
         content = fi[2],
+        newline = "unix",
     )
     for fi in _FORMAT_INFOS
 ]

--- a/tests/bzlrelease_tests/rules_tests/release_artifact_tests/archive_test.sh
+++ b/tests/bzlrelease_tests/rules_tests/release_artifact_tests/archive_test.sh
@@ -11,20 +11,35 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v3 ---
 
+# return a unix-style path on all platforms
+# workaround for https://github.com/bazelbuild/bazel/issues/22803
+function rlocation_as_unix() {
+  path=$(rlocation ${1})
+  case "$(uname -s)" in
+  CYGWIN* | MINGW32* | MSYS* | MINGW*)
+    path=${path//\\//} # backslashes to forward
+    path=/${path//:/}  # d:/ to /d/
+    ;;
+  esac
+  echo $path
+}
+
 # MARK - Locate Deps
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+assertions_sh="$(rlocation_as_unix "${assertions_sh_location}")" || \
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/assertions.sh
 source "${assertions_sh}"
 
 archive_tar_gz_location=cgrindel_bazel_starlib/tests/bzlrelease_tests/rules_tests/release_artifact_tests/archive.tar.gz
-archive_tar_gz="$(rlocation "${archive_tar_gz_location}")" || \
+archive_tar_gz="$(rlocation_as_unix "${archive_tar_gz_location}")" || \
   (echo >&2 "Failed to locate ${archive_tar_gz_location}" && exit 1)
+
 
 # MARK - Test
 
+echo ${archive_tar_gz}
 contents="$(tar -tf "${archive_tar_gz}")"
 assert_match "bzlrelease/" "${contents}" 
 assert_match "bzlrelease/private/" "${contents}" 

--- a/updatesrc/private/updatesrc_diff_and_update.bzl
+++ b/updatesrc/private/updatesrc_diff_and_update.bzl
@@ -57,6 +57,7 @@ def updatesrc_diff_and_update(
             name = diff_test_prefix + src_name + diff_test_suffix,
             file1 = src,
             file2 = out,
+            file2_to_lf = True,
             visibility = diff_test_visibility,
             **kwargs
         )

--- a/updatesrc/private/updatesrc_diff_and_update.bzl
+++ b/updatesrc/private/updatesrc_diff_and_update.bzl
@@ -53,6 +53,7 @@ def updatesrc_diff_and_update(
         src = srcs[idx]
         out = outs[idx]
         src_name = src.replace("/", "_")
+
         # this difftest fails as file2 has CRLf on windows
         # fix: https://github.com/bazelbuild/bazel-skylib/pull/527
         diff_test(

--- a/updatesrc/private/updatesrc_diff_and_update.bzl
+++ b/updatesrc/private/updatesrc_diff_and_update.bzl
@@ -53,11 +53,12 @@ def updatesrc_diff_and_update(
         src = srcs[idx]
         out = outs[idx]
         src_name = src.replace("/", "_")
+        # this difftest fails as file2 has CRLf on windows
+        # fix: https://github.com/bazelbuild/bazel-skylib/pull/527
         diff_test(
             name = diff_test_prefix + src_name + diff_test_suffix,
             file1 = src,
             file2 = out,
-            file2_to_lf = True,
             visibility = diff_test_visibility,
             **kwargs
         )


### PR DESCRIPTION
There are multiple issues on windows:

1. * bazel-skylib diff_test is case sensitive, fix pending https://github.com/bazelbuild/bazel-skylib/pull/527
2. * git clone on windows by default clones CRLF, breaking many tests
3. * buildifier_prebuilt version used doesn't include windows binaries
4. * no windows launcher for bzlformat_lint_test, resulting in bazel errors
5. * archive_test fails with a tar error

Issues 2-5 above are all fixed by this PR

### Test results (windows)
(still filling in these results)
Before
--enable_runfiles
--noenable_run

With this PR only
--enable_runfiles 34 failures
--noenable_runfiles

With this PR and https://github.com/bazelbuild/bazel-skylib/pull/527
--enable_runfiles 0 failures
--noenable_runfiles 85 failures

### Future activity
Note: most of the --noenable_runfiles failures are of this form:
```
INFO: From Testing //tests/shlib_tests/lib_tests/files_tests:bzlformat_lint_test:
==================== Test output for //tests/shlib_tests/lib_tests/files_tests:bzlformat_lint_test:
D:/udu/b/356umzpb/execroot/_main/bazel-out/x64_windows-fastbuild/bin/tests/shlib_tests/lib_tests/files_tests/bzlformat_lint_test.sh: line 14: tests/shlib_tests/lib_tests/files_tests/bzlformat_lint_test_BUILD.bazel.sh: No such file or directory
tests/shlib_tests/lib_tests/files_tests/bzlformat_lint_test_BUILD.bazel.sh failed with 127.
1 lint tests failed.
================================================================================
```

Look into this:
```
INFO: From Action tests/bzlrelease_tests/rules_tests/generate_workspace_snippet_tests/archive_sha256:
which: no shasum in (/usr/bin:/usr/bin:/bin:/c/WINDOWS:/c/WINDOWS/System32:/c/WINDOWS/System32/WindowsPowerShell/v1.0)
```
