### PR TITLE
chore: upgrade stardoc to 0.6.2

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,7 +19,7 @@ bazel_dep(
 bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(
     name = "stardoc",
-    version = "0.5.6",
+    version = "0.6.2",
     repo_name = "io_bazel_stardoc",
 )
 bazel_dep(

--- a/doc/bazeldoc/build_rules_overview.md
+++ b/doc/bazeldoc/build_rules_overview.md
@@ -29,7 +29,7 @@ Defines targets for generating documentation, testing that the generated doc mat
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="doc_for_provs-doc_provs"></a>doc_provs |  A <code>list</code> of document provider <code>struct</code> values as returned from <code>providers.create()</code>.   |  none |
+| <a id="doc_for_provs-doc_provs"></a>doc_provs |  A `list` of document provider `struct` values as returned from `providers.create()`.   |  none |
 | <a id="doc_for_provs-kwargs"></a>kwargs |  Common attributes that are applied to the underlying rules.   |  none |
 
 
@@ -49,10 +49,10 @@ Defines a target that writes a documentation file that contains a header and a l
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="write_file_list-name"></a>name |  The name of the target.   |  none |
-| <a id="write_file_list-out"></a>out |  The basename of the output filename as a <code>string</code>.   |  none |
-| <a id="write_file_list-header_content"></a>header_content |  A <code>list</code> of strings representing the header content of the file.   |  <code>[]</code> |
-| <a id="write_file_list-doc_provs"></a>doc_provs |  A <code>list</code> of document provider <code>struct</code> values as returned from <code>providers.create()</code>.   |  <code>[]</code> |
-| <a id="write_file_list-do_not_edit_warning"></a>do_not_edit_warning |  A <code>bool</code> specifying whether a comment should be added to the top of the written file.   |  <code>True</code> |
+| <a id="write_file_list-out"></a>out |  The basename of the output filename as a `string`.   |  none |
+| <a id="write_file_list-header_content"></a>header_content |  A `list` of strings representing the header content of the file.   |  `[]` |
+| <a id="write_file_list-doc_provs"></a>doc_provs |  A `list` of document provider `struct` values as returned from `providers.create()`.   |  `[]` |
+| <a id="write_file_list-do_not_edit_warning"></a>do_not_edit_warning |  A `bool` specifying whether a comment should be added to the top of the written file.   |  `True` |
 
 **RETURNS**
 
@@ -75,10 +75,10 @@ Defines a target that writes a header file that will be used as a header templat
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="write_header-name"></a>name |  The name of the target.   |  none |
-| <a id="write_header-out"></a>out |  The basename of the output filename as a <code>string</code>.   |  <code>None</code> |
-| <a id="write_header-header_content"></a>header_content |  A <code>list</code> of strings representing the header content of the file.   |  <code>[]</code> |
-| <a id="write_header-symbols"></a>symbols |  A <code>list</code> of symbol names that will be included in the documentation.   |  <code>[]</code> |
-| <a id="write_header-do_not_edit_warning"></a>do_not_edit_warning |  A <code>bool</code> specifying whether a comment should be added to the top of the written file.   |  <code>True</code> |
+| <a id="write_header-out"></a>out |  The basename of the output filename as a `string`.   |  `None` |
+| <a id="write_header-header_content"></a>header_content |  A `list` of strings representing the header content of the file.   |  `[]` |
+| <a id="write_header-symbols"></a>symbols |  A `list` of symbol names that will be included in the documentation.   |  `[]` |
+| <a id="write_header-do_not_edit_warning"></a>do_not_edit_warning |  A `bool` specifying whether a comment should be added to the top of the written file.   |  `True` |
 
 **RETURNS**
 

--- a/doc/bazeldoc/providers.md
+++ b/doc/bazeldoc/providers.md
@@ -18,16 +18,16 @@ Create a documentation provider.
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="providers.create-name"></a>name |  A <code>string</code> which identifies the doc output. If no <code>symbols</code> are provided, all of the symbols which are defined in the corresponding <code>.bzl</code> file are documented.   |  none |
-| <a id="providers.create-stardoc_input"></a>stardoc_input |  A <code>string</code> representing the input label provided to the <code>stardoc</code> declaration.   |  none |
-| <a id="providers.create-deps"></a>deps |  A <code>list</code> of deps for the stardoc rule.   |  none |
-| <a id="providers.create-doc_label"></a>doc_label |  Optional. A <code>string</code> which is the doc label name.   |  <code>None</code> |
-| <a id="providers.create-out_basename"></a>out_basename |  Optional. A <code>string</code> which is the basename for the output file.   |  <code>None</code> |
-| <a id="providers.create-doc_basename"></a>doc_basename |  Optional. A <code>string</code> which is the basename for the final documentation file.   |  <code>None</code> |
-| <a id="providers.create-header_label"></a>header_label |  Optional. A <code>string</code> which is the header label name, if the header is being generated.   |  <code>None</code> |
-| <a id="providers.create-header_basename"></a>header_basename |  Optional. The basename (<code>string</code>) of the header filename file, if one is being used.   |  <code>None</code> |
-| <a id="providers.create-symbols"></a>symbols |  Optional. A <code>list</code> of symbol names that should be included in the documentation.   |  <code>None</code> |
-| <a id="providers.create-is_stardoc"></a>is_stardoc |  A <code>bool</code> indicating whether a <code>stardoc</code> declaration should be created.   |  <code>True</code> |
+| <a id="providers.create-name"></a>name |  A `string` which identifies the doc output. If no `symbols` are provided, all of the symbols which are defined in the corresponding `.bzl` file are documented.   |  none |
+| <a id="providers.create-stardoc_input"></a>stardoc_input |  A `string` representing the input label provided to the `stardoc` declaration.   |  none |
+| <a id="providers.create-deps"></a>deps |  A `list` of deps for the stardoc rule.   |  none |
+| <a id="providers.create-doc_label"></a>doc_label |  Optional. A `string` which is the doc label name.   |  `None` |
+| <a id="providers.create-out_basename"></a>out_basename |  Optional. A `string` which is the basename for the output file.   |  `None` |
+| <a id="providers.create-doc_basename"></a>doc_basename |  Optional. A `string` which is the basename for the final documentation file.   |  `None` |
+| <a id="providers.create-header_label"></a>header_label |  Optional. A `string` which is the header label name, if the header is being generated.   |  `None` |
+| <a id="providers.create-header_basename"></a>header_basename |  Optional. The basename (`string`) of the header filename file, if one is being used.   |  `None` |
+| <a id="providers.create-symbols"></a>symbols |  Optional. A `list` of symbol names that should be included in the documentation.   |  `None` |
+| <a id="providers.create-is_stardoc"></a>is_stardoc |  A `bool` indicating whether a `stardoc` declaration should be created.   |  `True` |
 
 **RETURNS**
 

--- a/doc/bzlformat/rules_and_macros_overview.md
+++ b/doc/bzlformat/rules_and_macros_overview.md
@@ -17,7 +17,7 @@ On this page:
 ## bzlformat_format
 
 <pre>
-bzlformat_format(<a href="#bzlformat_format-name">name</a>, <a href="#bzlformat_format-fix_lint_warnings">fix_lint_warnings</a>, <a href="#bzlformat_format-output_suffix">output_suffix</a>, <a href="#bzlformat_format-srcs">srcs</a>, <a href="#bzlformat_format-warnings">warnings</a>)
+bzlformat_format(<a href="#bzlformat_format-name">name</a>, <a href="#bzlformat_format-srcs">srcs</a>, <a href="#bzlformat_format-fix_lint_warnings">fix_lint_warnings</a>, <a href="#bzlformat_format-output_suffix">output_suffix</a>, <a href="#bzlformat_format-warnings">warnings</a>)
 </pre>
 
 Formats Starlark source files using Buildifier.
@@ -28,10 +28,10 @@ Formats Starlark source files using Buildifier.
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="bzlformat_format-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="bzlformat_format-fix_lint_warnings"></a>fix_lint_warnings |  Should lint warnings be fixed, if possible.   | Boolean | optional | <code>True</code> |
-| <a id="bzlformat_format-output_suffix"></a>output_suffix |  The suffix added to the formatted output filename.   | String | optional | <code>".formatted"</code> |
 | <a id="bzlformat_format-srcs"></a>srcs |  The Starlark source files to format.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
-| <a id="bzlformat_format-warnings"></a>warnings |  The warnings that should be fixed if lint fix is enabled.   | String | optional | <code>"all"</code> |
+| <a id="bzlformat_format-fix_lint_warnings"></a>fix_lint_warnings |  Should lint warnings be fixed, if possible.   | Boolean | optional |  `True`  |
+| <a id="bzlformat_format-output_suffix"></a>output_suffix |  The suffix added to the formatted output filename.   | String | optional |  `".formatted"`  |
+| <a id="bzlformat_format-warnings"></a>warnings |  The warnings that should be fixed if lint fix is enabled.   | String | optional |  `"all"`  |
 
 
 <a id="bzlformat_lint_test"></a>
@@ -51,7 +51,7 @@ Lints the specified Starlark files using Buildifier.
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="bzlformat_lint_test-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="bzlformat_lint_test-srcs"></a>srcs |  The Starlark source files to lint.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
-| <a id="bzlformat_lint_test-warnings"></a>warnings |  The warnings that should be fixed if lint fix is enabled.   | String | optional | <code>"all"</code> |
+| <a id="bzlformat_lint_test-warnings"></a>warnings |  The warnings that should be fixed if lint fix is enabled.   | String | optional |  `"all"`  |
 
 
 <a id="bzlformat_missing_pkgs"></a>
@@ -84,8 +84,8 @@ following targets are defined:
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="bzlformat_missing_pkgs-name"></a>name |  A <code>string</code> that acts as the prefix for the target names that are defined.   |  none |
-| <a id="bzlformat_missing_pkgs-exclude"></a>exclude |  A <code>list</code> of packages to exclude from the find, test and fix operations. Each package should be specifed in the format <code>//path/to/package</code>.   |  <code>[]</code> |
+| <a id="bzlformat_missing_pkgs-name"></a>name |  A `string` that acts as the prefix for the target names that are defined.   |  none |
+| <a id="bzlformat_missing_pkgs-exclude"></a>exclude |  A `list` of packages to exclude from the find, test and fix operations. Each package should be specifed in the format `//path/to/package`.   |  `[]` |
 
 **RETURNS**
 
@@ -110,12 +110,12 @@ NOTE: Any labels detected in the `srcs` will be ignored.
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="bzlformat_pkg-name"></a>name |  The prefix <code>string</code> that is used when creating the targets.   |  <code>"bzlformat"</code> |
-| <a id="bzlformat_pkg-srcs"></a>srcs |  Optional. A <code>list</code> of Starlark source files. If no value is provided, any files that match <code>*.bzl</code>, <code>BUILD</code> or <code>BUILD.bazel</code> are used.   |  <code>None</code> |
-| <a id="bzlformat_pkg-lint_test"></a>lint_test |  Optional. A <code>bool</code> specifying whether a lint test should be defined.   |  <code>True</code> |
-| <a id="bzlformat_pkg-format_visibility"></a>format_visibility |  Optional. A <code>list</code> of Bazel visibility declarations for the format targets.   |  <code>None</code> |
-| <a id="bzlformat_pkg-update_visibility"></a>update_visibility |  Optional. A <code>list</code> of Bazel visibility declarations for the update target.   |  <code>None</code> |
-| <a id="bzlformat_pkg-lint_test_visibility"></a>lint_test_visibility |  Optional. A <code>list</code> of Bazel visibility declarations for the lint test target.   |  <code>None</code> |
+| <a id="bzlformat_pkg-name"></a>name |  The prefix `string` that is used when creating the targets.   |  `"bzlformat"` |
+| <a id="bzlformat_pkg-srcs"></a>srcs |  Optional. A `list` of Starlark source files. If no value is provided, any files that match `*.bzl`, `BUILD` or `BUILD.bazel` are used.   |  `None` |
+| <a id="bzlformat_pkg-lint_test"></a>lint_test |  Optional. A `bool` specifying whether a lint test should be defined.   |  `True` |
+| <a id="bzlformat_pkg-format_visibility"></a>format_visibility |  Optional. A `list` of Bazel visibility declarations for the format targets.   |  `None` |
+| <a id="bzlformat_pkg-update_visibility"></a>update_visibility |  Optional. A `list` of Bazel visibility declarations for the update target.   |  `None` |
+| <a id="bzlformat_pkg-lint_test_visibility"></a>lint_test_visibility |  Optional. A `list` of Bazel visibility declarations for the lint test target.   |  `None` |
 
 **RETURNS**
 

--- a/doc/bzllib/bazel_labels.md
+++ b/doc/bzllib/bazel_labels.md
@@ -18,30 +18,8 @@ bazel_labels.new(<a href="#bazel_labels.new-name">name</a>, <a href="#bazel_labe
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="bazel_labels.new-name"></a>name |  <p align="center"> - </p>   |  none |
-| <a id="bazel_labels.new-repository_name"></a>repository_name |  <p align="center"> - </p>   |  <code>None</code> |
-| <a id="bazel_labels.new-package"></a>package |  <p align="center"> - </p>   |  <code>None</code> |
-
-
-<a id="bazel_labels.parse"></a>
-
-## bazel_labels.parse
-
-<pre>
-bazel_labels.parse(<a href="#bazel_labels.parse-value">value</a>)
-</pre>
-
-Parse a string as a Bazel label returning its parts.
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="bazel_labels.parse-value"></a>value |  A <code>string</code> value to parse.   |  none |
-
-**RETURNS**
-
-A `struct` as returned from `bazel_labels.create`.
+| <a id="bazel_labels.new-repository_name"></a>repository_name |  <p align="center"> - </p>   |  `None` |
+| <a id="bazel_labels.new-package"></a>package |  <p align="center"> - </p>   |  `None` |
 
 
 <a id="bazel_labels.normalize"></a>
@@ -59,10 +37,32 @@ Converts a value into a Bazel label string.
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="bazel_labels.normalize-value"></a>value |  A <code>Label</code>, <code>struct</code> from <code>bazel_labels.new</code>, or a <code>string</code>.   |  none |
+| <a id="bazel_labels.normalize-value"></a>value |  A `Label`, `struct` from `bazel_labels.new`, or a `string`.   |  none |
 
 **RETURNS**
 
 A fully-formed Bazel label string.
+
+
+<a id="bazel_labels.parse"></a>
+
+## bazel_labels.parse
+
+<pre>
+bazel_labels.parse(<a href="#bazel_labels.parse-value">value</a>)
+</pre>
+
+Parse a string as a Bazel label returning its parts.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="bazel_labels.parse-value"></a>value |  A `string` value to parse.   |  none |
+
+**RETURNS**
+
+A `struct` as returned from `bazel_labels.create`.
 
 

--- a/doc/bzllib/filter_srcs.md
+++ b/doc/bzllib/filter_srcs.md
@@ -7,7 +7,7 @@
 ## filter_srcs
 
 <pre>
-filter_srcs(<a href="#filter_srcs-name">name</a>, <a href="#filter_srcs-expected_count">expected_count</a>, <a href="#filter_srcs-filename_ends_with">filename_ends_with</a>, <a href="#filter_srcs-srcs">srcs</a>)
+filter_srcs(<a href="#filter_srcs-name">name</a>, <a href="#filter_srcs-srcs">srcs</a>, <a href="#filter_srcs-expected_count">expected_count</a>, <a href="#filter_srcs-filename_ends_with">filename_ends_with</a>)
 </pre>
 
 Filters the provided inputs using the specified criteria.
@@ -18,8 +18,8 @@ Filters the provided inputs using the specified criteria.
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="filter_srcs-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="filter_srcs-expected_count"></a>expected_count |  The expected number of results.   | Integer | optional | <code>-1</code> |
-| <a id="filter_srcs-filename_ends_with"></a>filename_ends_with |  The suffix of the path will be compared to this value.   | String | optional | <code>""</code> |
 | <a id="filter_srcs-srcs"></a>srcs |  The inputs that will be evaluated by the filter.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
+| <a id="filter_srcs-expected_count"></a>expected_count |  The expected number of results.   | Integer | optional |  `-1`  |
+| <a id="filter_srcs-filename_ends_with"></a>filename_ends_with |  The suffix of the path will be compared to this value.   | String | optional |  `""`  |
 
 

--- a/doc/bzllib/lists.md
+++ b/doc/bzllib/lists.md
@@ -17,7 +17,7 @@ Returns a new `list` with any `None` values removed.
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="lists.compact-items"></a>items |  A <code>list</code> of items to evaluate.   |  none |
+| <a id="lists.compact-items"></a>items |  A `list` of items to evaluate.   |  none |
 
 **RETURNS**
 
@@ -52,8 +52,8 @@ target, this function returns `False`.
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="lists.contains-items"></a>items |  A <code>list</code> of items to evaluate.   |  none |
-| <a id="lists.contains-target_or_fn"></a>target_or_fn |  An item to be evaluated for equality or a boolean <code>function</code>. A boolean <code>function</code> is defined as one that takes a single argument and returns a <code>bool</code> value.   |  none |
+| <a id="lists.contains-items"></a>items |  A `list` of items to evaluate.   |  none |
+| <a id="lists.contains-target_or_fn"></a>target_or_fn |  An item to be evaluated for equality or a boolean `function`. A boolean `function` is defined as one that takes a single argument and returns a `bool` value.   |  none |
 
 **RETURNS**
 
@@ -75,8 +75,8 @@ Returns a new `list` containing the items from the original that     satisfy the
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="lists.filter-items"></a>items |  A <code>list</code> of items to evaluate.   |  none |
-| <a id="lists.filter-bool_fn"></a>bool_fn |  A <code>function</code> that takes a single parameter returns a <code>bool</code> value.   |  none |
+| <a id="lists.filter-items"></a>items |  A `list` of items to evaluate.   |  none |
+| <a id="lists.filter-bool_fn"></a>bool_fn |  A `function` that takes a single parameter returns a `bool` value.   |  none |
 
 **RETURNS**
 
@@ -105,8 +105,8 @@ boolean function, this function returns `None`.
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="lists.find-items"></a>items |  A <code>list</code> of items to evaluate.   |  none |
-| <a id="lists.find-bool_fn"></a>bool_fn |  A <code>function</code> that takes a single parameter and returns a <code>bool</code> value.   |  none |
+| <a id="lists.find-items"></a>items |  A `list` of items to evaluate.   |  none |
+| <a id="lists.find-bool_fn"></a>bool_fn |  A `function` that takes a single parameter and returns a `bool` value.   |  none |
 
 **RETURNS**
 
@@ -151,8 +151,8 @@ suit your needs.
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="lists.flatten-items"></a>items |  A <code>list</code> or a single item.   |  none |
-| <a id="lists.flatten-max_iterations"></a>max_iterations |  Optional. The maximum number of processing iterations.   |  <code>10000</code> |
+| <a id="lists.flatten-items"></a>items |  A `list` or a single item.   |  none |
+| <a id="lists.flatten-max_iterations"></a>max_iterations |  Optional. The maximum number of processing iterations.   |  `10000` |
 
 **RETURNS**
 
@@ -175,8 +175,8 @@ Returns a new `list` where each item is the result of calling the map     `funct
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="lists.map-items"></a>items |  A <code>list</code> of items to evaluate.   |  none |
-| <a id="lists.map-map_fn"></a>map_fn |  A <code>function</code> that takes a single parameter returns a value that will be added to the new list at the correspnding location.   |  none |
+| <a id="lists.map-items"></a>items |  A `list` of items to evaluate.   |  none |
+| <a id="lists.map-map_fn"></a>map_fn |  A `function` that takes a single parameter returns a value that will be added to the new list at the correspnding location.   |  none |
 
 **RETURNS**
 

--- a/doc/bzllib/src_utils.md
+++ b/doc/bzllib/src_utils.md
@@ -2,28 +2,6 @@
 # `src_utils` API
 
 
-<a id="src_utils.is_path"></a>
-
-## src_utils.is_path
-
-<pre>
-src_utils.is_path(<a href="#src_utils.is_path-src">src</a>)
-</pre>
-
-Determines whether the provided string is a path.
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="src_utils.is_path-src"></a>src |  A <code>string</code> value.   |  none |
-
-**RETURNS**
-
-A `bool` specifying whether the `string` value looks like a path.
-
-
 <a id="src_utils.is_label"></a>
 
 ## src_utils.is_label
@@ -39,11 +17,33 @@ Determines whether the provided string is a label.
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="src_utils.is_label-src"></a>src |  A <code>string</code> value.   |  none |
+| <a id="src_utils.is_label-src"></a>src |  A `string` value.   |  none |
 
 **RETURNS**
 
 A `bool` specifying whether the `string` value looks like a label.
+
+
+<a id="src_utils.is_path"></a>
+
+## src_utils.is_path
+
+<pre>
+src_utils.is_path(<a href="#src_utils.is_path-src">src</a>)
+</pre>
+
+Determines whether the provided string is a path.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="src_utils.is_path-src"></a>src |  A `string` value.   |  none |
+
+**RETURNS**
+
+A `bool` specifying whether the `string` value looks like a path.
 
 
 <a id="src_utils.path_to_name"></a>
@@ -61,9 +61,9 @@ Converts a path string to a name suitable for use as a label name.
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="src_utils.path_to_name-path"></a>path |  A path as a <code>string</code>.   |  none |
-| <a id="src_utils.path_to_name-prefix"></a>prefix |  Optional. A string which will be prefixed to the namified path with an underscore separating the prefix.   |  <code>None</code> |
-| <a id="src_utils.path_to_name-suffix"></a>suffix |  Optional. A <code>string</code> which will be appended to the namified path with an underscore separating the suffix.   |  <code>None</code> |
+| <a id="src_utils.path_to_name-path"></a>path |  A path as a `string`.   |  none |
+| <a id="src_utils.path_to_name-prefix"></a>prefix |  Optional. A string which will be prefixed to the namified path with an underscore separating the prefix.   |  `None` |
+| <a id="src_utils.path_to_name-suffix"></a>suffix |  Optional. A `string` which will be appended to the namified path with an underscore separating the suffix.   |  `None` |
 
 **RETURNS**
 

--- a/doc/bzlrelease/create_release.md
+++ b/doc/bzlrelease/create_release.md
@@ -20,7 +20,7 @@ This utility expects Github's CLI (`gh`) to be installed. Running this     utili
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="create_release-name"></a>name |  The name of the executable target as a <code>string</code>.   |  none |
+| <a id="create_release-name"></a>name |  The name of the executable target as a `string`.   |  none |
 | <a id="create_release-workflow_name"></a>workflow_name |  The name of the Github Actions workflow.   |  none |
 
 

--- a/doc/bzlrelease/generate_release_notes.md
+++ b/doc/bzlrelease/generate_release_notes.md
@@ -20,8 +20,8 @@ Typically, this macro is used in conjunction with the     `generate_workspace_sn
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="generate_release_notes-name"></a>name |  The name of the executable target as a <code>string</code>.   |  none |
-| <a id="generate_release_notes-generate_workspace_snippet"></a>generate_workspace_snippet |  Optional.The label that should be executed to generate the workspace snippet.   |  <code>None</code> |
-| <a id="generate_release_notes-generate_module_snippet"></a>generate_module_snippet |  Optional.The label that should be executed to generate the Bazel module snippet.   |  <code>None</code> |
+| <a id="generate_release_notes-name"></a>name |  The name of the executable target as a `string`.   |  none |
+| <a id="generate_release_notes-generate_workspace_snippet"></a>generate_workspace_snippet |  Optional.The label that should be executed to generate the workspace snippet.   |  `None` |
+| <a id="generate_release_notes-generate_module_snippet"></a>generate_module_snippet |  Optional.The label that should be executed to generate the Bazel module snippet.   |  `None` |
 
 

--- a/doc/bzlrelease/generate_workspace_snippet.md
+++ b/doc/bzlrelease/generate_workspace_snippet.md
@@ -20,10 +20,10 @@ Without a template, the utility will output an `http_archive` declaration.     W
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="generate_workspace_snippet-name"></a>name |  The name of the executable target as a <code>string</code>.   |  none |
-| <a id="generate_workspace_snippet-template"></a>template |  Optional. The path to a template file  as a <code>string</code>.   |  <code>None</code> |
-| <a id="generate_workspace_snippet-workspace_name"></a>workspace_name |  Optional. The name of the workspace. If not provided, the workspace name is derived from the owner and repository name.   |  <code>None</code> |
-| <a id="generate_workspace_snippet-sha256_file"></a>sha256_file |  Optional. The path to a file with the SHA256 value for the release archive.   |  <code>None</code> |
-| <a id="generate_workspace_snippet-url_templates"></a>url_templates |  Optional. A <code>list</code> of templates to use when generating the URL values for the release archive.   |  <code>[]</code> |
+| <a id="generate_workspace_snippet-name"></a>name |  The name of the executable target as a `string`.   |  none |
+| <a id="generate_workspace_snippet-template"></a>template |  Optional. The path to a template file  as a `string`.   |  `None` |
+| <a id="generate_workspace_snippet-workspace_name"></a>workspace_name |  Optional. The name of the workspace. If not provided, the workspace name is derived from the owner and repository name.   |  `None` |
+| <a id="generate_workspace_snippet-sha256_file"></a>sha256_file |  Optional. The path to a file with the SHA256 value for the release archive.   |  `None` |
+| <a id="generate_workspace_snippet-url_templates"></a>url_templates |  Optional. A `list` of templates to use when generating the URL values for the release archive.   |  `[]` |
 
 

--- a/doc/bzlrelease/hash_sha256.md
+++ b/doc/bzlrelease/hash_sha256.md
@@ -7,13 +7,12 @@
 ## hash_sha256
 
 <pre>
-hash_sha256(<a href="#hash_sha256-name">name</a>, <a href="#hash_sha256-out">out</a>, <a href="#hash_sha256-src">src</a>)
+hash_sha256(<a href="#hash_sha256-name">name</a>, <a href="#hash_sha256-src">src</a>, <a href="#hash_sha256-out">out</a>)
 </pre>
 
-Generates a SHA256 hash for the specified file and writes it to a file. 
+Generates a SHA256 hash for the specified file and writes it to a file.
 
 If an output filename is provided, the value is written to a file with that name. Otherwise, it is written to a file with the name of the declaration.
-
 
 **ATTRIBUTES**
 
@@ -21,7 +20,7 @@ If an output filename is provided, the value is written to a file with that name
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="hash_sha256-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="hash_sha256-out"></a>out |  The filename for the output file.   | String | optional | <code>""</code> |
 | <a id="hash_sha256-src"></a>src |  The file whose contents should be hashed.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="hash_sha256-out"></a>out |  The filename for the output file.   | String | optional |  `""`  |
 
 

--- a/doc/bzlrelease/release_archive.md
+++ b/doc/bzlrelease/release_archive.md
@@ -7,13 +7,12 @@
 ## release_archive
 
 <pre>
-release_archive(<a href="#release_archive-name">name</a>, <a href="#release_archive-ext">ext</a>, <a href="#release_archive-out">out</a>, <a href="#release_archive-srcs">srcs</a>)
+release_archive(<a href="#release_archive-name">name</a>, <a href="#release_archive-srcs">srcs</a>, <a href="#release_archive-out">out</a>, <a href="#release_archive-ext">ext</a>)
 </pre>
 
 Create a source release archive.
 
 This rule uses `tar` to collect and compress files into an archive file suitable for use as a release artifact. Any permissions on the source files will be preserved.
-
 
 **ATTRIBUTES**
 
@@ -21,8 +20,8 @@ This rule uses `tar` to collect and compress files into an archive file suitable
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="release_archive-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="release_archive-ext"></a>ext |  The extension for the archive.   | String | optional | <code>".tar.gz"</code> |
-| <a id="release_archive-out"></a>out |  The name of the output file.   | String | optional | <code>""</code> |
 | <a id="release_archive-srcs"></a>srcs |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
+| <a id="release_archive-out"></a>out |  The name of the output file.   | String | optional |  `""`  |
+| <a id="release_archive-ext"></a>ext |  The extension for the archive.   | String | optional |  `".tar.gz"`  |
 
 

--- a/doc/bzlrelease/update_readme.md
+++ b/doc/bzlrelease/update_readme.md
@@ -12,7 +12,7 @@ update_readme(<a href="#update_readme-name">name</a>, <a href="#update_readme-ge
 
 Declares an executable target that updates a README.md with an updated workspace snippet.
 
-The utility will replace the lines between `&lt;!-- BEGIN WORKSPACE SNIPPET --&gt;` and     `&lt;!-- END WORKSPACE SNIPPET --&gt;` with the workspace snippet provided by the     `generate_workspace_snippet` utility that is provided.
+The utility will replace the lines between `<!-- BEGIN WORKSPACE SNIPPET -->` and     `<!-- END WORKSPACE SNIPPET -->` with the workspace snippet provided by the     `generate_workspace_snippet` utility that is provided.
 
 
 **PARAMETERS**
@@ -20,9 +20,9 @@ The utility will replace the lines between `&lt;!-- BEGIN WORKSPACE SNIPPET --&g
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="update_readme-name"></a>name |  The name of the executable target as a <code>string</code>.   |  none |
-| <a id="update_readme-generate_workspace_snippet"></a>generate_workspace_snippet |  Optional. The label that should be executed to generate the workspace snippet.   |  <code>None</code> |
-| <a id="update_readme-generate_module_snippet"></a>generate_module_snippet |  Optional. The label that should be executed to generate the Bazel module snippet.   |  <code>None</code> |
-| <a id="update_readme-readme"></a>readme |  A <code>string</code> representing the relative path to the README.md file from the root of the workspace.   |  <code>None</code> |
+| <a id="update_readme-name"></a>name |  The name of the executable target as a `string`.   |  none |
+| <a id="update_readme-generate_workspace_snippet"></a>generate_workspace_snippet |  Optional. The label that should be executed to generate the workspace snippet.   |  `None` |
+| <a id="update_readme-generate_module_snippet"></a>generate_module_snippet |  Optional. The label that should be executed to generate the Bazel module snippet.   |  `None` |
+| <a id="update_readme-readme"></a>readme |  A `string` representing the relative path to the README.md file from the root of the workspace.   |  `None` |
 
 

--- a/doc/bzltidy/rules_and_macros_overview.md
+++ b/doc/bzltidy/rules_and_macros_overview.md
@@ -25,6 +25,6 @@ Defines targets for executing targets against the workspace and     confirming t
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="tidy-name"></a>name |  The name of the target.   |  none |
-| <a id="tidy-targets"></a>targets |  A <code>list</code> of targets to execute.   |  none |
+| <a id="tidy-targets"></a>targets |  A `list` of targets to execute.   |  none |
 
 

--- a/doc/shlib/execute_binary.md
+++ b/doc/shlib/execute_binary.md
@@ -7,7 +7,7 @@
 ## execute_binary
 
 <pre>
-execute_binary(<a href="#execute_binary-name">name</a>, <a href="#execute_binary-arguments">arguments</a>, <a href="#execute_binary-binary">binary</a>, <a href="#execute_binary-data">data</a>, <a href="#execute_binary-execute_in_workspace">execute_in_workspace</a>, <a href="#execute_binary-file_arguments">file_arguments</a>)
+execute_binary(<a href="#execute_binary-name">name</a>, <a href="#execute_binary-data">data</a>, <a href="#execute_binary-arguments">arguments</a>, <a href="#execute_binary-binary">binary</a>, <a href="#execute_binary-execute_in_workspace">execute_in_workspace</a>, <a href="#execute_binary-file_arguments">file_arguments</a>)
 </pre>
 
 This rule executes a binary target with the specified arguments. It generates a Bash script that contains a call to the binary with the arguments embedded in the script. This is useful in the following situations:
@@ -20,17 +20,16 @@ Why Not Use A Macro?
 
 You can use a macro which encapsulates the details of the xxx_binary declaration. However, the dependencies for the xxx_binary declaration must be visible anywhere the macro is used.
 
-
 **ATTRIBUTES**
 
 
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="execute_binary-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="execute_binary-arguments"></a>arguments |  The list of arguments that will be embedded into the resulting executable. <br><br>NOTE: Use this attribute instead of <code>args</code>. The <code>args</code> attribute is not processed for file arguments and is not preserved in the resulting script.   | List of strings | optional | <code>[]</code> |
+| <a id="execute_binary-data"></a>data |  Files needed by the binary at runtime.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="execute_binary-arguments"></a>arguments |  The list of arguments that will be embedded into the resulting executable.<br><br>NOTE: Use this attribute instead of `args`. The `args` attribute is not processed for file arguments and is not preserved in the resulting script.   | List of strings | optional |  `[]`  |
 | <a id="execute_binary-binary"></a>binary |  The binary to be executed.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
-| <a id="execute_binary-data"></a>data |  Files needed by the binary at runtime.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
-| <a id="execute_binary-execute_in_workspace"></a>execute_in_workspace |  If true, the binary will be executed in the Bazel workspace (i.e., source) directory.   | Boolean | optional | <code>False</code> |
-| <a id="execute_binary-file_arguments"></a>file_arguments |  A <code>dict</code> mapping of file labels to placeholder names. If any of the specified <code>arguments</code> for <code>execute_binary</code> are paths to files, add an entry in this attribute where the key is the filename or label referencing the file and the value is a placeholder name. Use the <code>file_placeholder</code> function to create a suitable placeholder string for the arguments.<br><br>Example<br><br><pre><code> execute_binary(     name = "do_something",     arguments = [         "--input",         file_placeholder("foo"),         "--input",         file_placeholder("bar"),     ],     file_arguments = {         # The key is the path          "foo.txt": "foo",         ":bar":  "bar",     }, ) </code></pre>   | <a href="https://bazel.build/rules/lib/dict">Dictionary: Label -> String</a> | optional | <code>{}</code> |
+| <a id="execute_binary-execute_in_workspace"></a>execute_in_workspace |  If true, the binary will be executed in the Bazel workspace (i.e., source) directory.   | Boolean | optional |  `False`  |
+| <a id="execute_binary-file_arguments"></a>file_arguments |  A `dict` mapping of file labels to placeholder names. If any of the specified `arguments` for `execute_binary` are paths to files, add an entry in this attribute where the key is the filename or label referencing the file and the value is a placeholder name. Use the `file_placeholder` function to create a suitable placeholder string for the arguments.<br><br>Example<br><br><pre><code>execute_binary(&#10;    name = "do_something",&#10;    arguments = [&#10;        "--input",&#10;        file_placeholder("foo"),&#10;        "--input",&#10;        file_placeholder("bar"),&#10;    ],&#10;    file_arguments = {&#10;        # The key is the path&#10;        "foo.txt": "foo",&#10;        ":bar":  "bar",&#10;    },&#10;)</code></pre>   | <a href="https://bazel.build/rules/lib/dict">Dictionary: Label -> String</a> | optional |  `{}`  |
 
 

--- a/doc/updatesrc/providers_overview.md
+++ b/doc/updatesrc/providers_overview.md
@@ -24,6 +24,6 @@ Information about files that should be copied from the output to the workspace.
 
 | Name  | Description |
 | :------------- | :------------- |
-| <a id="UpdateSrcsInfo-update_srcs"></a>update_srcs |  A <code>depset</code> of structs as created by <code>update_srcs.create()</code> which specify the source files and their outputs.    |
+| <a id="UpdateSrcsInfo-update_srcs"></a>update_srcs |  A `depset` of structs as created by `update_srcs.create()` which specify the source files and their outputs.    |
 
 

--- a/doc/updatesrc/rules_and_macros_overview.md
+++ b/doc/updatesrc/rules_and_macros_overview.md
@@ -17,17 +17,16 @@ On this page:
 ## updatesrc_update
 
 <pre>
-updatesrc_update(<a href="#updatesrc_update-name">name</a>, <a href="#updatesrc_update-deps">deps</a>, <a href="#updatesrc_update-outs">outs</a>, <a href="#updatesrc_update-srcs">srcs</a>)
+updatesrc_update(<a href="#updatesrc_update-name">name</a>, <a href="#updatesrc_update-deps">deps</a>, <a href="#updatesrc_update-srcs">srcs</a>, <a href="#updatesrc_update-outs">outs</a>)
 </pre>
 
 Updates the source files in the workspace directory using the specified output files.
 
-There are two ways to specify the update mapping for this rule. 
+There are two ways to specify the update mapping for this rule.
 
 Option #1: You can specify a list of source files and output files using the `srcs` and `outs` attributes, respectively. The source file at index 'n' in the `srcs` list will be updated by the output file at index 'n' in the `outs` list.
 
 Option #2: Rules that provide `UpdateSrcsInfo` can be specified in the `deps` attribute.
-
 
 **ATTRIBUTES**
 
@@ -35,9 +34,9 @@ Option #2: Rules that provide `UpdateSrcsInfo` can be specified in the `deps` at
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="updatesrc_update-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="updatesrc_update-deps"></a>deps |  Build targets that output <code>UpdateSrcsInfo</code>.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
-| <a id="updatesrc_update-outs"></a>outs |  Output files that will be used to update the files listed in the <code>srcs</code> attribute. Every file listed in the <code>outs</code> attribute must have a corresponding source file list in the <code>srcs</code> attribute.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
-| <a id="updatesrc_update-srcs"></a>srcs |  Source files that will be updated by the files listed in the <code>outs</code> attribute. Every file listed in the <code>srcs</code> attribute must have a corresponding output file listed in the <code>outs</code> attribute.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
+| <a id="updatesrc_update-deps"></a>deps |  Build targets that output `UpdateSrcsInfo`.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="updatesrc_update-srcs"></a>srcs |  Source files that will be updated by the files listed in the `outs` attribute. Every file listed in the `srcs` attribute must have a corresponding output file listed in the `outs` attribute.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="updatesrc_update-outs"></a>outs |  Output files that will be used to update the files listed in the `srcs` attribute. Every file listed in the `outs` attribute must have a corresponding source file list in the `srcs` attribute.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 
 
 <a id="updatesrc_diff_and_update"></a>
@@ -56,14 +55,14 @@ Defines an `updatesrc_update` for the package and `diff_test` targets for each s
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="updatesrc_diff_and_update-srcs"></a>srcs |  Source files that will be updated by the files listed in the <code>outs</code> attribute.  Every file listed in the <code>srcs</code> attribute must have a corresponding output file listed in the <code>outs</code> attribute.   |  none |
-| <a id="updatesrc_diff_and_update-outs"></a>outs |  Output files that will be used to update the files listed in the <code>srcs</code> attribute. Every file listed in the <code>outs</code> attribute must have a corresponding source file list in the <code>srcs</code> attribute.   |  none |
-| <a id="updatesrc_diff_and_update-name"></a>name |  Optional. The name of the <code>updatesrc_update</code> target.   |  <code>None</code> |
-| <a id="updatesrc_diff_and_update-update_name"></a>update_name |  Deprecated. The name of the <code>updatesrc_update</code> target.   |  <code>"update"</code> |
-| <a id="updatesrc_diff_and_update-diff_test_prefix"></a>diff_test_prefix |  Optional. The prefix to be used for the <code>diff_test</code> target names.   |  <code>""</code> |
-| <a id="updatesrc_diff_and_update-diff_test_suffix"></a>diff_test_suffix |  Optional. The suffix to be used for the <code>diff_test</code> target names.   |  <code>"_difftest"</code> |
-| <a id="updatesrc_diff_and_update-update_visibility"></a>update_visibility |  Optional. The visibility declarations for the <code>updatesrc_update</code> target.   |  <code>None</code> |
-| <a id="updatesrc_diff_and_update-diff_test_visibility"></a>diff_test_visibility |  Optional. The visibility declarations for the <code>diff_test</code> targets.   |  <code>None</code> |
+| <a id="updatesrc_diff_and_update-srcs"></a>srcs |  Source files that will be updated by the files listed in the `outs` attribute.  Every file listed in the `srcs` attribute must have a corresponding output file listed in the `outs` attribute.   |  none |
+| <a id="updatesrc_diff_and_update-outs"></a>outs |  Output files that will be used to update the files listed in the `srcs` attribute. Every file listed in the `outs` attribute must have a corresponding source file list in the `srcs` attribute.   |  none |
+| <a id="updatesrc_diff_and_update-name"></a>name |  Optional. The name of the `updatesrc_update` target.   |  `None` |
+| <a id="updatesrc_diff_and_update-update_name"></a>update_name |  Deprecated. The name of the `updatesrc_update` target.   |  `"update"` |
+| <a id="updatesrc_diff_and_update-diff_test_prefix"></a>diff_test_prefix |  Optional. The prefix to be used for the `diff_test` target names.   |  `""` |
+| <a id="updatesrc_diff_and_update-diff_test_suffix"></a>diff_test_suffix |  Optional. The suffix to be used for the `diff_test` target names.   |  `"_difftest"` |
+| <a id="updatesrc_diff_and_update-update_visibility"></a>update_visibility |  Optional. The visibility declarations for the `updatesrc_update` target.   |  `None` |
+| <a id="updatesrc_diff_and_update-diff_test_visibility"></a>diff_test_visibility |  Optional. The visibility declarations for the `diff_test` targets.   |  `None` |
 | <a id="updatesrc_diff_and_update-kwargs"></a>kwargs |  Common attributes that are applied to the underlying rules.   |  none |
 
 
@@ -91,8 +90,8 @@ and `targets_to_run_before` attributes.
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="updatesrc_update_all-name"></a>name |  The name of the target.   |  none |
-| <a id="updatesrc_update_all-targets_to_run"></a>targets_to_run |  A <code>list</code> of labels to execute after the <code>updatesrc_update</code> targets.   |  <code>[]</code> |
-| <a id="updatesrc_update_all-targets_to_run_before"></a>targets_to_run_before |  A <code>list</code> of labels to execute before the <code>updatesrc_update</code> targets.   |  <code>[]</code> |
+| <a id="updatesrc_update_all-targets_to_run"></a>targets_to_run |  A `list` of labels to execute after the `updatesrc_update` targets.   |  `[]` |
+| <a id="updatesrc_update_all-targets_to_run_before"></a>targets_to_run_before |  A `list` of labels to execute before the `updatesrc_update` targets.   |  `[]` |
 
 **RETURNS**
 

--- a/doc/updatesrc/update_srcs.md
+++ b/doc/updatesrc/update_srcs.md
@@ -17,8 +17,8 @@ Creates a `struct` specifying a source file and an output file that should be us
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="update_srcs.create-src"></a>src |  A <code>File</code> designating a file in the workspace.   |  none |
-| <a id="update_srcs.create-out"></a>out |  A <code>File</code> designating a file in the output directory.   |  none |
+| <a id="update_srcs.create-src"></a>src |  A `File` designating a file in the workspace.   |  none |
+| <a id="update_srcs.create-out"></a>out |  A `File` designating a file in the output directory.   |  none |
 
 **RETURNS**
 


### PR DESCRIPTION
Upgrade stardoc to support doc generation for bzlmod extensions. I had issues upgrading all the way to 0.7.0.
