### PR TITLE
Provide a helpful message what to do if diff fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
           buildbuddy_api_key: ${{  secrets.BUILDBUDDY_API_KEY }}
       - uses: ./.github/actions/execute_test
         with:
-          bzlmod_enabled: ${{ matrix.bzlmod_enabled }}
+          bzlmod_enabled: ${{ matrix.enable_bzlmod }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           test_target: ${{ matrix.test }}
   tidy_and_test_matrix:

--- a/doc/updatesrc/rules_and_macros_overview.md
+++ b/doc/updatesrc/rules_and_macros_overview.md
@@ -49,7 +49,7 @@ Option #2: Rules that provide `UpdateSrcsInfo` can be specified in the `deps` at
 load("@cgrindel_bazel_starlib//updatesrc:defs.bzl", "updatesrc_diff_and_update")
 
 updatesrc_diff_and_update(<a href="#updatesrc_diff_and_update-srcs">srcs</a>, <a href="#updatesrc_diff_and_update-outs">outs</a>, <a href="#updatesrc_diff_and_update-name">name</a>, <a href="#updatesrc_diff_and_update-update_name">update_name</a>, <a href="#updatesrc_diff_and_update-diff_test_prefix">diff_test_prefix</a>, <a href="#updatesrc_diff_and_update-diff_test_suffix">diff_test_suffix</a>,
-                          <a href="#updatesrc_diff_and_update-update_visibility">update_visibility</a>, <a href="#updatesrc_diff_and_update-diff_test_visibility">diff_test_visibility</a>, <a href="#updatesrc_diff_and_update-kwargs">**kwargs</a>)
+                          <a href="#updatesrc_diff_and_update-update_visibility">update_visibility</a>, <a href="#updatesrc_diff_and_update-diff_test_visibility">diff_test_visibility</a>, <a href="#updatesrc_diff_and_update-failure_message">failure_message</a>, <a href="#updatesrc_diff_and_update-kwargs">kwargs</a>)
 </pre>
 
 Defines an `updatesrc_update` for the package and `diff_test` targets for each src-out pair.
@@ -67,6 +67,7 @@ Defines an `updatesrc_update` for the package and `diff_test` targets for each s
 | <a id="updatesrc_diff_and_update-diff_test_suffix"></a>diff_test_suffix |  Optional. The suffix to be used for the `diff_test` target names.   |  `"_difftest"` |
 | <a id="updatesrc_diff_and_update-update_visibility"></a>update_visibility |  Optional. The visibility declarations for the `updatesrc_update` target.   |  `None` |
 | <a id="updatesrc_diff_and_update-diff_test_visibility"></a>diff_test_visibility |  Optional. The visibility declarations for the `diff_test` targets.   |  `None` |
+| <a id="updatesrc_diff_and_update-failure_message"></a>failure_message |  Additional message to log if the files' contents do not match.   |  `None` |
 | <a id="updatesrc_diff_and_update-kwargs"></a>kwargs |  Common attributes that are applied to the underlying rules.   |  none |
 
 

--- a/doc/updatesrc/rules_and_macros_overview.md
+++ b/doc/updatesrc/rules_and_macros_overview.md
@@ -49,7 +49,7 @@ Option #2: Rules that provide `UpdateSrcsInfo` can be specified in the `deps` at
 load("@cgrindel_bazel_starlib//updatesrc:defs.bzl", "updatesrc_diff_and_update")
 
 updatesrc_diff_and_update(<a href="#updatesrc_diff_and_update-srcs">srcs</a>, <a href="#updatesrc_diff_and_update-outs">outs</a>, <a href="#updatesrc_diff_and_update-name">name</a>, <a href="#updatesrc_diff_and_update-update_name">update_name</a>, <a href="#updatesrc_diff_and_update-diff_test_prefix">diff_test_prefix</a>, <a href="#updatesrc_diff_and_update-diff_test_suffix">diff_test_suffix</a>,
-                          <a href="#updatesrc_diff_and_update-update_visibility">update_visibility</a>, <a href="#updatesrc_diff_and_update-diff_test_visibility">diff_test_visibility</a>, <a href="#updatesrc_diff_and_update-failure_message">failure_message</a>, <a href="#updatesrc_diff_and_update-kwargs">kwargs</a>)
+                          <a href="#updatesrc_diff_and_update-update_visibility">update_visibility</a>, <a href="#updatesrc_diff_and_update-diff_test_visibility">diff_test_visibility</a>, <a href="#updatesrc_diff_and_update-failure_message">failure_message</a>, <a href="#updatesrc_diff_and_update-kwargs">**kwargs</a>)
 </pre>
 
 Defines an `updatesrc_update` for the package and `diff_test` targets for each src-out pair.

--- a/updatesrc/private/updatesrc_diff_and_update.bzl
+++ b/updatesrc/private/updatesrc_diff_and_update.bzl
@@ -12,6 +12,7 @@ def updatesrc_diff_and_update(
         diff_test_suffix = "_difftest",
         update_visibility = None,
         diff_test_visibility = None,
+        failure_message = None,
         **kwargs):
     """Defines an `updatesrc_update` for the package and `diff_test` targets for each src-out pair.
 
@@ -33,6 +34,7 @@ def updatesrc_diff_and_update(
                            `updatesrc_update` target.
         diff_test_visibility: Optional. The visibility declarations for the
                               `diff_test` targets.
+        failure_message: Additional message to log if the files' contents do not match.
         **kwargs: Common attributes that are applied to the underlying rules.
     """
 
@@ -48,24 +50,32 @@ def updatesrc_diff_and_update(
     if len(srcs) != len(outs):
         fail("The number of srcs does not match the number of outs.")
 
-    # Define the diff tests.
-    for idx in range(len(srcs)):
-        src = srcs[idx]
-        out = outs[idx]
-        src_name = src.replace("/", "_")
-        diff_test(
-            name = diff_test_prefix + src_name + diff_test_suffix,
-            file1 = src,
-            file2 = out,
-            visibility = diff_test_visibility,
-            **kwargs
-        )
-
     if name == None:
         if update_name == None:
             fail("Please specify a value for the name attribute.")
         else:
             name = update_name
+
+    msg = failure_message
+
+    # Define the diff tests.
+    for idx in range(len(srcs)):
+        src = srcs[idx]
+        out = outs[idx]
+        src_name = src.replace("/", "_")
+
+        if failure_message == None:
+            # create a helpful message if none has been given
+            msg = "Run 'bazel run {}' to update {}".format(name, src)
+
+        diff_test(
+            name = diff_test_prefix + src_name + diff_test_suffix,
+            file1 = src,
+            file2 = out,
+            visibility = diff_test_visibility,
+            failure_message = msg,
+            **kwargs
+        )
 
     # Define the update target
     updatesrc_update(


### PR DESCRIPTION
When using `updatesrc_diff_and_update` there will be a corresponding `update` target which should be run if
the files differ.
