### PR TITLE
fix: use `rules_multitool` to use GitHub CLI (gh)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -169,6 +169,7 @@ _RUNTIME_PKGS = [
     "//shlib/rules",
     "//shlib/rules/private",
     "//shlib/tools",
+    "//tools/gh",
     "//updatesrc",
     "//updatesrc/private",
 ]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -28,6 +28,11 @@ bazel_dep(
 )
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "rules_shell", version = "0.3.0")
+bazel_dep(name = "rules_multitool", version = "1.0.0")
+
+multitool = use_extension("@rules_multitool//multitool:extension.bzl", "multitool")
+multitool.hub(lockfile = "//tools/gh:multitool.lock.json")
+use_repo(multitool, "multitool")
 
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(version = "1.23.3")

--- a/bzlrelease/tools/create_release.sh
+++ b/bzlrelease/tools/create_release.sh
@@ -40,8 +40,6 @@ source "${github_sh}"
 
 # MARK - Check for Required Software
 
-is_installed gh || fail "Could not find Github CLI (gh)."
-
 
 # MARK - Usage
 

--- a/bzlrelease/tools/create_release_tag.sh
+++ b/bzlrelease/tools/create_release_tag.sh
@@ -41,7 +41,6 @@ source "${github_sh}"
 # MARK - Check for Required Software
 
 required_software="Both git and Github CLI (gh) are required to run this utility."
-is_installed gh || fail "Could not find Github CLI (gh)." "${required_software}"
 is_installed git || fail "Could not find git." "${required_software}"
 
 

--- a/bzlrelease/tools/generate_gh_changelog.sh
+++ b/bzlrelease/tools/generate_gh_changelog.sh
@@ -40,7 +40,6 @@ source "${github_sh}"
 
 # MARK - Check for Required Software
 
-is_installed gh || fail "Could not find Github CLI (gh)."
 is_installed git || fail "Could not find git."
 
 

--- a/shlib/lib/BUILD.bazel
+++ b/shlib/lib/BUILD.bazel
@@ -53,6 +53,9 @@ sh_library(
 sh_library(
     name = "github",
     srcs = ["github.sh"],
+    data = [
+        "@multitool//tools/gh",
+    ],
 )
 
 # MARK: - Collect Files for Integation Tests

--- a/shlib/lib/github.sh
+++ b/shlib/lib/github.sh
@@ -2,15 +2,16 @@
 
 # Github-related Functions
 
-# This is used to determine if the library has been loaded
-cgrindel_bazel_starlib_lib_private_github_loaded() { return; }
+gh_location=multitool/tools/gh/gh
+gh="$(rlocation "${gh_location}")" || \
+  (echo >&2 "Failed to locate ${gh_location}" && exit 1)
 
 # MARK - Github Auth Status Functions
 
 # Returns the raw gh auth status displyaing the auth token.
 # Doc: https://cli.github.com/manual/gh_auth_status
 get_gh_auth_status() {
-  gh auth status -t 2>&1
+  "${gh}" auth status -t 2>&1
 }
 
 # Example gh auth status:
@@ -93,7 +94,7 @@ get_gh_repo_name() {
 # Succeeds if the Github release exists. Otherwise, it fails.
 gh_release_exists() {
   local tag="${1}"
-  gh release view "${tag}" 2> /dev/null
+  "${gh}" release view "${tag}" 2> /dev/null
 }
 
 # MARK - Github API Functions
@@ -132,5 +133,5 @@ get_gh_changelog() {
   [[ ${#api_args[@]} == 0 ]] && fail "Expected one or more API args."
 
   # Execute the API call
-  gh api "repos/{owner}/{repo}/releases/generate-notes" "${api_args[@]}" --jq '.body'
+  "${gh}" api "repos/{owner}/{repo}/releases/generate-notes" "${api_args[@]}" --jq '.body'
 }

--- a/tests/shlib_tests/lib_tests/github_tests/get_gh_auth_status_test.sh
+++ b/tests/shlib_tests/lib_tests/github_tests/get_gh_auth_status_test.sh
@@ -31,7 +31,6 @@ github_sh="$(rlocation "${github_sh_location}")" || \
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/github.sh
 source "${github_sh}"
 
-is_installed gh || fail "Could not find Github CLI (gh)."
 
 # MARK - Test
 

--- a/tests/shlib_tests/lib_tests/github_tests/get_gh_changelog_test.sh
+++ b/tests/shlib_tests/lib_tests/github_tests/get_gh_changelog_test.sh
@@ -35,7 +35,6 @@ setup_git_repo_sh_location=cgrindel_bazel_starlib/tests/setup_git_repo.sh
 setup_git_repo_sh="$(rlocation "${setup_git_repo_sh_location}")" || \
   (echo >&2 "Failed to locate ${setup_git_repo_sh_location}" && exit 1)
 
-is_installed gh || fail "Could not find Github CLI (gh)."
 
 # MARK - Setup
 

--- a/tools/gh/BUILD.bazel
+++ b/tools/gh/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
+
+bzlformat_pkg(name = "bzlformat")
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["*"]),
+    visibility = ["//:__subpackages__"],
+)

--- a/tools/gh/multitool.lock.json
+++ b/tools/gh/multitool.lock.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://raw.githubusercontent.com/theoremlp/rules_multitool/main/lockfile.schema.json",
+  "gh": {
+    "binaries": [
+      {
+        "kind": "archive",
+        "url": "https://github.com/cli/cli/releases/download/v2.66.1/gh_2.66.1_linux_arm64.tar.gz",
+        "file": "gh_2.66.1_linux_arm64/bin/gh",
+        "sha256": "f11a2c3d1a2cfd97106fa6405fbb4c1254a7e91be38537148ab7d27209698a6b",
+        "os": "linux",
+        "cpu": "arm64"
+      },
+      {
+        "kind": "archive",
+        "url": "https://github.com/cli/cli/releases/download/v2.66.1/gh_2.66.1_linux_amd64.tar.gz",
+        "file": "gh_2.66.1_linux_amd64/bin/gh",
+        "sha256": "387b4e9a717ddf2efa8426a774f14463bf64e41fb7bec3463c737cf5413e5a79",
+        "os": "linux",
+        "cpu": "x86_64"
+      },
+      {
+        "kind": "archive",
+        "url": "https://github.com/cli/cli/releases/download/v2.66.1/gh_2.66.1_macOS_amd64.zip",
+        "file": "gh_2.66.1_macOS_amd64/bin/gh",
+        "sha256": "7ae1b19f5b4c46545be7c9a16a52b922b9dee4755f051c7fa6f105784632d035",
+        "os": "macos",
+        "cpu": "arm64"
+      },
+      {
+        "kind": "archive",
+        "url": "https://github.com/cli/cli/releases/download/v2.66.1/gh_2.66.1_macOS_amd64.zip",
+        "file": "gh_2.66.1_macOS_amd64/bin/gh",
+        "sha256": "7ae1b19f5b4c46545be7c9a16a52b922b9dee4755f051c7fa6f105784632d035",
+        "os": "macos",
+        "cpu": "x86_64"
+      },
+      {
+        "kind": "archive",
+        "url": "https://github.com/cli/cli/releases/download/v2.66.1/gh_2.66.1_windows_amd64.zip",
+        "file": "bin/gh.exe",
+        "sha256": "2f8cd5d8bcffc65dc4dc69bb48ca536b53f792744ba7da7e75b238bde9deb2bf",
+        "os": "windows",
+        "cpu": "x86_64"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Addresses issues where `gh` could not be found in `rules_bazel_integration_test` tests.