### PR TITLE
feat: use BSD tar toolchain for release archive functionality

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -36,6 +36,7 @@ bazel_dep(
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "rules_shell", version = "0.3.0")
 bazel_dep(name = "rules_multitool", version = "1.0.0")
+bazel_dep(name = "aspect_bazel_lib", version = "2.13.0")
 
 multitool = use_extension("@rules_multitool//multitool:extension.bzl", "multitool")
 multitool.hub(lockfile = "//tools/gh:multitool.lock.json")
@@ -63,7 +64,7 @@ bazel_dep(
 )
 bazel_dep(
     name = "rules_bazel_integration_test",
-    version = "0.31.0",
+    version = "0.32.0",
     dev_dependency = True,
 )
 

--- a/bzlrelease/private/BUILD.bazel
+++ b/bzlrelease/private/BUILD.bazel
@@ -54,11 +54,12 @@ filegroup(
 )
 
 bzl_library(
-    name = "hash_sha256",
-    srcs = ["hash_sha256.bzl"],
+    name = "release_archive",
+    srcs = ["release_archive.bzl"],
+    deps = ["//tools/tar:tar_toolchains"],
 )
 
 bzl_library(
-    name = "release_archive",
-    srcs = ["release_archive.bzl"],
+    name = "hash_sha256",
+    srcs = ["hash_sha256.bzl"],
 )

--- a/bzlrelease/private/release_archive.bzl
+++ b/bzlrelease/private/release_archive.bzl
@@ -28,7 +28,6 @@ def _release_archive_impl(ctx):
     args.add("-T", file_list_out)
     ctx.actions.run(
         outputs = [out],
-        # inputs = [file_list_out] + ctx.files.srcs,
         inputs = depset(
             direct = [file_list_out] + ctx.files.srcs,
             transitive = [bsdtar.default.files],

--- a/bzlrelease/private/release_archive.bzl
+++ b/bzlrelease/private/release_archive.bzl
@@ -1,6 +1,6 @@
 """Definition for `release_archive` rule."""
 
-_TAR_TOOLCHAIN_TYPE = "@aspect_bazel_lib//lib:tar_toolchain_type"
+load("//tools/tar:tar_toolchains.bzl", "tar_toolchains")
 
 def _release_archive_impl(ctx):
     out_basename = ctx.attr.out
@@ -20,23 +20,7 @@ def _release_archive_impl(ctx):
         content = file_list_args,
     )
 
-    # # Create the archive
-    # args = ctx.actions.args()
-    # args.add(out)
-    # args.add(file_list_out)
-    # ctx.actions.run_shell(
-    #     outputs = [out],
-    #     inputs = [file_list_out] + ctx.files.srcs,
-    #     arguments = [args],
-    #     command = """\
-    # archive="$1"
-    # file_list="$2"
-    # shift 1
-    # tar 2>/dev/null -hczvf "$archive" -T "${file_list}"
-    # """,
-    # )
-
-    bsdtar = ctx.toolchains[_TAR_TOOLCHAIN_TYPE]
+    bsdtar = ctx.toolchains[tar_toolchains.type]
 
     args = ctx.actions.args()
     args.add("-f", out)
@@ -51,7 +35,7 @@ def _release_archive_impl(ctx):
         ),
         arguments = [args],
         executable = bsdtar.tarinfo.binary,
-        toolchain = _TAR_TOOLCHAIN_TYPE,
+        toolchain = tar_toolchains.type,
     )
 
     return DefaultInfo(
@@ -74,7 +58,7 @@ release_archive = rule(
             mandatory = True,
         ),
     },
-    toolchains = [_TAR_TOOLCHAIN_TYPE],
+    toolchains = [tar_toolchains.type],
     doc = """\
 Create a source release archive.
 

--- a/tests/bzlrelease_tests/rules_tests/release_artifact_tests/BUILD.bazel
+++ b/tests/bzlrelease_tests/rules_tests/release_artifact_tests/BUILD.bazel
@@ -16,7 +16,10 @@ release_archive(
 sh_test(
     name = "archive_test",
     srcs = ["archive_test.sh"],
-    data = [":archive"],
+    data = [
+        ":archive",
+        "//tools/tar",
+    ],
     deps = [
         "@cgrindel_bazel_starlib//shlib/lib:assertions",
         "@rules_shell//shell/runfiles",

--- a/tests/bzlrelease_tests/rules_tests/release_artifact_tests/archive_test.sh
+++ b/tests/bzlrelease_tests/rules_tests/release_artifact_tests/archive_test.sh
@@ -23,9 +23,13 @@ archive_tar_gz_location=cgrindel_bazel_starlib/tests/bzlrelease_tests/rules_test
 archive_tar_gz="$(rlocation "${archive_tar_gz_location}")" || \
   (echo >&2 "Failed to locate ${archive_tar_gz_location}" && exit 1)
 
+tar_exe_location=cgrindel_bazel_starlib/tools/tar/tar.exe
+tar="$(rlocation "${tar_exe_location}")" || \
+  (echo >&2 "Failed to locate ${tar_exe_location}" && exit 1)
+
 # MARK - Test
 
-contents="$(tar -tf "${archive_tar_gz}")"
+contents="$( "${tar}" -tf "${archive_tar_gz}" )"
 assert_match "bzlrelease/" "${contents}" 
 assert_match "bzlrelease/private/" "${contents}" 
 assert_match "bzlrelease/tools/" "${contents}" 

--- a/tools/tar/BUILD.bazel
+++ b/tools/tar/BUILD.bazel
@@ -4,7 +4,10 @@ load(":tar_binary.bzl", "tar_binary")
 
 bzlformat_pkg(name = "bzlformat")
 
-tar_binary(name = "tar")
+tar_binary(
+    name = "tar",
+    visibility = ["//visibility:public"],
+)
 
 bzl_library(
     name = "tar_binary",

--- a/tools/tar/BUILD.bazel
+++ b/tools/tar/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
+load(":tar_binary.bzl", "tar_binary")
+
+bzlformat_pkg(name = "bzlformat")
+
+tar_binary(name = "tar")
+
+bzl_library(
+    name = "tar_binary",
+    srcs = ["tar_binary.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [":tar_toolchains"],
+)
+
+bzl_library(
+    name = "tar_toolchains",
+    srcs = ["tar_toolchains.bzl"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/tar/tar_binary.bzl
+++ b/tools/tar/tar_binary.bzl
@@ -1,0 +1,37 @@
+"""Implementation for `tar_binary` rule."""
+
+load(":tar_toolchains.bzl", "tar_toolchains")
+
+# Heavily inspired by
+# https://tarhub.com/bazelbuild/bazel-skylib/blob/7209de9148e98dc20425cf83747613f23d40827b/rules/native_binary.bzl#L23
+
+def _tar_binary_impl(ctx):
+    out = ctx.actions.declare_file(
+        ctx.attr.out if (ctx.attr.out != "") else ctx.attr.name + ".exe",
+    )
+    bsdtar = ctx.toolchains[tar_toolchains.type]
+    ctx.actions.symlink(
+        target_file = bsdtar.tarinfo.binary,
+        output = out,
+        is_executable = True,
+    )
+    return DefaultInfo(
+        executable = out,
+        files = depset([out]),
+    )
+
+tar_binary = rule(
+    implementation = _tar_binary_impl,
+    executable = True,
+    doc = "Expose the `tar` binary.",
+    attrs = {
+        # "out" is attr.string instead of attr.output, so that it is select()'able.
+        "out": attr.string(
+            default = "",
+            doc = "An output name for the copy of the binary. Defaults to " +
+                  "name.exe. (We add .exe to the name by default because it's " +
+                  "required on Windows and tolerated on other platforms.)",
+        ),
+    },
+    toolchains = [tar_toolchains.type],
+)

--- a/tools/tar/tar_toolchains.bzl
+++ b/tools/tar/tar_toolchains.bzl
@@ -1,0 +1,5 @@
+"""Implementation of 'tar_toolchains' module."""
+
+tar_toolchains = struct(
+    type = "@aspect_bazel_lib//lib:tar_toolchain_type",
+)


### PR DESCRIPTION
- Use [BSD tar toolchain](https://github.com/bazel-contrib/bazel-lib/blob/main/lib/private/tar_toolchain.bzl) for release archive functionality.
- Define `//tools/tar` target.
