### PR TITLE
fix: sync Bazel version for BVCR presubmit

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: "examples/bzlmod_e2e"
   matrix:
     platform: ["macos", "ubuntu2004"]
-    bazel: ["8.0.1"]
+    bazel: ["8.1.1"]
   tasks:
     run_tests:
       name: "Run test module"


### PR DESCRIPTION
Fix BCR presubmit failure.
