### PR TITLE
fix: set `LC_ALL=C` when using `sort`

### DIFF
--- a/shlib/lib/arrays.sh
+++ b/shlib/lib/arrays.sh
@@ -13,7 +13,9 @@ cgrindel_bazel_shlib_lib_arrays_loaded() { return; }
 #   stderr: None.
 sort_items() {
   local IFS=$'\n'
-  sort -u <<<"$*"
+  # Use LC_ALL=C to ensure that sort is in byte order. Keep things consistent on
+  # different systems.
+  LC_ALL=C sort -u <<<"$*"
 }
 
 # Prints the arguments with each argument on its own line.
@@ -25,7 +27,7 @@ sort_items() {
 #   stdout: A line per item.
 #   stderr: None.
 print_by_line() {
-  for item in "${@:-}" ; do
+  for item in "${@:-}"; do
     echo "${item}"
   done
 }
@@ -53,7 +55,7 @@ join_by() {
 #   while (("$#")); do
 #     items+=( $( echo "${1}" | base64) )
 #     shift 1
-#   done 
+#   done
 #   echo "${items[@]}"
 # }
 #
@@ -63,7 +65,7 @@ join_by() {
 #   while (("$#")); do
 #     items+=( $( echo "${1}" | base64 --decode) )
 #     shift 1
-#   done 
+#   done
 #   echo "${items[@]}"
 # }
 
@@ -79,7 +81,7 @@ double_quote_items() {
   while (("$#")); do
     echo "\"${1}\""
     shift 1
-  done 
+  done
 }
 
 # Searches for the expected value in the follow-on arguments. If your list is sorted and has
@@ -95,19 +97,19 @@ double_quote_items() {
 #   Returns 0 if the expected value is found. Otherwise returns -1.
 contains_item() {
   # NOTE: The variables are purposefully short. Bash performance is greatly
-  # influenced by the number of variables and the length of their names. 
+  # influenced by the number of variables and the length of their names.
   # x: expected value
 
   # Remember the expected value
   local x="${1}"
   shift
-  
+
   # Do a quick regex to see if the value is in the rest of the args
   # If not, then don't bother looping
   [[ ! "${*}" =~ ${x} ]] && return 1
 
   # Loop through items for a precise match
-  for it in "${@}" ; do
+  for it in "${@}"; do
     [[ "${it}" == "${x}" ]] && return 0
   done
 
@@ -115,8 +117,8 @@ contains_item() {
   return 1
 }
 
-# Searches for the expected value in the follow-on arguments. This function assumes that the list 
-# items are sorted and unique. Only use this function over 'contains_item' if you expect to have 40 
+# Searches for the expected value in the follow-on arguments. This function assumes that the list
+# items are sorted and unique. Only use this function over 'contains_item' if you expect to have 40
 # or more items in your list. Check out //tools:contains_item_perf_comparison to run some comparisons
 # between this function and contains_item.
 #
@@ -130,7 +132,7 @@ contains_item() {
 #   Returns 0 if the expected value is found. Otherwise returns -1.
 contains_item_sorted() {
   # NOTE: The variables are purposefully short. Bash performance is greatly
-  # influenced by the number of variables and the length of their names. 
+  # influenced by the number of variables and the length of their names.
   # Removed count var - Fastest (0.191s vs 0.214s contains_item)
   # x: expected value
   # s: start index
@@ -151,11 +153,11 @@ contains_item_sorted() {
 
   while true; do
     # Find midpoint
-    local m=$(( s + (e - s + 1)/2 ))
+    local m=$((s + (e - s + 1) / 2))
 
     # If the midpoint value (!m) is the expected, found it
     local mv="${!m}"
-    [[ "${x}" == "${mv}" ]] && return 
+    [[ "${x}" == "${mv}" ]] && return
 
     # If the start index and end index are the same, finished searching
     [[ $s -eq $e ]] && return 1
@@ -163,10 +165,10 @@ contains_item_sorted() {
     # Update the start/end index based upon whether the expected is greater
     # than or less than the midpoint value.
     if [[ "${x}" < "${mv}" ]]; then
-      local e=$(( m - 1 ))
+      local e=$((m - 1))
     else
       [[ $m -eq $e ]] && return 1
-      local s=$(( m + 1 ))
+      local s=$((m + 1))
     fi
   done
 }

--- a/tests/shlib_tests/lib_tests/arrays_tests/sort_items_test.sh
+++ b/tests/shlib_tests/lib_tests/arrays_tests/sort_items_test.sh
@@ -2,36 +2,42 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/assertions.sh
 source "${assertions_sh}"
 
 arrays_sh_location=cgrindel_bazel_starlib/shlib/lib/arrays.sh
-arrays_sh="$(rlocation "${arrays_sh_location}")" || \
+arrays_sh="$(rlocation "${arrays_sh_location}")" ||
   (echo >&2 "Failed to locate ${arrays_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/arrays.sh
 source "${arrays_sh}"
 
-
-array=(b e a c e)
-expected=(a b c e)
+array=(b e a c swift e Swift Source)
+expected=(Source Swift a b c e swift)
 actual=()
 while IFS=$'\n' read -r line; do actual+=("$line"); done < <(
   sort_items "${array[@]}"
 )
 
 assert_equal "${#expected[@]}" "${#actual[@]}"
-for (( i = 0; i < ${#expected[@]}; i++ )); do
+for ((i = 0; i < ${#expected[@]}; i++)); do
   assert_equal "${expected[i]}" "${actual[i]}"
 done


### PR DESCRIPTION
Address subtle sort differences seen when sorting uppercase and lowercase paths on MacOs vs Linux. Setting `LC_ALL=C` ensures that byte order is used.
