### PR TITLE
chore: address build warnings 

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,7 +15,7 @@ register_toolchains(
 
 bazel_dep(
     name = "rules_go",
-    version = "0.50.1",
+    version = "0.55.1",
     repo_name = "io_bazel_rules_go",
 )
 bazel_dep(
@@ -26,7 +26,7 @@ bazel_dep(
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(
     name = "stardoc",
-    version = "0.7.2",
+    version = "0.8.0",
     repo_name = "io_bazel_stardoc",
 )
 bazel_dep(

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -24,11 +24,10 @@ build:cache --experimental_remote_cache_async
 build:cache --experimental_remote_cache_compression
 
 # Recommended by BuildBuddy
-# TODO: Rename this to remote_build_event_upload once we are no longer supporting 6.x.x.
-build --experimental_remote_build_event_upload=minimal
-build --noslim_profile 
-build --experimental_profile_include_target_label 
-build --experimental_profile_include_primary_output 
+build --remote_build_event_upload=minimal
+build --noslim_profile
+build --experimental_profile_include_target_label
+build --experimental_profile_include_primary_output
 build --nolegacy_important_outputs
 
 # Finish BES upload in the background. Disable BES upload when running.
@@ -39,3 +38,6 @@ run --bes_results_url=
 
 # Easily run without caches
 common:no_cache --remote_cache= --disk_cache= --repository_cache=
+
+# Do not autoload any legacy symbols that are now provided in separate repos.
+common --incompatible_autoload_externally=


### PR DESCRIPTION
- Rename `--experimental_remote_build_event_upload` to `--remote_build_event_upload`.
- Add `--incompatible_autoload_externally=` to ensure that we are not using autoloaded symbols.
- Upgrade to stardoc 0.8.0.