### PR TITLE
chore: upgrade `aspect_bazel_lib` to 2.19.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,22 +38,10 @@ jobs:
           - test: '@@//examples/bzlformat:simple_test_bazel_.bazelversion'
             runner: macos-13
             enable_bzlmod: true
-          - test: '@@//examples/bzlformat:simple_test_bazel_last_green'
-            runner: ubuntu-22.04
-            enable_bzlmod: true
-          - test: '@@//examples/bzlformat:simple_test_bazel_last_green'
-            runner: macos-13
-            enable_bzlmod: true
           - test: '@@//examples/markdown:simple_test_bazel_.bazelversion'
             runner: ubuntu-22.04
             enable_bzlmod: true
           - test: '@@//examples/markdown:simple_test_bazel_.bazelversion'
-            runner: macos-13
-            enable_bzlmod: true
-          - test: '@@//examples/markdown:simple_test_bazel_last_green'
-            runner: ubuntu-22.04
-            enable_bzlmod: true
-          - test: '@@//examples/markdown:simple_test_bazel_last_green'
             runner: macos-13
             enable_bzlmod: true
           - test: '@@//examples/tools:tools_test_bazel_.bazelversion'
@@ -62,22 +50,10 @@ jobs:
           - test: '@@//examples/tools:tools_test_bazel_.bazelversion'
             runner: macos-13
             enable_bzlmod: true
-          - test: '@@//examples/tools:tools_test_bazel_last_green'
-            runner: ubuntu-22.04
-            enable_bzlmod: true
-          - test: '@@//examples/tools:tools_test_bazel_last_green'
-            runner: macos-13
-            enable_bzlmod: true
           - test: '@@//examples/updatesrc:simple_test_bazel_.bazelversion'
             runner: ubuntu-22.04
             enable_bzlmod: true
           - test: '@@//examples/updatesrc:simple_test_bazel_.bazelversion'
-            runner: macos-13
-            enable_bzlmod: true
-          - test: '@@//examples/updatesrc:simple_test_bazel_last_green'
-            runner: ubuntu-22.04
-            enable_bzlmod: true
-          - test: '@@//examples/updatesrc:simple_test_bazel_last_green'
             runner: macos-13
             enable_bzlmod: true
           - test: '@@//examples:bzlmod_e2e_test_bazel_.bazelversion'
@@ -86,22 +62,10 @@ jobs:
           - test: '@@//examples:bzlmod_e2e_test_bazel_.bazelversion'
             runner: macos-13
             enable_bzlmod: true
-          - test: '@@//examples:bzlmod_e2e_test_bazel_last_green'
-            runner: ubuntu-22.04
-            enable_bzlmod: true
-          - test: '@@//examples:bzlmod_e2e_test_bazel_last_green'
-            runner: macos-13
-            enable_bzlmod: true
           - test: '@@//tests/bzlformat_tests/tools_tests/missing_pkgs_tests:missing_pkgs_test_bazel_.bazelversion'
             runner: ubuntu-22.04
             enable_bzlmod: true
           - test: '@@//tests/bzlformat_tests/tools_tests/missing_pkgs_tests:missing_pkgs_test_bazel_.bazelversion'
-            runner: macos-13
-            enable_bzlmod: true
-          - test: '@@//tests/bzlformat_tests/tools_tests/missing_pkgs_tests:missing_pkgs_test_bazel_last_green'
-            runner: ubuntu-22.04
-            enable_bzlmod: true
-          - test: '@@//tests/bzlformat_tests/tools_tests/missing_pkgs_tests:missing_pkgs_test_bazel_last_green'
             runner: macos-13
             enable_bzlmod: true
           - test: '@@//tests/bzlrelease_tests/rules_tests/generate_release_notes_tests:generate_release_notes_test'
@@ -147,12 +111,6 @@ jobs:
             runner: ubuntu-22.04
             enable_bzlmod: true
           - test: '@@//tests/updatesrc_tests:updatesrc_test_bazel_.bazelversion'
-            runner: macos-13
-            enable_bzlmod: true
-          - test: '@@//tests/updatesrc_tests:updatesrc_test_bazel_last_green'
-            runner: ubuntu-22.04
-            enable_bzlmod: true
-          - test: '@@//tests/updatesrc_tests:updatesrc_test_bazel_last_green'
             runner: macos-13
             enable_bzlmod: true
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,22 @@ jobs:
           - test: '@@//examples/bzlformat:simple_test_bazel_.bazelversion'
             runner: macos-13
             enable_bzlmod: true
+          - test: '@@//examples/bzlformat:simple_test_bazel_last_green'
+            runner: ubuntu-22.04
+            enable_bzlmod: true
+          - test: '@@//examples/bzlformat:simple_test_bazel_last_green'
+            runner: macos-13
+            enable_bzlmod: true
           - test: '@@//examples/markdown:simple_test_bazel_.bazelversion'
             runner: ubuntu-22.04
             enable_bzlmod: true
           - test: '@@//examples/markdown:simple_test_bazel_.bazelversion'
+            runner: macos-13
+            enable_bzlmod: true
+          - test: '@@//examples/markdown:simple_test_bazel_last_green'
+            runner: ubuntu-22.04
+            enable_bzlmod: true
+          - test: '@@//examples/markdown:simple_test_bazel_last_green'
             runner: macos-13
             enable_bzlmod: true
           - test: '@@//examples/tools:tools_test_bazel_.bazelversion'
@@ -50,10 +62,22 @@ jobs:
           - test: '@@//examples/tools:tools_test_bazel_.bazelversion'
             runner: macos-13
             enable_bzlmod: true
+          - test: '@@//examples/tools:tools_test_bazel_last_green'
+            runner: ubuntu-22.04
+            enable_bzlmod: true
+          - test: '@@//examples/tools:tools_test_bazel_last_green'
+            runner: macos-13
+            enable_bzlmod: true
           - test: '@@//examples/updatesrc:simple_test_bazel_.bazelversion'
             runner: ubuntu-22.04
             enable_bzlmod: true
           - test: '@@//examples/updatesrc:simple_test_bazel_.bazelversion'
+            runner: macos-13
+            enable_bzlmod: true
+          - test: '@@//examples/updatesrc:simple_test_bazel_last_green'
+            runner: ubuntu-22.04
+            enable_bzlmod: true
+          - test: '@@//examples/updatesrc:simple_test_bazel_last_green'
             runner: macos-13
             enable_bzlmod: true
           - test: '@@//examples:bzlmod_e2e_test_bazel_.bazelversion'
@@ -62,10 +86,22 @@ jobs:
           - test: '@@//examples:bzlmod_e2e_test_bazel_.bazelversion'
             runner: macos-13
             enable_bzlmod: true
+          - test: '@@//examples:bzlmod_e2e_test_bazel_last_green'
+            runner: ubuntu-22.04
+            enable_bzlmod: true
+          - test: '@@//examples:bzlmod_e2e_test_bazel_last_green'
+            runner: macos-13
+            enable_bzlmod: true
           - test: '@@//tests/bzlformat_tests/tools_tests/missing_pkgs_tests:missing_pkgs_test_bazel_.bazelversion'
             runner: ubuntu-22.04
             enable_bzlmod: true
           - test: '@@//tests/bzlformat_tests/tools_tests/missing_pkgs_tests:missing_pkgs_test_bazel_.bazelversion'
+            runner: macos-13
+            enable_bzlmod: true
+          - test: '@@//tests/bzlformat_tests/tools_tests/missing_pkgs_tests:missing_pkgs_test_bazel_last_green'
+            runner: ubuntu-22.04
+            enable_bzlmod: true
+          - test: '@@//tests/bzlformat_tests/tools_tests/missing_pkgs_tests:missing_pkgs_test_bazel_last_green'
             runner: macos-13
             enable_bzlmod: true
           - test: '@@//tests/bzlrelease_tests/rules_tests/generate_release_notes_tests:generate_release_notes_test'
@@ -111,6 +147,12 @@ jobs:
             runner: ubuntu-22.04
             enable_bzlmod: true
           - test: '@@//tests/updatesrc_tests:updatesrc_test_bazel_.bazelversion'
+            runner: macos-13
+            enable_bzlmod: true
+          - test: '@@//tests/updatesrc_tests:updatesrc_test_bazel_last_green'
+            runner: ubuntu-22.04
+            enable_bzlmod: true
+          - test: '@@//tests/updatesrc_tests:updatesrc_test_bazel_last_green'
             runner: macos-13
             enable_bzlmod: true
     runs-on: ${{ matrix.runner }}

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,7 +20,7 @@ bazel_dep(
 )
 bazel_dep(
     name = "gazelle",
-    version = "0.40.0",
+    version = "0.44.0",
     repo_name = "bazel_gazelle",
 )
 bazel_dep(name = "bazel_skylib", version = "1.7.1")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -77,14 +77,11 @@ bazel_binaries = use_extension(
     dev_dependency = True,
 )
 bazel_binaries.download(version_file = "//:.bazelversion")
-
-# GH525: Enable once local_config_platform issue is resolved.
-# bazel_binaries.download(version = "last_green")
+bazel_binaries.download(version = "last_green")
 use_repo(
     bazel_binaries,
     "bazel_binaries",
     "bazel_binaries_bazelisk",
     "build_bazel_bazel_.bazelversion",
-    # GH525: Enable once local_config_platform issue is resolved.
-    # "build_bazel_bazel_last_green",
+    "build_bazel_bazel_last_green",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -77,11 +77,14 @@ bazel_binaries = use_extension(
     dev_dependency = True,
 )
 bazel_binaries.download(version_file = "//:.bazelversion")
-bazel_binaries.download(version = "last_green")
+
+# GH525: Enable once archive extraction regression is fixed.
+# bazel_binaries.download(version = "last_green")
 use_repo(
     bazel_binaries,
     "bazel_binaries",
     "bazel_binaries_bazelisk",
     "build_bazel_bazel_.bazelversion",
-    "build_bazel_bazel_last_green",
+    # GH525: Enable once archive extraction regression is fixed.
+    # "build_bazel_bazel_last_green",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -46,7 +46,7 @@ multitool.hub(lockfile = "//tools/gh:multitool.lock.json")
 use_repo(multitool, "multitool")
 
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
-go_sdk.download(version = "1.23.3")
+go_sdk.download(version = "1.23.5")
 
 go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -33,10 +33,10 @@ bazel_dep(
     name = "buildifier_prebuilt",
     version = "7.3.1",
 )
-bazel_dep(name = "platforms", version = "0.0.10")
-bazel_dep(name = "rules_shell", version = "0.3.0")
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "rules_shell", version = "0.4.1")
 bazel_dep(name = "rules_multitool", version = "1.0.0")
-bazel_dep(name = "aspect_bazel_lib", version = "2.13.0")
+bazel_dep(name = "aspect_bazel_lib", version = "2.19.4")
 
 multitool = use_extension(
     "@rules_multitool//multitool:extension.bzl",

--- a/examples/bzlmod_e2e/MODULE.bazel
+++ b/examples/bzlmod_e2e/MODULE.bazel
@@ -4,7 +4,7 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "rules_shell", version = "0.3.0")
+bazel_dep(name = "rules_shell", version = "0.4.1")
 bazel_dep(name = "cgrindel_bazel_starlib", version = "0.0.0")
 local_path_override(
     module_name = "cgrindel_bazel_starlib",

--- a/examples/tools/workspace/MODULE.bazel
+++ b/examples/tools/workspace/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "rules_shell", version = "0.3.0")
+bazel_dep(name = "rules_shell", version = "0.4.1")
 bazel_dep(name = "cgrindel_bazel_starlib")
 local_path_override(
     module_name = "cgrindel_bazel_starlib",

--- a/examples/updatesrc/simple/MODULE.bazel
+++ b/examples/updatesrc/simple/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "rules_shell", version = "0.3.0")
+bazel_dep(name = "rules_shell", version = "0.4.1")
 bazel_dep(name = "cgrindel_bazel_starlib")
 local_path_override(
     module_name = "cgrindel_bazel_starlib",


### PR DESCRIPTION
- Upgrade `aspect_bazel_lib` to 2.19.4 to address https://github.com/cgrindel/swift_gazelle_plugin/issues/86#issuecomment-3016813840.
- Upgrade `platforms` to 0.0.11 to address build warning.

Related to #525.