### PR TITLE
chore: add `rules_lint` and define `//tools/format`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -44,6 +44,12 @@ bzlformat_pkg(name = "bzlformat")
 
 bzlformat_missing_pkgs(name = "bzlformat_missing_pkgs")
 
+# MARK: - Format using rules_lint
+
+alias(
+    name = "format",
+    actual = "//tools/format",
+)
 # MARK: - Update Source Files
 
 updatesrc_update_all(name = "update_all")
@@ -61,6 +67,7 @@ tidy(
         ":go_mod_tidy",
         ":gazelle_update_repos",
         ":update_build_files",
+        ":format",
     ],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -70,14 +70,7 @@ bazel_dep(
     version = "0.32.0",
     dev_dependency = True,
 )
-bazel_dep(name = "aspect_rules_lint", version = "1.5.0", dev_dependency = True)
-
-# DEBUG BEGIN
-local_path_override(
-    module_name = "aspect_rules_lint",
-    path = "/Users/chuck/code/cgrindel/rules_lint/add_rules_shell",
-)
-# DEBUG END
+bazel_dep(name = "aspect_rules_lint", version = "1.5.1", dev_dependency = True)
 
 bazel_binaries = use_extension(
     "@rules_bazel_integration_test//:extensions.bzl",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -70,6 +70,7 @@ bazel_dep(
     version = "0.32.0",
     dev_dependency = True,
 )
+bazel_dep(name = "aspect_rules_lint", version = "1.5.0", dev_dependency = True)
 
 bazel_binaries = use_extension(
     "@rules_bazel_integration_test//:extensions.bzl",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -34,7 +34,7 @@ bazel_dep(
     version = "7.3.1",
 )
 bazel_dep(name = "platforms", version = "0.0.11")
-bazel_dep(name = "rules_shell", version = "0.4.1")
+bazel_dep(name = "rules_shell", version = "0.5.0")
 bazel_dep(name = "rules_multitool", version = "1.0.0")
 bazel_dep(name = "aspect_bazel_lib", version = "2.19.4")
 
@@ -71,6 +71,13 @@ bazel_dep(
     dev_dependency = True,
 )
 bazel_dep(name = "aspect_rules_lint", version = "1.5.0", dev_dependency = True)
+
+# DEBUG BEGIN
+local_path_override(
+    module_name = "aspect_rules_lint",
+    path = "/Users/chuck/code/cgrindel/rules_lint/add_rules_shell",
+)
+# DEBUG END
 
 bazel_binaries = use_extension(
     "@rules_bazel_integration_test//:extensions.bzl",

--- a/bzlformat/tools/buildifier.sh
+++ b/bzlformat/tools/buildifier.sh
@@ -2,31 +2,38 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Locate Deps
 
 fail_sh_location=cgrindel_bazel_starlib/shlib/lib/fail.sh
-fail_sh="$(rlocation "${fail_sh_location}")" || \
+fail_sh="$(rlocation "${fail_sh_location}")" ||
   (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../shlib/lib/fail.sh
 source "${fail_sh}"
 
 arrays_sh_location=cgrindel_bazel_starlib/shlib/lib/arrays.sh
-arrays_sh="$(rlocation "${arrays_sh_location}")" || \
+arrays_sh="$(rlocation "${arrays_sh_location}")" ||
   (echo >&2 "Failed to locate ${arrays_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../shlib/lib/arrays.sh
 source "${arrays_sh}"
 
 buildifier_location=buildifier_prebuilt/buildifier/buildifier
-buildifier="$(rlocation "${buildifier_location}")" || \
+buildifier="$(rlocation "${buildifier_location}")" ||
   (echo >&2 "Failed to locate ${buildifier_location}" && exit 1)
 
 # MARK - Process Args
@@ -35,7 +42,7 @@ buildifier="$(rlocation "${buildifier_location}")" || \
 # off - Do not lint
 # warn - Report lint issues.
 # fix = Attempt to fix lint issues.
-lint_modes=( off warn fix )
+lint_modes=(off warn fix)
 lint_mode="off"
 
 warnings="all"
@@ -50,7 +57,7 @@ Usage:
 ${utility} [OPTION]... <input> <output>
 
 Options:
-  --lint_mode <lint_mode>  The buildifier lint mode: $( join_by ", " "${lint_modes[@]}" ) (default: ${lint_mode})
+  --lint_mode <lint_mode>  The buildifier lint mode: $(join_by ", " "${lint_modes[@]}") (default: ${lint_mode})
   --warnings <warnings>    A comma-separated warnings used in the lint mode or "all" (default: ${warnings})
   <input>                  A path to a Starlark file
   <output>                 A path where to write the output from buildifier
@@ -60,24 +67,24 @@ EOF
 args=()
 while (("$#")); do
   case "${1}" in
-    "--help")
-      show_usage
-      ;;
-    "--lint_mode")
-      lint_mode="${2}"
-      shift 2
-      ;;
-    "--warnings")
-      warnings="${2}"
-      shift 2
-      ;;
-    --*)
-      usage_error "Unexpected option. ${1}"
-      ;;
-    *)
-      args+=("${1}")
-      shift 1
-      ;;
+  "--help")
+    show_usage
+    ;;
+  "--lint_mode")
+    lint_mode="${2}"
+    shift 2
+    ;;
+  "--warnings")
+    warnings="${2}"
+    shift 2
+    ;;
+  --*)
+    usage_error "Unexpected option. ${1}"
+    ;;
+  *)
+    args+=("${1}")
+    shift 1
+    ;;
   esac
 done
 
@@ -85,37 +92,36 @@ done
 bzl_path="${args[0]}"
 [[ ${#args[@]} -gt 1 ]] && out_path="${args[1]}"
 
-contains_item "${lint_mode}" "${lint_modes[@]}" || \
-  usage_error "Invalid lint_mode (${lint_mode}). Expected to be one of the following: $( join_by ", " "${lint_modes[@]}" )."
-
+contains_item "${lint_mode}" "${lint_modes[@]}" ||
+  usage_error "Invalid lint_mode (${lint_mode}). Expected to be one of the following: $(join_by ", " "${lint_modes[@]}")."
 
 # MARK - Execute Buildifier
 
 exec_buildifier() {
   local bzl_path="${1}"
   shift 1
-  local buildifier_cmd=( "${buildifier}" "--path=${bzl_path}" )
-  [[ ${#} -gt 0 ]] && buildifier_cmd+=( "${@}" )
+  local buildifier_cmd=("${buildifier}" "--path=${bzl_path}")
+  [[ ${#} -gt 0 ]] && buildifier_cmd+=("${@}")
   "${buildifier_cmd[@]}"
 }
 
-cat_cmd=( cat "${bzl_path}" ) 
+cat_cmd=(cat "${bzl_path}")
 
-buildifier_cmd=( exec_buildifier "${bzl_path}" "--warnings=${warnings}" )
+buildifier_cmd=(exec_buildifier "${bzl_path}" "--warnings=${warnings}")
 case "${lint_mode}" in
-  "fix")
-    buildifier_cmd+=( "--lint=fix" )
-    ;;
-  "warn")
-    buildifier_cmd+=( "--lint=warn" )
-    ;;
-  "off")
-    buildifier_cmd+=( "--lint=off" )
-    ;;
+"fix")
+  buildifier_cmd+=("--lint=fix")
+  ;;
+"warn")
+  buildifier_cmd+=("--lint=warn")
+  ;;
+"off")
+  buildifier_cmd+=("--lint=off")
+  ;;
 esac
 
 if [[ -n "${out_path:-}" ]]; then
-  "${cat_cmd[@]}" | "${buildifier_cmd[@]}" > "${out_path}"
+  "${cat_cmd[@]}" | "${buildifier_cmd[@]}" >"${out_path}"
 else
-  "${cat_cmd[@]}" | "${buildifier_cmd[@]}" > /dev/null
+  "${cat_cmd[@]}" | "${buildifier_cmd[@]}" >/dev/null
 fi

--- a/bzlformat/tools/missing_pkgs/common.sh
+++ b/bzlformat/tools/missing_pkgs/common.sh
@@ -16,14 +16,13 @@ normalize_pkg() {
   # Strip a trailing slash
   # Make sure to add prefix (//)
   case "${pkg}" in
-    "//"*)
-      ;;
-    "/"*)
-      local pkg="/${pkg}"
-      ;;
-    *)
-      local pkg="//${pkg}"
-      ;;
+  "//"*) ;;
+  "/"*)
+    local pkg="/${pkg}"
+    ;;
+  *)
+    local pkg="//${pkg}"
+    ;;
   esac
   echo "${pkg}"
 }

--- a/bzlformat/tools/missing_pkgs/find.sh
+++ b/bzlformat/tools/missing_pkgs/find.sh
@@ -2,16 +2,23 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
-# Use the Bazel binary specified by the integration test. Otherise, fall back 
+# Use the Bazel binary specified by the integration test. Otherise, fall back
 # to bazel.
 bazel="${BIT_BAZEL_BINARY:-bazel}"
 
@@ -20,14 +27,14 @@ arrays_lib="$(rlocation cgrindel_bazel_starlib/shlib/lib/arrays.sh)"
 source "${arrays_lib}"
 
 common_sh_location=cgrindel_bazel_starlib/bzlformat/tools/missing_pkgs/common.sh
-common_sh="$(rlocation "${common_sh_location}")" || \
+common_sh="$(rlocation "${common_sh_location}")" ||
   (echo >&2 "Failed to locate ${common_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/common.sh
 source "${common_sh}"
 
 query_for_pkgs() {
   local query="${1}"
-  # We need to add a prefix here (//). Otherwise, the root package would be an 
+  # We need to add a prefix here (//). Otherwise, the root package would be an
   # empty string. Empty strings are easily lost in Bash.
   "${bazel}" query "${query}" --output package | sed -e 's|^|//|'
 }
@@ -37,18 +44,18 @@ exclude_pkgs=()
 args=()
 while (("$#")); do
   case "${1}" in
-    "--exclude")
-      exclude_pkgs+=( "$(normalize_pkg "${2}")" )
-      shift 2
-      ;;
-    "--fail_on_missing_pkgs")
-      fail_on_missing_pkgs=true
-      shift 1
-      ;;
-    *)
-      args+=("${1}")
-      shift 1
-      ;;
+  "--exclude")
+    exclude_pkgs+=("$(normalize_pkg "${2}")")
+    shift 2
+    ;;
+  "--fail_on_missing_pkgs")
+    fail_on_missing_pkgs=true
+    shift 1
+    ;;
+  *)
+    args+=("${1}")
+    shift 1
+    ;;
   esac
 done
 
@@ -66,9 +73,9 @@ while IFS=$'\n' read -r line; do pkgs_with_format+=("$line"); done < <(
 
 pkgs_missing_format=()
 if [[ "${#all_pkgs[@]}" -gt 0 ]]; then
-  for pkg in "${all_pkgs[@]}" ; do
+  for pkg in "${all_pkgs[@]}"; do
     if ! contains_item "${pkg}" "${pkgs_with_format[@]:-}" && ! contains_item "${pkg}" "${exclude_pkgs[@]:-}"; then
-      pkgs_missing_format+=( "${pkg}" )
+      pkgs_missing_format+=("${pkg}")
     fi
   done
 fi
@@ -82,4 +89,3 @@ if [[ ${#pkgs_missing_format[@]} -gt 0 ]]; then
     exit 1
   fi
 fi
-

--- a/bzlformat/tools/missing_pkgs/fix.sh
+++ b/bzlformat/tools/missing_pkgs/fix.sh
@@ -4,13 +4,20 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 arrays_lib="$(rlocation cgrindel_bazel_starlib/shlib/lib/arrays.sh)"
@@ -18,7 +25,7 @@ arrays_lib="$(rlocation cgrindel_bazel_starlib/shlib/lib/arrays.sh)"
 source "${arrays_lib}"
 
 common_sh_location=cgrindel_bazel_starlib/bzlformat/tools/missing_pkgs/common.sh
-common_sh="$(rlocation "${common_sh_location}")" || \
+common_sh="$(rlocation "${common_sh_location}")" ||
   (echo >&2 "Failed to locate ${common_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/common.sh
 source "${common_sh}"
@@ -27,29 +34,28 @@ source "${common_sh}"
 find_missing_pkgs_bin="$(rlocation cgrindel_bazel_starlib/bzlformat/tools/missing_pkgs/find.sh)"
 
 buildozer_location=buildifier_prebuilt/buildozer/buildozer
-buildozer="$(rlocation "${buildozer_location}")" || \
+buildozer="$(rlocation "${buildozer_location}")" ||
   (echo >&2 "Failed to locate ${buildozer_location}" && exit 1)
 
 exclude_pkgs=()
 args=()
 while (("$#")); do
   case "${1}" in
-    "--exclude")
-      exclude_pkgs+=( "$(normalize_pkg "${2}")" )
-      shift 2
-      ;;
-    *)
-      args+=("${1}")
-      shift 1
-      ;;
+  "--exclude")
+    exclude_pkgs+=("$(normalize_pkg "${2}")")
+    shift 2
+    ;;
+  *)
+    args+=("${1}")
+    shift 1
+    ;;
   esac
 done
-
 
 cd "${BUILD_WORKSPACE_DIRECTORY}"
 
 find_args=()
-for pkg in "${exclude_pkgs[@]:-}" ; do
+for pkg in "${exclude_pkgs[@]:-}"; do
   find_args+=(--exclude "${pkg}")
 done
 missing_pkgs=()
@@ -61,19 +67,19 @@ while IFS=$'\n' read -r line; do missing_pkgs+=("$line"); done < <(
 [[ ${#missing_pkgs[@]} -eq 0 ]] && echo "No missing package updates were found." && exit
 
 echo "Updating the following packages:"
-for pkg in "${missing_pkgs[@]}" ; do
+for pkg in "${missing_pkgs[@]}"; do
   echo "${pkg}"
 done
 
 buildozer_cmds=()
-buildozer_cmds+=( 'fix movePackageToTop' )
-buildozer_cmds+=( 'new_load @cgrindel_bazel_starlib//bzlformat:defs.bzl bzlformat_pkg' )
-buildozer_cmds+=( 'new bzlformat_pkg bzlformat' )
-buildozer_cmds+=( 'fix unusedLoads' )
+buildozer_cmds+=('fix movePackageToTop')
+buildozer_cmds+=('new_load @cgrindel_bazel_starlib//bzlformat:defs.bzl bzlformat_pkg')
+buildozer_cmds+=('new bzlformat_pkg bzlformat')
+buildozer_cmds+=('fix unusedLoads')
 
 # Execute the buildozer commands
 missing_pkgs_args=()
-for pkg in "${missing_pkgs[@]}" ; do
-  missing_pkgs_args+=( "${pkg}:__pkg__" )
+for pkg in "${missing_pkgs[@]}"; do
+  missing_pkgs_args+=("${pkg}:__pkg__")
 done
 "${buildozer}" "${buildozer_cmds[@]}" "${missing_pkgs_args[@]}"

--- a/bzlrelease/tools/create_release.sh
+++ b/bzlrelease/tools/create_release.sh
@@ -2,44 +2,49 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Locate Dependencies
 
 fail_sh_location=cgrindel_bazel_starlib/shlib/lib/fail.sh
-fail_sh="$(rlocation "${fail_sh_location}")" || \
+fail_sh="$(rlocation "${fail_sh_location}")" ||
   (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../shlib/lib/fail.sh
 source "${fail_sh}"
 
 env_sh_location=cgrindel_bazel_starlib/shlib/lib/env.sh
-env_sh="$(rlocation "${env_sh_location}")" || \
+env_sh="$(rlocation "${env_sh_location}")" ||
   (echo >&2 "Failed to locate ${env_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../shlib/lib/env.sh
 source "${env_sh}"
 
 git_sh_location=cgrindel_bazel_starlib/shlib/lib/git.sh
-git_sh="$(rlocation "${git_sh_location}")" || \
+git_sh="$(rlocation "${git_sh_location}")" ||
   (echo >&2 "Failed to locate ${git_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../shlib/lib/git.sh
 source "${git_sh}"
 
 github_sh_location=cgrindel_bazel_starlib/shlib/lib/github.sh
-github_sh="$(rlocation "${github_sh_location}")" || \
+github_sh="$(rlocation "${github_sh_location}")" ||
   (echo >&2 "Failed to locate ${github_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../shlib/lib/github.sh
 source "${github_sh}"
 
-
 # MARK - Check for Required Software
-
 
 # MARK - Usage
 
@@ -64,7 +69,6 @@ Options:
 EOF
 }
 
-
 # MARK - Process Arguments
 
 reset_tag=false
@@ -72,28 +76,28 @@ reset_tag=false
 args=()
 while (("$#")); do
   case "${1}" in
-    "--help")
-      show_usage
-      ;;
-    --workflow)
-      workflow_name="${2}"
-      shift 2
-      ;;
-    --ref)
-      ref="${2}"
-      shift 2
-      ;;
-    --reset_tag)
-      reset_tag=true
-      shift 1
-      ;;
-    --*)
-      fail "Unrecognized flag. ${1}"
-      ;;
-    *)
-      args+=("${1}")
-      shift 1
-      ;;
+  "--help")
+    show_usage
+    ;;
+  --workflow)
+    workflow_name="${2}"
+    shift 2
+    ;;
+  --ref)
+    ref="${2}"
+    shift 2
+    ;;
+  --reset_tag)
+    reset_tag=true
+    shift 1
+    ;;
+  --*)
+    fail "Unrecognized flag. ${1}"
+    ;;
+  *)
+    args+=("${1}")
+    shift 1
+    ;;
   esac
 done
 
@@ -102,7 +106,6 @@ done
 [[ ${#args[@]} == 0 ]] && usage_error "Expected a version tag for the release. (e.g v.1.2.3)"
 tag="${args[0]}"
 is_valid_release_tag "${tag}" || fail "Invalid version tag. Expected it to start with 'v'."
-
 
 # MARK - Run the workflow
 

--- a/bzlrelease/tools/create_release_tag.sh
+++ b/bzlrelease/tools/create_release_tag.sh
@@ -2,37 +2,44 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Locate Dependencies
 
 fail_sh_location=cgrindel_bazel_starlib/shlib/lib/fail.sh
-fail_sh="$(rlocation "${fail_sh_location}")" || \
+fail_sh="$(rlocation "${fail_sh_location}")" ||
   (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../shlib/lib/fail.sh
 source "${fail_sh}"
 
 env_sh_location=cgrindel_bazel_starlib/shlib/lib/env.sh
-env_sh="$(rlocation "${env_sh_location}")" || \
+env_sh="$(rlocation "${env_sh_location}")" ||
   (echo >&2 "Failed to locate ${env_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../shlib/lib/env.sh
 source "${env_sh}"
 
 git_sh_location=cgrindel_bazel_starlib/shlib/lib/git.sh
-git_sh="$(rlocation "${git_sh_location}")" || \
+git_sh="$(rlocation "${git_sh_location}")" ||
   (echo >&2 "Failed to locate ${git_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../shlib/lib/git.sh
 source "${git_sh}"
 
 github_sh_location=cgrindel_bazel_starlib/shlib/lib/github.sh
-github_sh="$(rlocation "${github_sh_location}")" || \
+github_sh="$(rlocation "${github_sh_location}")" ||
   (echo >&2 "Failed to locate ${github_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../shlib/lib/github.sh
 source "${github_sh}"
@@ -56,25 +63,25 @@ main_branch=main
 args=()
 while (("$#")); do
   case "${1}" in
-    "--help")
-      show_usage
-      ;;
-    --remote)
-      remote="${2}"
-      shift 2
-      ;;
-    --branch)
-      main_branch="${2}"
-      shift 2
-      ;;
-    --reset_tag)
-      reset_tag=true
-      shift 1
-      ;;
-    *)
-      args+=("${1}")
-      shift 1
-      ;;
+  "--help")
+    show_usage
+    ;;
+  --remote)
+    remote="${2}"
+    shift 2
+    ;;
+  --branch)
+    main_branch="${2}"
+    shift 2
+    ;;
+  --reset_tag)
+    reset_tag=true
+    shift 1
+    ;;
+  *)
+    args+=("${1}")
+    shift 1
+    ;;
   esac
 done
 
@@ -82,7 +89,6 @@ done
 tag="${args[0]}"
 
 is_valid_release_tag "${tag}" || fail "Invalid version tag. Expected it to start with 'v'."
-
 
 # MARK - Create the release
 
@@ -103,7 +109,7 @@ git_tag_exists_on_remote "${tag}" "${remote}" && fail "This tag already exists o
 if git_tag_exists "${tag}"; then
   echo "The tag (${tag}) exists locally, but does not exist on origin."
 else
-  commit="$( get_git_commit_hash "${remote}/${main_branch}" )"
+  commit="$(get_git_commit_hash "${remote}/${main_branch}")"
   cat <<-EOF
 Creating release tag.
 Tag:    ${tag}

--- a/bzlrelease/tools/generate_git_archive.sh
+++ b/bzlrelease/tools/generate_git_archive.sh
@@ -9,43 +9,50 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Locate Dependencies
 
 fail_sh_location=cgrindel_bazel_starlib/shlib/lib/fail.sh
-fail_sh="$(rlocation "${fail_sh_location}")" || \
+fail_sh="$(rlocation "${fail_sh_location}")" ||
   (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../shlib/lib/fail.sh
 source "${fail_sh}"
 
 env_sh_location=cgrindel_bazel_starlib/shlib/lib/env.sh
-env_sh="$(rlocation "${env_sh_location}")" || \
+env_sh="$(rlocation "${env_sh_location}")" ||
   (echo >&2 "Failed to locate ${env_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../shlib/lib/env.sh
 source "${env_sh}"
 
 git_sh_location=cgrindel_bazel_starlib/shlib/lib/git.sh
-git_sh="$(rlocation "${git_sh_location}")" || \
+git_sh="$(rlocation "${git_sh_location}")" ||
   (echo >&2 "Failed to locate ${git_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../shlib/lib/git.sh
 source "${git_sh}"
 
 github_sh_location=cgrindel_bazel_starlib/shlib/lib/github.sh
-github_sh="$(rlocation "${github_sh_location}")" || \
+github_sh="$(rlocation "${github_sh_location}")" ||
   (echo >&2 "Failed to locate ${github_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../shlib/lib/github.sh
 source "${github_sh}"
 
 git_exe_location=cgrindel_bazel_starlib/tools/git/git.exe
-git="$(rlocation "${git_exe_location}")" || \
+git="$(rlocation "${git_exe_location}")" ||
   (echo >&2 "Failed to locate ${git_exe_location}" && exit 1)
 
 # MARK - Process Args
@@ -57,38 +64,38 @@ compress=true
 args=()
 while (("$#")); do
   case "${1}" in
-    "--remote")
-      remote="${2}"
-      shift 2
-      ;;
-    "--main")
-      main_branch="${2}"
-      shift 2
-      ;;
-    "--repo")
-      repo="${2}"
-      shift 2
-      ;;
-    "--tag_name")
-      tag_name="${2}"
-      shift 2
-      ;;
-    "--prefix")
-      prefix="${2}"
-      shift 2
-      ;;
-    "--nocompress")
-      compress=false
-      shift 1
-      ;;
-    "--output")
-      output_path="${2}"
-      shift 2
-      ;;
-    *)
-      args+=("${1}")
-      shift 1
-      ;;
+  "--remote")
+    remote="${2}"
+    shift 2
+    ;;
+  "--main")
+    main_branch="${2}"
+    shift 2
+    ;;
+  "--repo")
+    repo="${2}"
+    shift 2
+    ;;
+  "--tag_name")
+    tag_name="${2}"
+    shift 2
+    ;;
+  "--prefix")
+    prefix="${2}"
+    shift 2
+    ;;
+  "--nocompress")
+    compress=false
+    shift 1
+    ;;
+  "--output")
+    output_path="${2}"
+    shift 2
+    ;;
+  *)
+    args+=("${1}")
+    shift 1
+    ;;
   esac
 done
 
@@ -105,29 +112,27 @@ fetch_latest_from_git_remote
 if [[ -z "${prefix:-}" ]]; then
   # Make sure that we have a repo name
   if [[ -z "${repo:-}" ]]; then
-    repo_url="$( get_git_remote_url )"
-    is_github_repo_url "${repo_url}" || \
+    repo_url="$(get_git_remote_url)"
+    is_github_repo_url "${repo_url}" ||
       fail "Could not figure out repo name. Please specify the repo name using the --repo flag."
-    repo="$( get_gh_repo_name "${repo_url}" )"
+    repo="$(get_gh_repo_name "${repo_url}")"
   fi
   prefix_suffix="${tag_name}"
   [[ "${prefix_suffix}" =~ ^v ]] && prefix_suffix="${prefix_suffix:1}"
   prefix="${repo}-${prefix_suffix}"
 fi
 
-
 # Figure out which commit or tag to use
 if git_tag_exists "${tag_name}"; then
   commit_or_tag="${tag_name}"
 else
   # The tag does not exist. Assume that we are about to tag the code in the main branch.
-  commit_or_tag="$( get_git_commit_hash "${remote_name}/${main_branch}" )"
+  commit_or_tag="$(get_git_commit_hash "${remote_name}/${main_branch}")"
 fi
-
 
 # Wrap the archive call
 create_archive() {
-  "${git}" archive --format=tar "--prefix=${prefix}/" "${commit_or_tag}" 
+  "${git}" archive --format=tar "--prefix=${prefix}/" "${commit_or_tag}"
 }
 
 # Compress
@@ -146,5 +151,5 @@ fi
 if [[ -z "${output_path:-}" ]]; then
   do_archive
 else
-  do_archive > "${output_path}"
+  do_archive >"${output_path}"
 fi

--- a/bzlrelease/tools/generate_module_snippet.sh
+++ b/bzlrelease/tools/generate_module_snippet.sh
@@ -1,23 +1,30 @@
 #!/usr/bin/env bash
 
-# Generates a Bazel module snippet suitable for inclusion in a MODULE.bazel 
+# Generates a Bazel module snippet suitable for inclusion in a MODULE.bazel
 # file.
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Locate Dependencies
 
 fail_sh_location=cgrindel_bazel_starlib/shlib/lib/fail.sh
-fail_sh="$(rlocation "${fail_sh_location}")" || \
+fail_sh="$(rlocation "${fail_sh_location}")" ||
   (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../shlib/lib/fail.sh
 source "${fail_sh}"
@@ -28,26 +35,26 @@ dev_dependency="false"
 args=()
 while (("$#")); do
   case "${1}" in
-    "--module_name")
-      module_name="${2}"
-      shift 2
-      ;;
-    "--version")
-      version="${2}"
-      shift 2
-      ;;
-    "--output")
-      output_path="${2}"
-      shift 2
-      ;;
-    "--dev_dependency")
-      dev_dependency="true"
-      shift 1
-      ;;
-    *)
-      args+=("${1}")
-      shift 1
-      ;;
+  "--module_name")
+    module_name="${2}"
+    shift 2
+    ;;
+  "--version")
+    version="${2}"
+    shift 2
+    ;;
+  "--output")
+    output_path="${2}"
+    shift 2
+    ;;
+  "--dev_dependency")
+    dev_dependency="true"
+    shift 1
+    ;;
+  *)
+    args+=("${1}")
+    shift 1
+    ;;
   esac
 done
 
@@ -65,23 +72,25 @@ fi
 # MARK - Generate the Snippet
 
 if [[ "${dev_dependency}" == "true" ]]; then
-  snippet="$(cat <<-EOF
+  snippet="$(
+    cat <<-EOF
 bazel_dep(
     name = "${module_name}",
     version = "${version}",
     dev_dependency = True,
 )
 EOF
-)"
+  )"
 else
-  snippet="$(cat <<-EOF
+  snippet="$(
+    cat <<-EOF
 bazel_dep(name = "${module_name}", version = "${version}")
 EOF
-)"
+  )"
 fi
 
-
-snippet="$(cat <<-EOF
+snippet="$(
+  cat <<-EOF
 \`\`\`python
 ${snippet}
 \`\`\`
@@ -94,5 +103,5 @@ EOF
 if [[ -z "${output_path:-}" ]]; then
   echo "${snippet}"
 else
-  echo "${snippet}" > "${output_path}"
+  echo "${snippet}" >"${output_path}"
 fi

--- a/bzlrelease/tools/generate_release_notes.sh
+++ b/bzlrelease/tools/generate_release_notes.sh
@@ -2,25 +2,32 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Locate Dependencies
 
 fail_sh_location=cgrindel_bazel_starlib/shlib/lib/fail.sh
-fail_sh="$(rlocation "${fail_sh_location}")" || \
+fail_sh="$(rlocation "${fail_sh_location}")" ||
   (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../shlib/lib/fail.sh
 source "${fail_sh}"
 
 generate_gh_changelog_sh_location=cgrindel_bazel_starlib/bzlrelease/tools/generate_gh_changelog.sh
-generate_gh_changelog_sh="$(rlocation "${generate_gh_changelog_sh_location}")" || \
+generate_gh_changelog_sh="$(rlocation "${generate_gh_changelog_sh_location}")" ||
   (echo >&2 "Failed to locate ${generate_gh_changelog_sh_location}" && exit 1)
 
 # MARK - Process Arguments
@@ -30,35 +37,35 @@ starting_dir="${PWD}"
 args=()
 while (("$#")); do
   case "${1}" in
-    "--output")
-      output_path="${2}"
-      shift 2
-      ;;
-    "--generate_workspace_snippet")
-      # If the input path is not absolute, then resolve it to be relative to
-      # the starting directory. We do this before we starting changing
-      # directories.
-      generate_workspace_snippet="${2}"
-      [[ "${generate_workspace_snippet}" =~ ^/ ]] || \
-        generate_workspace_snippet="${starting_dir}/${generate_workspace_snippet}"
-      shift 2
-      ;;
-    "--generate_module_snippet")
-      # If the input path is not absolute, then resolve it to be relative to
-      # the starting directory. We do this before we starting changing
-      # directories.
-      generate_module_snippet="${2}"
-      [[ "${generate_module_snippet}" =~ ^/ ]] || \
-        generate_module_snippet="${starting_dir}/${generate_module_snippet}"
-      shift 2
-      ;;
-    --*)
-      fail "Unrecognized flag ${1}."
-      ;;
-    *)
-      args+=("${1}")
-      shift 1
-      ;;
+  "--output")
+    output_path="${2}"
+    shift 2
+    ;;
+  "--generate_workspace_snippet")
+    # If the input path is not absolute, then resolve it to be relative to
+    # the starting directory. We do this before we starting changing
+    # directories.
+    generate_workspace_snippet="${2}"
+    [[ "${generate_workspace_snippet}" =~ ^/ ]] ||
+      generate_workspace_snippet="${starting_dir}/${generate_workspace_snippet}"
+    shift 2
+    ;;
+  "--generate_module_snippet")
+    # If the input path is not absolute, then resolve it to be relative to
+    # the starting directory. We do this before we starting changing
+    # directories.
+    generate_module_snippet="${2}"
+    [[ "${generate_module_snippet}" =~ ^/ ]] ||
+      generate_module_snippet="${starting_dir}/${generate_module_snippet}"
+    shift 2
+    ;;
+  --*)
+    fail "Unrecognized flag ${1}."
+    ;;
+  *)
+    args+=("${1}")
+    shift 1
+    ;;
   esac
 done
 
@@ -79,17 +86,18 @@ cd "${BUILD_WORKSPACE_DIRECTORY}"
   "that Github produces appears to be compatible with Linux implementations of gzip. Hence," \
   "generating release notes on this OS may result in an incompatible SHA256 value."
 
-changelog_md="$( "${generate_gh_changelog_sh}" "${tag_name}" )"
+changelog_md="$("${generate_gh_changelog_sh}" "${tag_name}")"
 
 if [[ -n "${generate_workspace_snippet:-}" ]]; then
-  workspace_snippet="$( "${generate_workspace_snippet}" --tag "${tag_name}" )"
+  workspace_snippet="$("${generate_workspace_snippet}" --tag "${tag_name}")"
 fi
 
 if [[ -n "${generate_module_snippet:-}" ]]; then
-  module_snippet="$( "${generate_module_snippet}" --version "${tag_name}" )"
+  module_snippet="$("${generate_module_snippet}" --version "${tag_name}")"
 fi
 
-release_notes_md="$(cat <<-EOF
+release_notes_md="$(
+  cat <<-EOF
 ## What Has Changed
 
 ${changelog_md}
@@ -97,30 +105,32 @@ EOF
 )"
 
 if [[ -n "${module_snippet:-}" ]]; then
-  release_notes_md="$(cat <<-EOF
+  release_notes_md="$(
+    cat <<-EOF
 ${release_notes_md}
 
 ## Bazel Module Snippet
 
 ${module_snippet}
 EOF
-)"
+  )"
 fi
 
 if [[ -n "${workspace_snippet:-}" ]]; then
-  release_notes_md="$(cat <<-EOF
+  release_notes_md="$(
+    cat <<-EOF
 ${release_notes_md}
 
 ## Workspace Snippet
 
 ${workspace_snippet}
 EOF
-)"
+  )"
 fi
 
 # Output the changelog
 if [[ -z "${output_path:-}" ]]; then
   echo "${release_notes_md}"
 else
-  echo "${release_notes_md}" > "${output_path}"
+  echo "${release_notes_md}" >"${output_path}"
 fi

--- a/bzlrelease/tools/generate_sha256.sh
+++ b/bzlrelease/tools/generate_sha256.sh
@@ -2,51 +2,57 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Locate Dependencies
 
 fail_sh_location=cgrindel_bazel_starlib/shlib/lib/fail.sh
-fail_sh="$(rlocation "${fail_sh_location}")" || \
+fail_sh="$(rlocation "${fail_sh_location}")" ||
   (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../shlib/lib/fail.sh
 source "${fail_sh}"
 
 env_sh_location=cgrindel_bazel_starlib/shlib/lib/env.sh
-env_sh="$(rlocation "${env_sh_location}")" || \
+env_sh="$(rlocation "${env_sh_location}")" ||
   (echo >&2 "Failed to locate ${env_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../shlib/lib/env.sh
 source "${env_sh}"
-
 
 # MARK - Process Arguments
 
 args=()
 while (("$#")); do
   case "${1}" in
-    "--source")
-      source_path="${2}"
-      shift 2
-      ;;
-    "--output")
-      output_path="${2}"
-      shift 2
-      ;;
-    "--utility")
-      utility="${2}"
-      shift 2
-      ;;
-    *)
-      args+=("${1}")
-      shift 1
-      ;;
+  "--source")
+    source_path="${2}"
+    shift 2
+    ;;
+  "--output")
+    output_path="${2}"
+    shift 2
+    ;;
+  "--utility")
+    utility="${2}"
+    shift 2
+    ;;
+  *)
+    args+=("${1}")
+    shift 1
+    ;;
   esac
 done
 
@@ -63,22 +69,22 @@ fi
 
 # Define the hash function
 case "${utility}" in
-  shasum)
-    function sumsha256() {
-      shasum -a 256 | sed -E -n 's/^([^[:space:]]+).*/\1/gp'
-    }
-    ;;
-  openssl)
-    function sumsha256() {
-      # On Ubuntu, we can see a prefix of '(stdin)= '
-      # 2023-02-01:  This has recently changed to be 'SHA2-256(stdin)='.
-      openssl dgst -sha256 | sed -E 's|^.*\(stdin\)= (.*)|\1|g'
-    }
-    ;;
-  *)
-    fail "Unrecognized utility. ${utility:-}"
-    ;;
+shasum)
+  function sumsha256() {
+    shasum -a 256 | sed -E -n 's/^([^[:space:]]+).*/\1/gp'
+  }
+  ;;
+openssl)
+  function sumsha256() {
+    # On Ubuntu, we can see a prefix of '(stdin)= '
+    # 2023-02-01:  This has recently changed to be 'SHA2-256(stdin)='.
+    openssl dgst -sha256 | sed -E 's|^.*\(stdin\)= (.*)|\1|g'
+  }
+  ;;
+*)
+  fail "Unrecognized utility. ${utility:-}"
+  ;;
 esac
 
 # Generate the hash
-sumsha256 < "${source_path:-/dev/stdin}" > "${output_path:-/dev/stdout}"
+sumsha256 <"${source_path:-/dev/stdin}" >"${output_path:-/dev/stdout}"

--- a/bzlrelease/tools/generate_workspace_snippet.sh
+++ b/bzlrelease/tools/generate_workspace_snippet.sh
@@ -12,41 +12,48 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Locate Dependencies
 
 fail_sh_location=cgrindel_bazel_starlib/shlib/lib/fail.sh
-fail_sh="$(rlocation "${fail_sh_location}")" || \
+fail_sh="$(rlocation "${fail_sh_location}")" ||
   (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../shlib/lib/fail.sh
 source "${fail_sh}"
 
 git_sh_location=cgrindel_bazel_starlib/shlib/lib/git.sh
-git_sh="$(rlocation "${git_sh_location}")" || \
+git_sh="$(rlocation "${git_sh_location}")" ||
   (echo >&2 "Failed to locate ${git_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../shlib/lib/git.sh
 source "${git_sh}"
 
 github_sh_location=cgrindel_bazel_starlib/shlib/lib/github.sh
-github_sh="$(rlocation "${github_sh_location}")" || \
+github_sh="$(rlocation "${github_sh_location}")" ||
   (echo >&2 "Failed to locate ${github_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../shlib/lib/github.sh
 source "${github_sh}"
 
 generate_git_archive_sh_location=cgrindel_bazel_starlib/bzlrelease/tools/generate_git_archive.sh
-generate_git_archive_sh="$(rlocation "${generate_git_archive_sh_location}")" || \
+generate_git_archive_sh="$(rlocation "${generate_git_archive_sh_location}")" ||
   (echo >&2 "Failed to locate ${generate_git_archive_sh_location}" && exit 1)
 
 generate_sha256_sh_location=cgrindel_bazel_starlib/bzlrelease/tools/generate_sha256.sh
-generate_sha256_sh="$(rlocation "${generate_sha256_sh_location}")" || \
+generate_sha256_sh="$(rlocation "${generate_sha256_sh_location}")" ||
   (echo >&2 "Failed to locate ${generate_sha256_sh_location}" && exit 1)
 
 # MARK - Keep Track of the starting directory
@@ -62,64 +69,64 @@ url_templates=()
 args=()
 while (("$#")); do
   case "${1}" in
-    "--sha256")
-      sha256="${2}"
-      shift 2
-      ;;
-    "--sha256_file")
-      sha256_file="${2}"
-      shift 2
-      ;;
-    "--tag")
-      tag="${2}"
-      shift 2
-      ;;
-    "--url")
-      url_templates+=( "${2}" )
-      shift 2
-      ;;
-    "--github_release_archive_url")
-      add_github_release_archive_url=true
-      add_github_src_archive_url=false
-      add_strip_prefix=false
-      shift 1
-      ;;
-    "--no_github_source_archive_url")
-      add_github_src_archive_url=false
-      shift 1
-      ;;
-    "--no_strip_prefix")
-      add_github_src_archive_url=false
-      shift 1
-      ;;
-    "--owner")
-      owner="${2}"
-      shift 2
-      ;;
-    "--repo")
-      repo="${2}"
-      shift 2
-      ;;
-    "--workspace_name")
-      workspace_name="${2}"
-      shift 2
-      ;;
-    "--output")
-      output_path="${2}"
-      shift 2
-      ;;
-    "--template")
-      # If the input path is not absolute, then resolve it to be relative to
-      # the starting directory. We do this before we starting changing
-      # directories.
-      template="${2}"
-      [[ "${template}" =~ ^/ ]] || template="${starting_dir}/${2}"
-      shift 2
-      ;;
-    *)
-      args+=( "${1}" )
-      shift 1
-      ;;
+  "--sha256")
+    sha256="${2}"
+    shift 2
+    ;;
+  "--sha256_file")
+    sha256_file="${2}"
+    shift 2
+    ;;
+  "--tag")
+    tag="${2}"
+    shift 2
+    ;;
+  "--url")
+    url_templates+=("${2}")
+    shift 2
+    ;;
+  "--github_release_archive_url")
+    add_github_release_archive_url=true
+    add_github_src_archive_url=false
+    add_strip_prefix=false
+    shift 1
+    ;;
+  "--no_github_source_archive_url")
+    add_github_src_archive_url=false
+    shift 1
+    ;;
+  "--no_strip_prefix")
+    add_github_src_archive_url=false
+    shift 1
+    ;;
+  "--owner")
+    owner="${2}"
+    shift 2
+    ;;
+  "--repo")
+    repo="${2}"
+    shift 2
+    ;;
+  "--workspace_name")
+    workspace_name="${2}"
+    shift 2
+    ;;
+  "--output")
+    output_path="${2}"
+    shift 2
+    ;;
+  "--template")
+    # If the input path is not absolute, then resolve it to be relative to
+    # the starting directory. We do this before we starting changing
+    # directories.
+    template="${2}"
+    [[ "${template}" =~ ^/ ]] || template="${starting_dir}/${2}"
+    shift 2
+    ;;
+  *)
+    args+=("${1}")
+    shift 1
+    ;;
   esac
 done
 
@@ -128,20 +135,20 @@ done
 [[ -z "${tag:-}" ]] && fail "Expected a tag value."
 
 # shellcheck disable=SC2016
-[[ "${add_github_src_archive_url}" == true ]] && \
-  url_templates+=( 'http://github.com/${owner}/${repo}/archive/${tag}.tar.gz' )
+[[ "${add_github_src_archive_url}" == true ]] &&
+  url_templates+=('http://github.com/${owner}/${repo}/archive/${tag}.tar.gz')
 # shellcheck disable=SC2016
-[[ "${add_github_release_archive_url}" == true ]] && \
-  url_templates+=( 'https://github.com/${owner}/${repo}/releases/download/${tag}/${repo}.${tag}.tar.gz' )
+[[ "${add_github_release_archive_url}" == true ]] &&
+  url_templates+=('https://github.com/${owner}/${repo}/releases/download/${tag}/${repo}.${tag}.tar.gz')
 [[ ${#url_templates[@]} -gt 0 ]] || fail "Expected one or more url templates."
 
 # MARK - Ensure that we have a SHA256 value
 
 if [[ -n "${sha256_file:-}" ]]; then
-  sha256="$(< "${sha256_file}")"
+  sha256="$(<"${sha256_file}")"
 fi
 if [[ -z "${sha256:-}" ]]; then
-  sha256="$( "${generate_git_archive_sh}" --tag_name "${tag}" | "${generate_sha256_sh}" )"
+  sha256="$("${generate_git_archive_sh}" --tag_name "${tag}" | "${generate_sha256_sh}")"
 fi
 
 # MARK - Generate the snippet
@@ -149,11 +156,11 @@ fi
 cd "${BUILD_WORKSPACE_DIRECTORY}"
 
 if [[ -z "${owner:-}" ]] || [[ -z "${repo:-}" ]]; then
-  repo_url="$( get_git_remote_url )"
-  is_github_repo_url "${repo_url}" || \
+  repo_url="$(get_git_remote_url)"
+  is_github_repo_url "${repo_url}" ||
     fail "This git repository's remote does not appear to be hosted by Github. repo_url: ${repo_url}"
-  owner="$( get_gh_repo_owner "${repo_url}" )"
-  repo="$( get_gh_repo_name "${repo_url}" )"
+  owner="$(get_gh_repo_owner "${repo_url}")"
+  repo="$(get_gh_repo_name "${repo_url}")"
 fi
 
 strip_prefix_suffix="${tag}"
@@ -168,16 +175,16 @@ fi
 
 # Evaluate the URL template
 urls="$(
-  for url_template in "${url_templates[@]}" ; do
+  for url_template in "${url_templates[@]}"; do
     url="$(eval echo "${url_template}")"
     echo "        \"${url}\","
   done
 )"
 
-
 if [[ "${add_strip_prefix}" == true ]]; then
   # Generate the workspace snippet
-  http_archive_statement="$(cat  <<-EOF
+  http_archive_statement="$(
+    cat <<-EOF
 http_archive(
     name = "${workspace_name}",
     sha256 = "${sha256}",
@@ -189,7 +196,8 @@ ${urls}
 EOF
   )"
 else
-  http_archive_statement="$(cat  <<-EOF
+  http_archive_statement="$(
+    cat <<-EOF
 http_archive(
     name = "${workspace_name}",
     sha256 = "${sha256}",
@@ -201,7 +209,6 @@ EOF
   )"
 fi
 
-
 if [[ -z "${template:-}" ]]; then
   snippet="${http_archive_statement}"
 else
@@ -211,19 +218,20 @@ else
     # remove the temp file when we are done.
     tmp_snippet_path="$(mktemp)"
     trap 'rm -rf "${tmp_snippet_path}"' EXIT
-    echo "${http_archive_statement}" > "${tmp_snippet_path}"
+    echo "${http_archive_statement}" >"${tmp_snippet_path}"
 
     # Replace the '${http_archive_statement}' with the generated http_archive
     # statement.
     sed -E \
-      -e '/\$\{http_archive_statement\}/r '"${tmp_snippet_path}"  \
-      -e '/\$\{http_archive_statement\}/d'  \
+      -e '/\$\{http_archive_statement\}/r '"${tmp_snippet_path}" \
+      -e '/\$\{http_archive_statement\}/d' \
       "${template}"
   )"
 fi
 
 # Wrap the resulting snippet in a markdown codeblock.
-snippet="$(cat <<-EOF
+snippet="$(
+  cat <<-EOF
 \`\`\`python
 ${snippet}
 \`\`\`
@@ -234,5 +242,5 @@ EOF
 if [[ -z "${output_path:-}" ]]; then
   echo "${snippet}"
 else
-  echo "${snippet}" > "${output_path}"
+  echo "${snippet}" >"${output_path}"
 fi

--- a/bzlrelease/tools/update_readme.sh
+++ b/bzlrelease/tools/update_readme.sh
@@ -2,27 +2,33 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Locate Dependencies
 
 fail_sh_location=cgrindel_bazel_starlib/shlib/lib/fail.sh
-fail_sh="$(rlocation "${fail_sh_location}")" || \
+fail_sh="$(rlocation "${fail_sh_location}")" ||
   (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../shlib/lib/fail.sh
 source "${fail_sh}"
 
 update_markdown_doc_sh_location=cgrindel_bazel_starlib/markdown/tools/update_markdown_doc.sh
-update_markdown_doc_sh="$(rlocation "${update_markdown_doc_sh_location}")" || \
+update_markdown_doc_sh="$(rlocation "${update_markdown_doc_sh_location}")" ||
   (echo >&2 "Failed to locate ${update_markdown_doc_sh_location}" && exit 1)
-
 
 # MARK - Process Arguments
 
@@ -31,36 +37,36 @@ starting_dir="${PWD}"
 args=()
 while (("$#")); do
   case "${1}" in
-    "--generate_workspace_snippet")
-      # If the input path is not absolute, then resolve it to be relative to
-      # the starting directory. We do this before we starting changing
-      # directories.
-      generate_workspace_snippet="${2}"
-      [[ "${generate_workspace_snippet}" =~ ^/ ]] || \
-        generate_workspace_snippet="${starting_dir}/${generate_workspace_snippet}"
-      shift 2
-      ;;
-    "--generate_module_snippet")
-      # If the input path is not absolute, then resolve it to be relative to
-      # the starting directory. We do this before we starting changing
-      # directories.
-      generate_module_snippet="${2}"
-      [[ "${generate_module_snippet}" =~ ^/ ]] || \
-        generate_module_snippet="${starting_dir}/${generate_module_snippet}"
-      shift 2
-      ;;
-    "--readme")
-      # This is a relative path from the root of the workspace.
-      readme_path="${2}"
-      shift 2
-      ;;
-    --*)
-      fail "Unrecognized flag ${1}."
-      ;;
-    *)
-      args+=("${1}")
-      shift 1
-      ;;
+  "--generate_workspace_snippet")
+    # If the input path is not absolute, then resolve it to be relative to
+    # the starting directory. We do this before we starting changing
+    # directories.
+    generate_workspace_snippet="${2}"
+    [[ "${generate_workspace_snippet}" =~ ^/ ]] ||
+      generate_workspace_snippet="${starting_dir}/${generate_workspace_snippet}"
+    shift 2
+    ;;
+  "--generate_module_snippet")
+    # If the input path is not absolute, then resolve it to be relative to
+    # the starting directory. We do this before we starting changing
+    # directories.
+    generate_module_snippet="${2}"
+    [[ "${generate_module_snippet}" =~ ^/ ]] ||
+      generate_module_snippet="${starting_dir}/${generate_module_snippet}"
+    shift 2
+    ;;
+  "--readme")
+    # This is a relative path from the root of the workspace.
+    readme_path="${2}"
+    shift 2
+    ;;
+  --*)
+    fail "Unrecognized flag ${1}."
+    ;;
+  *)
+    args+=("${1}")
+    shift 1
+    ;;
   esac
 done
 

--- a/bzltidy/private/check_tidy.sh
+++ b/bzltidy/private/check_tidy.sh
@@ -5,7 +5,7 @@ set -o errexit -o nounset -o pipefail
 # Purposefully not using Bazel's Bash runfiles support. Running it here,
 # appears to mess up the execution of targets that also use it.
 
-# Use the Bazel binary specified by the integration test. Otherise, fall back 
+# Use the Bazel binary specified by the integration test. Otherise, fall back
 # to bazel.
 bazel="${BIT_BAZEL_BINARY:-bazel}"
 
@@ -65,18 +65,18 @@ EOF
 
 git_status() {
   local out="${1}"
-  git status --porcelain > "${out}"
+  git status --porcelain >"${out}"
 }
 
 git_diff() {
   local out="${1}"
-  git diff > "${out}"
+  git diff >"${out}"
 }
 
 diff_files() {
   local first="${1}"
   local second="${2}"
-  diff "${first}" "${second}" 
+  diff "${first}" "${second}"
 }
 
 # MARK - Process Args
@@ -84,20 +84,20 @@ diff_files() {
 tidy_target=
 while (("$#")); do
   case "${1}" in
-    "--help")
-      show_usage
-      ;;
-    --*)
-      usage_error "Unrecognized option. ${1}"
-      ;;
-    *)
-      if [[ -z "${tidy_target:-}" ]]; then
-        tidy_target="${1}"
-      else
-        usage_error "Unrecognized argument. ${1}"
-      fi
-      shift 1
-      ;;
+  "--help")
+    show_usage
+    ;;
+  --*)
+    usage_error "Unrecognized option. ${1}"
+    ;;
+  *)
+    if [[ -z "${tidy_target:-}" ]]; then
+      tidy_target="${1}"
+    else
+      usage_error "Unrecognized argument. ${1}"
+    fi
+    shift 1
+    ;;
   esac
 done
 
@@ -138,12 +138,12 @@ after_diff="${after_dir}/diff"
 git_diff "${after_diff}"
 
 # Compare the before and after
-status_diff="$( diff_files "${before_status}" "${after_status}" || true )"
+status_diff="$(diff_files "${before_status}" "${after_status}" || true)"
 if [[ -n "${status_diff:-}" ]]; then
   fail "The git status outputs changed." "${status_diff}"
 fi
 
-diff_diff="$( diff_files "${before_diff}" "${after_diff}" || true )" 
+diff_diff="$(diff_files "${before_diff}" "${after_diff}" || true)"
 if [[ -n "${diff_diff:-}" ]]; then
   fail "The git diff outputs changed." "${diff_diff}"
 fi

--- a/bzltidy/private/tidy.sh
+++ b/bzltidy/private/tidy.sh
@@ -5,7 +5,7 @@ set -o errexit -o nounset -o pipefail
 # Purposefully not using Bazel's Bash runfiles support. Running it here,
 # appears to mess up the execution of targets that also use it.
 
-# Use the Bazel binary specified by the integration test. Otherise, fall back 
+# Use the Bazel binary specified by the integration test. Otherise, fall back
 # to bazel.
 bazel="${BIT_BAZEL_BINARY:-bazel}"
 
@@ -79,16 +79,16 @@ run_bazel_targets() {
 targets=()
 while (("$#")); do
   case "${1}" in
-    "--help")
-      show_usage
-      ;;
-    --*)
-      usage_error "Unrecognized option. ${1}"
-      ;;
-    *)
-      targets+=("${1}")
-      shift 1
-      ;;
+  "--help")
+    show_usage
+    ;;
+  --*)
+    usage_error "Unrecognized option. ${1}"
+    ;;
+  *)
+    targets+=("${1}")
+    shift 1
+    ;;
   esac
 done
 

--- a/bzltidy/private/tidy_all.sh
+++ b/bzltidy/private/tidy_all.sh
@@ -5,7 +5,7 @@ set -o errexit -o nounset -o pipefail
 # Purposefully not using Bazel's Bash runfiles support. Running it here,
 # appears to mess up the execution of targets that also use it.
 
-# Use the Bazel binary specified by the integration test. Otherise, fall back 
+# Use the Bazel binary specified by the integration test. Otherise, fall back
 # to bazel.
 bazel="${BIT_BAZEL_BINARY:-bazel}"
 
@@ -64,12 +64,12 @@ sort_items() {
 # Flags:
 #  --start_dir: The directory where to start the search.
 #  --error_if_not_found: If specified, the function will return 1 if the file is not found.
-# 
+#
 # Args:
 #  target_file: The basename for the file to be found.
 #
 # Outputs:
-#   stdout: The fully-qualified path to the 
+#   stdout: The fully-qualified path to the
 #   stderr: None.
 upsearch() {
   # Lovingly inspired by https://unix.stackexchange.com/a/13474.
@@ -79,19 +79,19 @@ upsearch() {
   local args=()
   while (("$#")); do
     case "${1}" in
-      "--start_dir")
-        local start_dir
-        start_dir="$(normalize_path "${2}")"
-        shift 2
-        ;;
-      "--error_if_not_found")
-        local error_if_not_found=1
-        shift 1
-        ;;
-      *)
-        args+=( "${1}" )
-        shift 1
-        ;;
+    "--start_dir")
+      local start_dir
+      start_dir="$(normalize_path "${2}")"
+      shift 2
+      ;;
+    "--error_if_not_found")
+      local error_if_not_found=1
+      shift 1
+      ;;
+    *)
+      args+=("${1}")
+      shift 1
+      ;;
     esac
   done
 
@@ -99,11 +99,10 @@ upsearch() {
 
   slashes=${start_dir//[^\/]/}
   directory="${start_dir}"
-  for (( n=${#slashes}; n>0; --n ))
-  do
+  for ((n = ${#slashes}; n > 0; --n)); do
     local test_path="${directory}/${target_file}"
-    test -e "${test_path}" && \
-      normalize_path "${test_path}" &&  return 
+    test -e "${test_path}" &&
+      normalize_path "${test_path}" && return
     directory="${directory}/.."
   done
 
@@ -131,7 +130,7 @@ normalize_path() {
     local basename
     basename="$(basename "${path}")"
   fi
-  dirname="$(cd "${dirname}" > /dev/null && pwd)"
+  dirname="$(cd "${dirname}" >/dev/null && pwd)"
   if [[ -z "${basename:-}" ]]; then
     echo "${dirname}"
   else
@@ -182,13 +181,13 @@ find_workspaces_with_modifications() {
 
   # Find the workspace file for each modified file.
   local workspaces=()
-  for file in "${modified_files[@]}" ; do
+  for file in "${modified_files[@]}"; do
     local dir
-    dir="$( dirname "${file}" )"
-    workspaces+=( "$(upsearch --error_if_not_found --start_dir "${dir}" "WORKSPACE")" )
+    dir="$(dirname "${file}")"
+    workspaces+=("$(upsearch --error_if_not_found --start_dir "${dir}" "WORKSPACE")")
   done
 
-  # Return a unique list 
+  # Return a unique list
   sort_items "${workspaces[@]}"
 }
 
@@ -204,23 +203,23 @@ tidy_target="//:tidy"
 
 while (("$#")); do
   case "${1}" in
-    "--help")
-      show_usage
-      ;;
-    "--mode")
-      find_workspace_mode="$2"
-      shift 2
-      ;;
-    "--tidy_target")
-      tidy_target="$2"
-      shift 2
-      ;;
-    --*)
-      usage_error "Unrecognized option. ${1}"
-      ;;
-    *)
-      usage_error "Unrecognized argument. ${1}"
-      ;;
+  "--help")
+    show_usage
+    ;;
+  "--mode")
+    find_workspace_mode="$2"
+    shift 2
+    ;;
+  "--tidy_target")
+    tidy_target="$2"
+    shift 2
+    ;;
+  --*)
+    usage_error "Unrecognized option. ${1}"
+    ;;
+  *)
+    usage_error "Unrecognized argument. ${1}"
+    ;;
   esac
 done
 
@@ -232,14 +231,15 @@ cd "${BUILD_WORKSPACE_DIRECTORY}"
 # Find all of the workspaces
 find_workspace_cmd=()
 case "${find_workspace_mode}" in
-  "all")
-    find_workspace_cmd=( find_all_workspaces "${BUILD_WORKSPACE_DIRECTORY}" )
-    ;;
-  "modified")
-    find_workspace_cmd=( find_workspaces_with_modifications "${BUILD_WORKSPACE_DIRECTORY}" )
-    ;;
-  *)
-    fail "Unrecognized find_workspace_mode: ${find_workspace_mode}."
+"all")
+  find_workspace_cmd=(find_all_workspaces "${BUILD_WORKSPACE_DIRECTORY}")
+  ;;
+"modified")
+  find_workspace_cmd=(find_workspaces_with_modifications "${BUILD_WORKSPACE_DIRECTORY}")
+  ;;
+*)
+  fail "Unrecognized find_workspace_mode: ${find_workspace_mode}."
+  ;;
 esac
 workspaces=()
 while IFS=$'\n' read -r line; do workspaces+=("$line"); done < <(
@@ -252,7 +252,7 @@ if [[ ${#workspaces[@]} -eq 0 ]]; then
 fi
 
 # Execute tidy target in the workspaces, if it exists.
-for workspace in "${workspaces[@]}" ; do
+for workspace in "${workspaces[@]}"; do
   workspace_dir="$(dirname "${workspace}")"
   cd "${workspace_dir}"
   if target_exists "${tidy_target}"; then

--- a/examples/bzlformat/simple_test.sh
+++ b/examples/bzlformat/simple_test.sh
@@ -2,41 +2,48 @@
 
 # This script performs an integration test for bzlformat.
 # Changes are made to a build file and a bzl file, then the update
-# all command is run to format the changes and copy them back to 
+# all command is run to format the changes and copy them back to
 # the workspace. Finally, the tests are run to be sure that everything
 # is formatted.
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../shlib/lib/assertions.sh
 source "${assertions_sh}"
 
 paths_sh_location=cgrindel_bazel_starlib/shlib/lib/paths.sh
-paths_sh="$(rlocation "${paths_sh_location}")" || \
+paths_sh="$(rlocation "${paths_sh_location}")" ||
   (echo >&2 "Failed to locate ${paths_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../shlib/lib/paths.sh
 source "${paths_sh}"
 
 messages_sh_location=cgrindel_bazel_starlib/shlib/lib/messages.sh
-messages_sh="$(rlocation "${messages_sh_location}")" || \
+messages_sh="$(rlocation "${messages_sh_location}")" ||
   (echo >&2 "Failed to locate ${messages_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../shlib/lib/messages.sh
 source "${messages_sh}"
 
 create_scratch_dir_sh_location=rules_bazel_integration_test/tools/create_scratch_dir.sh
-create_scratch_dir_sh="$(rlocation "${create_scratch_dir_sh_location}")" || \
+create_scratch_dir_sh="$(rlocation "${create_scratch_dir_sh_location}")" ||
   (echo >&2 "Failed to locate ${create_scratch_dir_sh_location}" && exit 1)
 
 # MARK - Process Arguments
@@ -47,9 +54,9 @@ workspace_dir="${BIT_WORKSPACE_DIR:-}"
 # Process args
 while (("$#")); do
   case "${1}" in
-    *)
-      shift 1
-      ;;
+  *)
+    shift 1
+    ;;
   esac
 done
 
@@ -76,11 +83,11 @@ internal_build_path="${scratch_dir}/mockascript/internal/BUILD.bazel"
 mockascript_library_path="${scratch_dir}/mockascript/internal/mockascript_library.bzl"
 
 # Add poorly formatted code to build file.
-echo "load(':foo.bzl', 'foo')" >> "${internal_build_path}"
+echo "load(':foo.bzl', 'foo')" >>"${internal_build_path}"
 
 # Add poorly formatted code to bzl file.
 echo "load(':foo.bzl', 'foo'); foo(tags=['b', 'a'],srcs=['d', 'c'])" \
-  >> "${mockascript_library_path}"
+  >>"${mockascript_library_path}"
 
 # Confirm that the tests fail with poorly formatted files.
 "${bazel}" test //... && fail "Expected tests to fail with poorly formatted files."

--- a/examples/bzlmod_e2e/header/header.sh
+++ b/examples/bzlmod_e2e/header/header.sh
@@ -7,7 +7,7 @@ out="$2"
 header="$3"
 
 first_line=$(head -n 1 "${src}")
-if [[ "${first_line}" != "${header}"  ]]; then
-  echo "${header}" > "${out}"
+if [[ "${first_line}" != "${header}" ]]; then
+  echo "${header}" >"${out}"
 fi
-cat "${src}" >> "${out}"
+cat "${src}" >>"${out}"

--- a/examples/bzlmod_e2e/srcs/Foo/BUILD.bazel
+++ b/examples/bzlmod_e2e/srcs/Foo/BUILD.bazel
@@ -1,5 +1,5 @@
-load("//header:header.bzl", "header")
 load("@cgrindel_bazel_starlib//updatesrc:defs.bzl", "updatesrc_update")
+load("//header:header.bzl", "header")
 
 header(
     name = "add_headers",

--- a/examples/tools/workspace/tools_test.sh
+++ b/examples/tools/workspace/tools_test.sh
@@ -2,29 +2,35 @@
 
 # --- begin runfiles.bash initialization v2 ---
 # Copy-pasted from the Bazel Bash runfiles library v2.
-set -o nounset -o pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+set -o nounset -o pipefail
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
 # shellcheck disable=SC1090
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -o errexit
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: cannot find $f"
+    exit 1
+  }
+f=
+set -o errexit
 # --- end runfiles.bash initialization v2 ---
 
 # MARK - Locate Deps
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 source "${assertions_sh}"
 
 git_exe_location=cgrindel_bazel_starlib/tools/git/git.exe
-git="$(rlocation "${git_exe_location}")" || \
+git="$(rlocation "${git_exe_location}")" ||
   (echo >&2 "Failed to locate ${git_exe_location}" && exit 1)
 
 tar_exe_location=cgrindel_bazel_starlib/tools/tar/tar.exe
-tar="$(rlocation "${tar_exe_location}")" || \
+tar="$(rlocation "${tar_exe_location}")" ||
   (echo >&2 "Failed to locate ${tar_exe_location}" && exit 1)
 
 # MARK - Test
@@ -36,5 +42,5 @@ if [[ ! -e "${git}" ]]; then
   fail "Did not find git."
 fi
 
-output="$( "${tar}" --help )"
+output="$("${tar}" --help)"
 assert_match tar "${output}" "tar help output"

--- a/examples/updatesrc/simple/header/header.sh
+++ b/examples/updatesrc/simple/header/header.sh
@@ -7,7 +7,7 @@ out="$2"
 header="$3"
 
 first_line=$(head -n 1 "${src}")
-if [[ "${first_line}" != "${header}"  ]]; then
-  echo "${header}" > "${out}"
+if [[ "${first_line}" != "${header}" ]]; then
+  echo "${header}" >"${out}"
 fi
-cat "${src}" >> "${out}"
+cat "${src}" >>"${out}"

--- a/examples/updatesrc/simple/srcs/Foo/BUILD.bazel
+++ b/examples/updatesrc/simple/srcs/Foo/BUILD.bazel
@@ -1,5 +1,5 @@
-load("//header:header.bzl", "header")
 load("@cgrindel_bazel_starlib//updatesrc:defs.bzl", "updatesrc_update")
+load("//header:header.bzl", "header")
 
 header(
     name = "add_headers",

--- a/markdown/tools/update_markdown_doc.sh
+++ b/markdown/tools/update_markdown_doc.sh
@@ -2,61 +2,67 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Locate Dependencies
 
 fail_sh_location=cgrindel_bazel_starlib/shlib/lib/fail.sh
-fail_sh="$(rlocation "${fail_sh_location}")" || \
+fail_sh="$(rlocation "${fail_sh_location}")" ||
   (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../shlib/lib/fail.sh
 source "${fail_sh}"
-
 
 # MARK - Process Args
 
 args=()
 while (("$#")); do
   case "${1}" in
-    "--marker_begin")
-      marker_begin="${2}"
-      shift 2
-      ;;
-    "--marker_end")
-      marker_end="${2}"
-      shift 2
-      ;;
-    "--marker")
-      marker="${2}"
-      shift 2
-      [[ "${marker}" =~ :$ ]] || marker="${marker}:"
-      marker_begin="${marker} BEGIN"
-      marker_end="${marker} END"
-      ;;
-    "--update")
-      update_path="${2}"
-      shift 2
-      ;;
-    --*)
-      fail "Unrecognized flag. ${1}"
-      ;;
-    *)
-      args+=("${1}")
-      shift 1
-      ;;
+  "--marker_begin")
+    marker_begin="${2}"
+    shift 2
+    ;;
+  "--marker_end")
+    marker_end="${2}"
+    shift 2
+    ;;
+  "--marker")
+    marker="${2}"
+    shift 2
+    [[ "${marker}" =~ :$ ]] || marker="${marker}:"
+    marker_begin="${marker} BEGIN"
+    marker_end="${marker} END"
+    ;;
+  "--update")
+    update_path="${2}"
+    shift 2
+    ;;
+  --*)
+    fail "Unrecognized flag. ${1}"
+    ;;
+  *)
+    args+=("${1}")
+    shift 1
+    ;;
   esac
 done
 
 [[ -z "${update_path:-}" ]] && fail "No update file was specified."
 
-{ [[ -z "${marker_begin:-}" ]] || [[ -z "${marker_end:-}" ]]; } && \
+{ [[ -z "${marker_begin:-}" ]] || [[ -z "${marker_end:-}" ]]; } &&
   fail "No markers were specified."
 
 [[ ${#args[@]} != 2 ]] && fail "Expected exactly two files: input and output."
@@ -69,7 +75,7 @@ out_path="${args[1]}"
 cp -f "${in_path}" "${out_path}"
 
 # Update the output file replacing with the contents of update_path.
-# 
+#
 # sed script explanation
 #
 # /<!-- '"${marker_begin}"' -->/{      # Find the begin marker

--- a/markdown/tools/update_markdown_toc.sh
+++ b/markdown/tools/update_markdown_toc.sh
@@ -2,69 +2,72 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Locate Deps
 
 fail_sh_location=cgrindel_bazel_starlib/shlib/lib/fail.sh
-fail_sh="$(rlocation "${fail_sh_location}")" || \
+fail_sh="$(rlocation "${fail_sh_location}")" ||
   (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../shlib/lib/fail.sh
 source "${fail_sh}"
 
 update_markdown_doc_sh_location=cgrindel_bazel_starlib/markdown/tools/update_markdown_doc.sh
-update_markdown_doc_sh="$(rlocation "${update_markdown_doc_sh_location}")" || \
+update_markdown_doc_sh="$(rlocation "${update_markdown_doc_sh_location}")" ||
   (echo >&2 "Failed to locate ${update_markdown_doc_sh_location}" && exit 1)
 
 generate_toc_location=cgrindel_bazel_starlib/markdown/tools/markdown_toc/cmd/generate_toc/generate_toc_/generate_toc
-generate_toc="$(rlocation "${generate_toc_location}")" || \
+generate_toc="$(rlocation "${generate_toc_location}")" ||
   (echo >&2 "Failed to locate ${generate_toc_location}" && exit 1)
-
-
 
 # MARK - Process args
 
 remove_toc_header_entry=true
 toc_header="Table of Contents"
-generate_toc_cmd=( "${generate_toc}" --start-level=2 )
+generate_toc_cmd=("${generate_toc}" --start-level=2)
 
 args=()
 while (("$#")); do
   case "${1}" in
-    "--no_remove_toc_header_entry")
-      remove_toc_header_entry=false
-      shift 1
-      ;;
-    "--toc_header")
-      toc_header="${2}"
-      shift 2
-      ;;
-    --*)
-      fail "Unexpected flag ${1}"
-      ;;
-    *)
-      args+=("${1}")
-      shift 1
-      ;;
+  "--no_remove_toc_header_entry")
+    remove_toc_header_entry=false
+    shift 1
+    ;;
+  "--toc_header")
+    toc_header="${2}"
+    shift 2
+    ;;
+  --*)
+    fail "Unexpected flag ${1}"
+    ;;
+  *)
+    args+=("${1}")
+    shift 1
+    ;;
   esac
 done
-
 
 [[ ${#args[@]} != 2 ]] && fail "Expected exactly two files: input and output."
 in_path="${args[0]}"
 out_path="${args[1]}"
 
-
 # MARK - Generate the TOC
 
-toc_dir_path="$( mktemp -d )"
+toc_dir_path="$(mktemp -d)"
 toc_path="${toc_dir_path}/toc.md"
 
 cleanup() {
@@ -72,29 +75,27 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Generate the TOC 
-generate_toc_cmd+=( "${in_path}" )
-"${generate_toc_cmd[@]}" > "${toc_path}"
-
+# Generate the TOC
+generate_toc_cmd+=("${in_path}")
+"${generate_toc_cmd[@]}" >"${toc_path}"
 
 # MARK - Clean up the TOC
 
 # Set up the sed command
-sed_cmd=( sed -i.bak -E )
+sed_cmd=(sed -i.bak -E)
 
 # Remove blank linkes
-sed_cmd+=( -e '/^\s*$/d' ) 
+sed_cmd+=(-e '/^\s*$/d')
 
 # Remove the TOC header entry
-[[ "${remove_toc_header_entry}" == true ]] && \
-  sed_cmd+=( -e '/^[*] \['"${toc_header}"'\]/d' )
+[[ "${remove_toc_header_entry}" == true ]] &&
+  sed_cmd+=(-e '/^[*] \['"${toc_header}"'\]/d')
 
 # Specify the path to the TOC.
-sed_cmd+=( "${toc_path}" ) 
+sed_cmd+=("${toc_path}")
 
 # Execute the sed command
 "${sed_cmd[@]}"
-
 
 # MARK - Update the markdown file with the TOC
 

--- a/shlib/lib/assertions.sh
+++ b/shlib/lib/assertions.sh
@@ -23,8 +23,8 @@ fail() {
 make_err_msg() {
   local err_msg="${1}"
   local prefix="${2:-}"
-  [[ -z ${prefix} ]] \
-    || local err_msg="${prefix} ${err_msg}"
+  [[ -z ${prefix} ]] ||
+    local err_msg="${prefix} ${err_msg}"
   echo "${err_msg}"
 }
 
@@ -44,8 +44,8 @@ assert_equal() {
   local err_msg
   if [[ ${expected} != "${actual}" ]]; then
     local diff_output
-    diff_output=$(diff <(echo "${expected}") <(echo "${actual}") 2>/dev/null \
-      || true)
+    diff_output=$(diff <(echo "${expected}") <(echo "${actual}") 2>/dev/null ||
+      true)
     if [[ -n ${diff_output} ]]; then
       err_msg="$(make_err_msg "Expected to be equal.
 Expected:

--- a/shlib/lib/env.sh
+++ b/shlib/lib/env.sh
@@ -8,6 +8,5 @@ cgrindel_bazel_starlib_lib_private_env_loaded() { return; }
 # Succeeds if the specified executable is found in the path. Otherwise, it fails.
 is_installed() {
   local name="${1}"
-  which "${name}" > /dev/null
+  which "${name}" >/dev/null
 }
-

--- a/shlib/lib/files.sh
+++ b/shlib/lib/files.sh
@@ -4,19 +4,26 @@
 if [[ $(type -t rlocation) != function ]]; then
   # --- begin runfiles.bash initialization v3 ---
   # Copy-pasted from the Bazel Bash runfiles library v3.
-  set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-  source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-    source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-    source "$0.runfiles/$f" 2>/dev/null || \
-    source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-    source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-    { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+  set -uo pipefail
+  set +e
+  f=bazel_tools/tools/bash/runfiles/runfiles.bash
+  source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+    source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+    source "$0.runfiles/$f" 2>/dev/null ||
+    source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+    source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+    {
+      echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+      exit 1
+    }
+  f=
+  set -e
   # --- end runfiles.bash initialization v3 ---
 fi
 
 if [[ $(type -t cgrindel_bazel_shlib_lib_paths_loaded) != function ]]; then
   paths_sh_location=cgrindel_bazel_starlib/shlib/lib/paths.sh
-  paths_sh="$(rlocation "${paths_sh_location}")" || \
+  paths_sh="$(rlocation "${paths_sh_location}")" ||
     (echo >&2 "Failed to locate ${paths_sh_location}" && exit 1)
   # shellcheck disable=SC1090 # external source
   source "${paths_sh}"
@@ -25,18 +32,17 @@ fi
 # This is used to determine if the library has been loaded
 cgrindel_bazel_shlib_lib_files_loaded() { return; }
 
-
 # Recursively searches for a file starting from the current directory up to the root of the filesystem.
 #
 # Flags:
 #  --start_dir: The directory where to start the search.
 #  --error_if_not_found: If specified, the function will return 1 if the file is not found.
-# 
+#
 # Args:
 #  target_file: The basename for the file to be found.
 #
 # Outputs:
-#   stdout: The fully-qualified path to the 
+#   stdout: The fully-qualified path to the
 #   stderr: None.
 upsearch() {
   # Lovingly inspired by https://unix.stackexchange.com/a/13474.
@@ -46,19 +52,19 @@ upsearch() {
   local args=()
   while (("$#")); do
     case "${1}" in
-      "--start_dir")
-        local start_dir
-        start_dir="$(normalize_path "${2}")"
-        shift 2
-        ;;
-      "--error_if_not_found")
-        local error_if_not_found=1
-        shift 1
-        ;;
-      *)
-        args+=( "${1}" )
-        shift 1
-        ;;
+    "--start_dir")
+      local start_dir
+      start_dir="$(normalize_path "${2}")"
+      shift 2
+      ;;
+    "--error_if_not_found")
+      local error_if_not_found=1
+      shift 1
+      ;;
+    *)
+      args+=("${1}")
+      shift 1
+      ;;
     esac
   done
 
@@ -66,11 +72,10 @@ upsearch() {
 
   slashes=${start_dir//[^\/]/}
   directory="${start_dir}"
-  for (( n=${#slashes}; n>0; --n ))
-  do
+  for ((n = ${#slashes}; n > 0; --n)); do
     local test_path="${directory}/${target_file}"
-    test -e "${test_path}" && \
-      normalize_path "${test_path}" &&  return 
+    test -e "${test_path}" &&
+      normalize_path "${test_path}" && return
     directory="${directory}/.."
   done
 
@@ -79,4 +84,3 @@ upsearch() {
     return 1
   fi
 }
-

--- a/shlib/lib/git.sh
+++ b/shlib/lib/git.sh
@@ -3,7 +3,7 @@
 # Git-related Functions
 
 git_exe_location=cgrindel_bazel_starlib/tools/git/git.exe
-git="$(rlocation "${git_exe_location}")" || \
+git="$(rlocation "${git_exe_location}")" ||
   (echo >&2 "Failed to locate ${git_exe_location}" && exit 1)
 
 # MARK - Default Values
@@ -12,22 +12,22 @@ remote=origin
 
 # Returns the URL for the git repository. It is typically in the form:
 #  git@github.com:cgrindel/bazel-starlib.git
-# OR 
+# OR
 #  https://github.com/cgrindel/bazel-starlib.git
 get_git_remote_url() {
   "${git}" config --get remote.origin.url
 }
 
 # Fetch the latest info from the remote.
-fetch_latest_from_git_remote() { 
+fetch_latest_from_git_remote() {
   local remote="${1:-}"
   local branch="${2:-}"
   fetch_cmd=("${git}" fetch)
   if [[ -n "${remote:-}" ]]; then
-    fetch_cmd+=( "${remote}" )
-    [[ -z "${branch:-}" ]] || fetch_cmd+=( "${branch}" )
+    fetch_cmd+=("${remote}")
+    [[ -z "${branch:-}" ]] || fetch_cmd+=("${branch}")
   fi
-  "${fetch_cmd[@]}" 2> /dev/null
+  "${fetch_cmd[@]}" 2>/dev/null
 }
 
 # MARK - Tag Functions
@@ -51,10 +51,10 @@ get_git_release_tags() {
   )
   [[ ${#tags[@]} == 0 ]] && return
   local release_tags=()
-  for tag in "${tags[@]}" ; do
-    is_valid_release_tag "${tag}" && release_tags+=( "${tag}" )
+  for tag in "${tags[@]}"; do
+    is_valid_release_tag "${tag}" && release_tags+=("${tag}")
   done
-  for release_tag in "${release_tags[@]}" ; do
+  for release_tag in "${release_tags[@]}"; do
     echo "${release_tag}"
   done
 }
@@ -66,7 +66,7 @@ git_tag_exists() {
     "${git}" tag
   )
   # Make sure that the for loop variable is not tag or something else common.
-  for cur_tag in "${tags[@]}" ; do
+  for cur_tag in "${tags[@]}"; do
     [[ "${cur_tag}" == "${target_tag}" ]] && return
   done
   return 1
@@ -77,7 +77,7 @@ create_git_tag() {
   local msg="${2}"
   local commit="${3:-}"
   git_tag_cmd=("${git}" tag -a -m "${msg}" "${tag}")
-  [[ -z "${commit:-}" ]] || git_tag_cmd+=( "${commit}" )
+  [[ -z "${commit:-}" ]] || git_tag_cmd+=("${commit}")
   "${git_tag_cmd[@]}"
 }
 
@@ -85,20 +85,20 @@ create_git_release_tag() {
   local tag="${1}"
   local commit="${2:-}"
   msg="Release ${tag}"
-  git_tag_cmd=( create_git_tag "${tag}" "${msg}" )
-  [[ -z "${commit:-}" ]] || git_tag_cmd+=( "${commit}" )
+  git_tag_cmd=(create_git_tag "${tag}" "${msg}")
+  [[ -z "${commit:-}" ]] || git_tag_cmd+=("${commit}")
   "${git_tag_cmd[@]}"
 }
 
 git_tag_exists_on_remote() {
   local tag="${1}"
   local remote="${2:-origin}"
-  "${git}" ls-remote --exit-code "${remote}" "refs/tags/${tag}" > /dev/null
+  "${git}" ls-remote --exit-code "${remote}" "refs/tags/${tag}" >/dev/null
 }
 
 delete_git_tag() {
   local tag="${1}"
-  "${git}" tag -d "${tag}" > /dev/null
+  "${git}" tag -d "${tag}" >/dev/null
 }
 
 push_git_tag_to_remote() {
@@ -110,9 +110,8 @@ push_git_tag_to_remote() {
 delete_git_tag_on_remote() {
   local tag="${1}"
   local remote="${2:-origin}"
-  "${git}" push --delete "${remote}" "${tag}" > /dev/null
+  "${git}" push --delete "${remote}" "${tag}" >/dev/null
 }
-
 
 # MARK - Branch Functions
 

--- a/shlib/lib/messages.sh
+++ b/shlib/lib/messages.sh
@@ -8,7 +8,7 @@ cgrindel_bazel_shlib_lib_messages_loaded() { return; }
 # Flags:
 #   --exit_code: Used to specify the exit code to return/exit.
 #   --no_exit: If specified, the function will `return` the exit code instead of calling `exit`.
-# 
+#
 # Args:
 #   *: All of the collected args are combined to create an error message. If no values are
 #      specified, then a default error message is used.
@@ -23,19 +23,19 @@ exit_with_msg() {
   local args=()
   while (("$#")); do
     case "${1}" in
-      "--exit_code")
-        local exit_code
-        exit_code=$(($2))
-        shift 2
-        ;;
-      "--no_exit")
-        local no_exit=1
-        shift 1
-        ;;
-      *)
-        args+=("${1}")
-        shift 1
-        ;;
+    "--exit_code")
+      local exit_code
+      exit_code=$(($2))
+      shift 2
+      ;;
+    "--no_exit")
+      local no_exit=1
+      shift 1
+      ;;
+    *)
+      args+=("${1}")
+      shift 1
+      ;;
     esac
   done
 
@@ -48,4 +48,3 @@ exit_with_msg() {
   fi
   exit ${exit_code}
 }
-

--- a/shlib/lib/paths.sh
+++ b/shlib/lib/paths.sh
@@ -21,11 +21,10 @@ normalize_path() {
     local basename
     basename="$(basename "${path}")"
   fi
-  dirname="$(cd "${dirname}" > /dev/null && pwd)"
+  dirname="$(cd "${dirname}" >/dev/null && pwd)"
   if [[ -z "${basename:-}" ]]; then
     echo "${dirname}"
   else
     echo "${dirname}/${basename}"
   fi
 }
-

--- a/shlib/tools/contains_item_perf_comparison.sh
+++ b/shlib/tools/contains_item_perf_comparison.sh
@@ -2,13 +2,20 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 arrays_lib="$(rlocation cgrindel_bazel_starlib/shlib/lib/arrays.sh)"
@@ -21,27 +28,27 @@ test_iterations=${1:-100}
 
 create_array() {
   local item_count=${1}
-  local max_val=$(( item_count - 1 ))
-  local width=$(( ${#max_val} ))
+  local max_val=$((item_count - 1))
+  local width=$((${#max_val}))
   local output=()
   local val=0
-  for (( ; val < item_count; val++ )); do
-    output+=( "$(printf "%0${width}d" $val)" )
+  for (( ; val < item_count; val++)); do
+    output+=("$(printf "%0${width}d" $val)")
   done
   print_by_line "${output[@]}"
 }
 
 do_contains_item_perf_test() {
-  for (( i = 0; i < test_iterations; i++ )); do
-    for item in "${@}" ; do
+  for ((i = 0; i < test_iterations; i++)); do
+    for item in "${@}"; do
       contains_item "${item}" "${@}"
     done
   done
 }
 
 do_contains_item_sorted_perf_test() {
-  for (( i = 0; i < test_iterations; i++ )); do
-    for item in "${@}" ; do
+  for ((i = 0; i < test_iterations; i++)); do
+    for item in "${@}"; do
       contains_item_sorted "${item}" "${@}"
     done
   done
@@ -51,15 +58,15 @@ echo "Test iterations: ${test_iterations}"
 echo ""
 
 array_sizes=(25 30 35 40 45 50)
-for size in "${array_sizes[@]}" ; do
-  echo "array size: ${size}" 
+for size in "${array_sizes[@]}"; do
+  echo "array size: ${size}"
   array=()
   while IFS=$'\n' read -r line; do array+=("$line"); done < <(
     create_array "${size}"
   )
-  contains_item_time="$( (time do_contains_item_perf_test "${array[@]}") 2>&1 )"
-  contains_item_sorted_time="$( (time do_contains_item_sorted_perf_test "${array[@]}") 2>&1 )"
-  echo "contains_item: ${contains_item_time}" 
-  echo "contains_item_sorted: ${contains_item_sorted_time}" 
+  contains_item_time="$( (time do_contains_item_perf_test "${array[@]}") 2>&1)"
+  contains_item_sorted_time="$( (time do_contains_item_sorted_perf_test "${array[@]}") 2>&1)"
+  echo "contains_item: ${contains_item_time}"
+  echo "contains_item_sorted: ${contains_item_sorted_time}"
   echo ""
 done

--- a/tests/bzlformat_tests/tools_tests/buildifier_test.sh
+++ b/tests/bzlformat_tests/tools_tests/buildifier_test.sh
@@ -2,27 +2,33 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Locate Deps
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../shlib/lib/assertions.sh
 source "${assertions_sh}"
 
 buildifier_sh_location=cgrindel_bazel_starlib/bzlformat/tools/buildifier.sh
-buildifier_sh="$(rlocation "${buildifier_sh_location}")" || \
+buildifier_sh="$(rlocation "${buildifier_sh_location}")" ||
   (echo >&2 "Failed to locate ${buildifier_sh_location}" && exit 1)
-
 
 # MARK - Constants
 
@@ -40,7 +46,6 @@ cat >"${dep_z_path}" <<-'EOF'
 ZZZ_LIST = []
 EOF
 
-
 cat >"${bad_bzl_path}" <<-'EOF'
 load(":zzz.bzl", "ZZZ_LIST")
 load(":aaa.bzl", "AAA_LIST")
@@ -51,10 +56,10 @@ FOO_LIST = [
 ] + AAA_LIST + ZZZ_LIST
 EOF
 
+# MARK - Test With Defaults
 
-# MARK - Test With Defaults 
-
-expected="$(cat <<-'EOF'
+expected="$(
+  cat <<-'EOF'
 load(":aaa.bzl", "AAA_LIST")
 load(":zzz.bzl", "ZZZ_LIST")
 
@@ -66,13 +71,13 @@ EOF
 )"
 
 "${buildifier_sh}" "${bad_bzl_path}" "${out_path}"
-actual="$(< "${out_path}")"
+actual="$(<"${out_path}")"
 assert_equal "${expected}" "${actual}" "With defaults"
-
 
 # MARK - Test Format Only (lint: off)
 
-expected="$(cat <<-'EOF'
+expected="$(
+  cat <<-'EOF'
 load(":aaa.bzl", "AAA_LIST")
 load(":zzz.bzl", "ZZZ_LIST")
 
@@ -84,13 +89,13 @@ EOF
 )"
 
 "${buildifier_sh}" --lint_mode off "${bad_bzl_path}" "${out_path}"
-actual="$(< "${out_path}")"
+actual="$(<"${out_path}")"
 assert_equal "${expected}" "${actual}" "Format only."
-
 
 # MARK - Test Lint Fix (lint: fix)
 
-expected="$(cat <<-'EOF'
+expected="$(
+  cat <<-'EOF'
 load(":aaa.bzl", "AAA_LIST")
 load(":zzz.bzl", "ZZZ_LIST")
 
@@ -102,13 +107,13 @@ EOF
 )"
 
 "${buildifier_sh}" --lint_mode fix "${bad_bzl_path}" "${out_path}"
-actual="$(< "${out_path}")"
+actual="$(<"${out_path}")"
 assert_equal "${expected}" "${actual}" "Format and lint fix."
-
 
 # MARK - Test Lint Warn (lint: warn) With Bad File
 
-expected="$(cat <<-'EOF'
+expected="$(
+  cat <<-'EOF'
 load(":aaa.bzl", "AAA_LIST")
 load(":zzz.bzl", "ZZZ_LIST")
 
@@ -122,9 +127,8 @@ EOF
 exit_code=0
 "${buildifier_sh}" --lint_mode warn "${bad_bzl_path}" "${out_path}" || exit_code=$?
 assert_equal 4 ${exit_code} "Expected check mode failure (4)."
-actual="$(< "${out_path}")"
+actual="$(<"${out_path}")"
 assert_equal "${expected}" "${actual}" "Format and lint (warn) with bad file."
-
 
 # MARK - Test Lint Warn (lint: warn) With Good File
 
@@ -140,7 +144,8 @@ FOO_LIST = [
 ] + AAA_LIST + ZZZ_LIST
 EOF
 
-expected="$(cat <<-'EOF'
+expected="$(
+  cat <<-'EOF'
 """Module doc comment."""
 
 load(":aaa.bzl", "AAA_LIST")
@@ -154,11 +159,10 @@ EOF
 )"
 
 "${buildifier_sh}" --lint_mode warn "${good_bzl_path}" "${out_path}"
-actual="$(< "${out_path}")"
+actual="$(<"${out_path}")"
 assert_equal "${expected}" "${actual}" "Format and lint (warn) with good file."
-
 
 # MARK - Test Help
 
-output="$( "${buildifier_sh}" --help )"
+output="$("${buildifier_sh}" --help)"
 assert_match "Executes buildifier for a Starlark file" "${output}" "Confirm help output."

--- a/tests/bzlformat_tests/tools_tests/missing_pkgs_tests/common_tests/normalize_pkg_test.sh
+++ b/tests/bzlformat_tests/tools_tests/missing_pkgs_tests/common_tests/normalize_pkg_test.sh
@@ -2,13 +2,20 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 assertions_lib="$(rlocation cgrindel_bazel_starlib/shlib/lib/assertions.sh)"

--- a/tests/bzlformat_tests/tools_tests/missing_pkgs_tests/missing_pkgs_test.sh
+++ b/tests/bzlformat_tests/tools_tests/missing_pkgs_tests/missing_pkgs_test.sh
@@ -2,39 +2,46 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/assertions.sh
 source "${assertions_sh}"
 
 paths_sh_location=cgrindel_bazel_starlib/shlib/lib/paths.sh
-paths_sh="$(rlocation "${paths_sh_location}")" || \
+paths_sh="$(rlocation "${paths_sh_location}")" ||
   (echo >&2 "Failed to locate ${paths_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/paths.sh
 source "${paths_sh}"
 
 messages_sh_location=cgrindel_bazel_starlib/shlib/lib/messages.sh
-messages_sh="$(rlocation "${messages_sh_location}")" || \
+messages_sh="$(rlocation "${messages_sh_location}")" ||
   (echo >&2 "Failed to locate ${messages_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/messages.sh
 source "${messages_sh}"
 
 buildozer_location=buildifier_prebuilt/buildozer/buildozer
-buildozer="$(rlocation "${buildozer_location}")" || \
+buildozer="$(rlocation "${buildozer_location}")" ||
   (echo >&2 "Failed to locate ${buildozer_location}" && exit 1)
 
 create_scratch_dir_sh_location=rules_bazel_integration_test/tools/create_scratch_dir.sh
-create_scratch_dir_sh="$(rlocation "${create_scratch_dir_sh_location}")" || \
+create_scratch_dir_sh="$(rlocation "${create_scratch_dir_sh_location}")" ||
   (echo >&2 "Failed to locate ${create_scratch_dir_sh_location}" && exit 1)
 
 bazel="${BIT_BAZEL_BINARY:-}"
@@ -43,9 +50,9 @@ workspace_dir="${BIT_WORKSPACE_DIR:-}"
 # Process args
 while (("$#")); do
   case "${1}" in
-    *)
-      shift 1
-      ;;
+  *)
+    shift 1
+    ;;
   esac
 done
 
@@ -66,7 +73,7 @@ while IFS=$'\n' read -r line; do missing_pkgs+=("$line"); done < <(
 assert_msg="Missing packages, no exclusions"
 expected_array=(// //foo //foo/bar)
 assert_equal ${#expected_array[@]} ${#missing_pkgs[@]} "${assert_msg}"
-for (( i = 0; i < ${#expected_array[@]}; i++ )); do
+for ((i = 0; i < ${#expected_array[@]}; i++)); do
   assert_equal "${expected_array[${i}]}" "${missing_pkgs[${i}]}" "${assert_msg}[${i}]"
 done
 
@@ -86,7 +93,7 @@ while IFS=$'\n' read -r line; do missing_pkgs+=("$line"); done < <(
 assert_msg="Missing packages, with exclusions"
 expected_array=(// //foo/bar)
 assert_equal ${#expected_array[@]} ${#missing_pkgs[@]} "${assert_msg}"
-for (( i = 0; i < ${#expected_array[@]}; i++ )); do
+for ((i = 0; i < ${#expected_array[@]}; i++)); do
   assert_equal "${expected_array[${i}]}" "${missing_pkgs[${i}]}" "${assert_msg}[${i}]"
 done
 
@@ -101,7 +108,7 @@ assert_msg="Update missing packages, with exclusions"
 # will parse each space-separated item.
 expected_array=("Updating the following packages:" // //foo/bar)
 assert_equal ${#expected_array[@]} ${#fix_pkgs[@]} "${assert_msg}"
-for (( i = 0; i < ${#expected_array[@]}; i++ )); do
+for ((i = 0; i < ${#expected_array[@]}; i++)); do
   assert_equal "${expected_array[${i}]}" "${fix_pkgs[${i}]}" "${assert_msg}[${i}]"
 done
 
@@ -117,7 +124,7 @@ while IFS=$'\n' read -r line; do missing_pkgs+=("$line"); done < <(
 assert_msg="Missing packages after removing exclusions"
 expected_array=(//foo)
 assert_equal ${#expected_array[@]} ${#missing_pkgs[@]} "${assert_msg}"
-for (( i = 0; i < ${#expected_array[@]}; i++ )); do
+for ((i = 0; i < ${#expected_array[@]}; i++)); do
   assert_equal "${expected_array[${i}]}" "${missing_pkgs[${i}]}" "${assert_msg}[${i}]"
 done
 
@@ -130,7 +137,7 @@ assert_msg="Update missing packages after removing exclusions"
 # will parse each space-separated item.
 expected_array=("Updating the following packages:" //foo)
 assert_equal ${#expected_array[@]} ${#fix_pkgs[@]} "${assert_msg}"
-for (( i = 0; i < ${#expected_array[@]}; i++ )); do
+for ((i = 0; i < ${#expected_array[@]}; i++)); do
   assert_equal "${expected_array[${i}]}" "${fix_pkgs[${i}]}" "${assert_msg}[${i}]"
 done
 
@@ -143,7 +150,7 @@ while IFS=$'\n' read -r line; do missing_pkgs+=("$line"); done < <(
 assert_msg="Expect no missing packages"
 expected_array=()
 assert_equal ${#expected_array[@]} ${#missing_pkgs[@]} "${assert_msg}"
-for (( i = 0; i < ${#expected_array[@]}; i++ )); do
+for ((i = 0; i < ${#expected_array[@]}; i++)); do
   assert_equal "${expected_array[${i}]}" "${missing_pkgs[${i}]}" "${assert_msg}[${i}]"
 done
 
@@ -156,6 +163,6 @@ assert_msg="Update with no missing packages"
 # will parse each space-separated item.
 expected_array=("No missing package updates were found.")
 assert_equal ${#expected_array[@]} ${#fix_pkgs[@]} "${assert_msg}"
-for (( i = 0; i < ${#expected_array[@]}; i++ )); do
+for ((i = 0; i < ${#expected_array[@]}; i++)); do
   assert_equal "${expected_array[${i}]}" "${fix_pkgs[${i}]}" "${assert_msg}[${i}]"
 done

--- a/tests/bzlrelease_tests/rules_tests/generate_release_notes_tests/generate_release_notes_test.sh
+++ b/tests/bzlrelease_tests/rules_tests/generate_release_notes_tests/generate_release_notes_test.sh
@@ -2,31 +2,38 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/assertions.sh
 source "${assertions_sh}"
 
 setup_git_repo_sh_location=cgrindel_bazel_starlib/tests/setup_git_repo.sh
-setup_git_repo_sh="$(rlocation "${setup_git_repo_sh_location}")" || \
+setup_git_repo_sh="$(rlocation "${setup_git_repo_sh_location}")" ||
   (echo >&2 "Failed to locate ${setup_git_repo_sh_location}" && exit 1)
 
 generate_release_notes_with_template_sh_location=cgrindel_bazel_starlib/tests/bzlrelease_tests/rules_tests/generate_release_notes_tests/generate_release_notes_with_template.sh
-generate_release_notes_with_template_sh="$(rlocation "${generate_release_notes_with_template_sh_location}")" || \
+generate_release_notes_with_template_sh="$(rlocation "${generate_release_notes_with_template_sh_location}")" ||
   (echo >&2 "Failed to locate ${generate_release_notes_with_template_sh_location}" && exit 1)
 
 generate_release_notes_with_workspace_name_sh_location=cgrindel_bazel_starlib/tests/bzlrelease_tests/rules_tests/generate_release_notes_tests/generate_release_notes_with_workspace_name.sh
-generate_release_notes_with_workspace_name_sh="$(rlocation "${generate_release_notes_with_workspace_name_sh_location}")" || \
+generate_release_notes_with_workspace_name_sh="$(rlocation "${generate_release_notes_with_workspace_name_sh_location}")" ||
   (echo >&2 "Failed to locate ${generate_release_notes_with_workspace_name_sh_location}" && exit 1)
 
 # MARK - Setup
@@ -34,19 +41,18 @@ generate_release_notes_with_workspace_name_sh="$(rlocation "${generate_release_n
 # shellcheck source=SCRIPTDIR/../../../setup_git_repo.sh
 source "${setup_git_repo_sh}"
 
-
 # MARK - Test
 
 tag="v999.0.0"
 
 # Test with template
-actual="$( "${generate_release_notes_with_template_sh}" "${tag}" )"
+actual="$("${generate_release_notes_with_template_sh}" "${tag}")"
 assert_match "name = \"cgrindel_bazel_starlib\"" "${actual}" "Did not find workspace name."
 assert_match "## What Has Changed" "${actual}" "Did not find release notes header."
 assert_match "bazel_starlib_dependencies()" "${actual}" "Did not find template content."
 
 # Test with workspace_name
-actual="$( "${generate_release_notes_with_workspace_name_sh}" "${tag}" )"
+actual="$("${generate_release_notes_with_workspace_name_sh}" "${tag}")"
 assert_match "name = \"foo_bar\"" "${actual}" "Did not find workspace name."
 assert_match "## What Has Changed" "${actual}" "Did not find release notes header."
 assert_match "bazel_starlib_dependencies()" "${actual}" "Did not find template content."

--- a/tests/bzlrelease_tests/rules_tests/generate_workspace_snippet_tests/generate_workspace_snippet_test.sh
+++ b/tests/bzlrelease_tests/rules_tests/generate_workspace_snippet_tests/generate_workspace_snippet_test.sh
@@ -2,39 +2,46 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/assertions.sh
 source "${assertions_sh}"
 
 setup_git_repo_sh_location=cgrindel_bazel_starlib/tests/setup_git_repo.sh
-setup_git_repo_sh="$(rlocation "${setup_git_repo_sh_location}")" || \
+setup_git_repo_sh="$(rlocation "${setup_git_repo_sh_location}")" ||
   (echo >&2 "Failed to locate ${setup_git_repo_sh_location}" && exit 1)
 
 without_template_sh_location=cgrindel_bazel_starlib/tests/bzlrelease_tests/rules_tests/generate_workspace_snippet_tests/without_template.sh
-without_template_sh="$(rlocation "${without_template_sh_location}")" || \
+without_template_sh="$(rlocation "${without_template_sh_location}")" ||
   (echo >&2 "Failed to locate ${without_template_sh_location}" && exit 1)
 
 with_template_sh_location=cgrindel_bazel_starlib/tests/bzlrelease_tests/rules_tests/generate_workspace_snippet_tests/with_template.sh
-with_template_sh="$(rlocation "${with_template_sh_location}")" || \
+with_template_sh="$(rlocation "${with_template_sh_location}")" ||
   (echo >&2 "Failed to locate ${with_template_sh_location}" && exit 1)
 
 with_sha256_file_and_url_template_sh_location=cgrindel_bazel_starlib/tests/bzlrelease_tests/rules_tests/generate_workspace_snippet_tests/with_sha256_file_and_url_template.sh
-with_sha256_file_and_url_template_sh="$(rlocation "${with_sha256_file_and_url_template_sh_location}")" || \
+with_sha256_file_and_url_template_sh="$(rlocation "${with_sha256_file_and_url_template_sh_location}")" ||
   (echo >&2 "Failed to locate ${with_sha256_file_and_url_template_sh_location}" && exit 1)
 
 archive_sha256_location=cgrindel_bazel_starlib/tests/bzlrelease_tests/rules_tests/generate_workspace_snippet_tests/archive_sha256
-archive_sha256="$(rlocation "${archive_sha256_location}")" || \
+archive_sha256="$(rlocation "${archive_sha256_location}")" ||
   (echo >&2 "Failed to locate ${archive_sha256_location}" && exit 1)
 
 # MARK - Setup
@@ -46,17 +53,17 @@ source "${setup_git_repo_sh}"
 
 tag="v999.0.0"
 
-actual="$( "${without_template_sh}" --tag "${tag}" )"
+actual="$("${without_template_sh}" --tag "${tag}")"
 assert_match 'http_archive\(' "${actual}" "Without Template http_archive"
 assert_match 'name = "cgrindel_bazel_starlib"' "${actual}" "Without Template name attribute"
 assert_no_match bazel_starlib_dependencies "${actual}" "Without Template bazel_starlib_dependencies"
 
-actual="$( "${with_template_sh}" --tag "${tag}" )"
+actual="$("${with_template_sh}" --tag "${tag}")"
 assert_match 'http_archive\(' "${actual}" "With Template http_archive"
 assert_match 'name = "cgrindel_bazel_starlib"' "${actual}" "With Template name attribute"
 assert_match bazel_starlib_dependencies "${actual}" "With Template bazel_starlib_dependencies"
 
-actual="$( "${with_sha256_file_and_url_template_sh}" --tag "${tag}" )"
+actual="$("${with_sha256_file_and_url_template_sh}" --tag "${tag}")"
 assert_match \
   'https://github.com/cgrindel/bazel-starlib/releases/download/v999.0.0/bazel-starlib.v999.0.0.tar.gz' \
   "${actual}" \
@@ -65,12 +72,12 @@ assert_match \
   'https://mirror.foo.org/cgrindel/bazel-starlib/bazel-starlib.v999.0.0.tar.gz' \
   "${actual}" \
   "With SHA256 File and URL Template correct custom URL"
-assert_no_match 'strip_prefix' "${actual}"  "With SHA256 File and URL Template no strip_prefix"
+assert_no_match 'strip_prefix' "${actual}" "With SHA256 File and URL Template no strip_prefix"
 assert_match \
   'name = "cgrindel_bazel_starlib"' \
   "${actual}" \
   "With SHA256 File and URL Template name attribute"
-expected_sha256="$(< "${archive_sha256}")"
+expected_sha256="$(<"${archive_sha256}")"
 assert_match \
   'sha256 = "'"${expected_sha256}"'"' \
   "${actual}" \

--- a/tests/bzlrelease_tests/rules_tests/hash_sha256_tests/hash_sha256_test.sh
+++ b/tests/bzlrelease_tests/rules_tests/hash_sha256_tests/hash_sha256_test.sh
@@ -2,24 +2,31 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 fail() {
   local msg="${1}"
-  echo >&2 "${msg}" 
+  echo >&2 "${msg}"
   exit 1
 }
 
 hash_file="${1}"
 expected_hash="${2}"
 
-actual_hash="$(< "${hash_file}")"
-[[ "${actual_hash}" == "${expected_hash}" ]] || \
+actual_hash="$(<"${hash_file}")"
+[[ "${actual_hash}" == "${expected_hash}" ]] ||
   fail "Expected actual hash to equal expected. actual: ${actual_hash}, expected: ${expected_hash}"

--- a/tests/bzlrelease_tests/rules_tests/release_artifact_tests/archive_test.sh
+++ b/tests/bzlrelease_tests/rules_tests/release_artifact_tests/archive_test.sh
@@ -2,34 +2,41 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Locate Deps
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/assertions.sh
 source "${assertions_sh}"
 
 archive_tar_gz_location=cgrindel_bazel_starlib/tests/bzlrelease_tests/rules_tests/release_artifact_tests/archive.tar.gz
-archive_tar_gz="$(rlocation "${archive_tar_gz_location}")" || \
+archive_tar_gz="$(rlocation "${archive_tar_gz_location}")" ||
   (echo >&2 "Failed to locate ${archive_tar_gz_location}" && exit 1)
 
 tar_exe_location=cgrindel_bazel_starlib/tools/tar/tar.exe
-tar="$(rlocation "${tar_exe_location}")" || \
+tar="$(rlocation "${tar_exe_location}")" ||
   (echo >&2 "Failed to locate ${tar_exe_location}" && exit 1)
 
 # MARK - Test
 
-contents="$( "${tar}" -tf "${archive_tar_gz}" )"
-assert_match "bzlrelease/" "${contents}" 
-assert_match "bzlrelease/private/" "${contents}" 
-assert_match "bzlrelease/tools/" "${contents}" 
+contents="$("${tar}" -tf "${archive_tar_gz}")"
+assert_match "bzlrelease/" "${contents}"
+assert_match "bzlrelease/private/" "${contents}"
+assert_match "bzlrelease/tools/" "${contents}"

--- a/tests/bzlrelease_tests/rules_tests/update_readme_tests/update_readme_test.sh
+++ b/tests/bzlrelease_tests/rules_tests/update_readme_tests/update_readme_test.sh
@@ -2,38 +2,45 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Locate Deps
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/assertions.sh
 source "${assertions_sh}"
 
 setup_git_repo_sh_location=cgrindel_bazel_starlib/tests/setup_git_repo.sh
-setup_git_repo_sh="$(rlocation "${setup_git_repo_sh_location}")" || \
+setup_git_repo_sh="$(rlocation "${setup_git_repo_sh_location}")" ||
   (echo >&2 "Failed to locate ${setup_git_repo_sh_location}" && exit 1)
 
 update_readme_sh_location=cgrindel_bazel_starlib/tests/bzlrelease_tests/rules_tests/update_readme_tests/update_readme.sh
-update_readme_sh="$(rlocation "${update_readme_sh_location}")" || \
+update_readme_sh="$(rlocation "${update_readme_sh_location}")" ||
   (echo >&2 "Failed to locate ${update_readme_sh_location}" && exit 1)
-
 
 # MARK - Setup
 
 # shellcheck source=SCRIPTDIR/../../../setup_git_repo.sh
 source "${setup_git_repo_sh}"
 
-readme_content="$(cat <<-EOF
+readme_content="$(
+  cat <<-EOF
 Text before workspace snippet
 <!-- BEGIN WORKSPACE SNIPPET -->
 Text should be replaced
@@ -49,30 +56,28 @@ EOF
 
 tag_name="v99999.0.0"
 
-
 # MARK - Test Specify README path
 
 readme_path="${BUILD_WORKSPACE_DIRECTORY}/foo/README.md"
 mkdir -p "$(dirname "${readme_path}")"
-echo "${readme_content}" > "${readme_path}"
+echo "${readme_content}" >"${readme_path}"
 
 "${update_readme_sh}" --readme "${readme_path}" "${tag_name}"
 
-actual="$(< "${readme_path}")"
+actual="$(<"${readme_path}")"
 assert_no_match "Text should be replaced" "${actual}"
 assert_match "http_archive" "${actual}"
 assert_match "${tag_name}" "${actual}"
 assert_match "bazel_dep" "${actual}"
 
-
 # MARK - Test Find README.md
 
 readme_path="${BUILD_WORKSPACE_DIRECTORY}/README.md"
-echo "${readme_content}" > "${readme_path}"
+echo "${readme_content}" >"${readme_path}"
 
 "${update_readme_sh}" "${tag_name}"
 
-actual="$(< "${readme_path}")"
+actual="$(<"${readme_path}")"
 assert_no_match "Text should be replaced" "${actual}"
 assert_match "http_archive" "${actual}"
 assert_match "${tag_name}" "${actual}"

--- a/tests/bzlrelease_tests/tools_tests/generate_gh_changelog_test.sh
+++ b/tests/bzlrelease_tests/tools_tests/generate_gh_changelog_test.sh
@@ -2,35 +2,42 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Dependencies
 
 fail_sh_location=cgrindel_bazel_starlib/shlib/lib/fail.sh
-fail_sh="$(rlocation "${fail_sh_location}")" || \
+fail_sh="$(rlocation "${fail_sh_location}")" ||
   (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../shlib/lib/fail.sh
 source "${fail_sh}"
 
 env_sh_location=cgrindel_bazel_starlib/shlib/lib/env.sh
-env_sh="$(rlocation "${env_sh_location}")" || \
+env_sh="$(rlocation "${env_sh_location}")" ||
   (echo >&2 "Failed to locate ${env_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../shlib/lib/env.sh
 source "${env_sh}"
 
 generate_gh_changelog_sh_location=cgrindel_bazel_starlib/bzlrelease/tools/generate_gh_changelog.sh
-generate_gh_changelog_sh="$(rlocation "${generate_gh_changelog_sh_location}")" || \
+generate_gh_changelog_sh="$(rlocation "${generate_gh_changelog_sh_location}")" ||
   (echo >&2 "Failed to locate ${generate_gh_changelog_sh_location}" && exit 1)
 
 setup_git_repo_sh_location=cgrindel_bazel_starlib/tests/setup_git_repo.sh
-setup_git_repo_sh="$(rlocation "${setup_git_repo_sh_location}")" || \
+setup_git_repo_sh="$(rlocation "${setup_git_repo_sh_location}")" ||
   (echo >&2 "Failed to locate ${setup_git_repo_sh_location}" && exit 1)
 
 # MARK - Setup
@@ -39,20 +46,18 @@ setup_git_repo_sh="$(rlocation "${setup_git_repo_sh_location}")" || \
 source "${setup_git_repo_sh}"
 cd "${repo_dir}"
 
-
-# MARK - Test changelog between two known tags 
+# MARK - Test changelog between two known tags
 
 tag_name="v0.1.1"
 prev_tag_name="v0.1.0"
-result="$( "${generate_gh_changelog_sh}" --previous_tag_name "${prev_tag_name}" "${tag_name}" )"
+result="$("${generate_gh_changelog_sh}" --previous_tag_name "${prev_tag_name}" "${tag_name}")"
 # [[ "${result}" =~ "**Full Changelog**: https://github.com/cgrindel/bazel-starlib/compare/v0.1.0...v0.1.1" ]] || \
-[[ "${result}" =~ \*\*Full\ Changelog\*\*:\ https://github.com/cgrindel/bazel-starlib/compare/v0\.1\.0\.\.\.v0\.1\.1 ]] || \
+[[ "${result}" =~ \*\*Full\ Changelog\*\*:\ https://github.com/cgrindel/bazel-starlib/compare/v0\.1\.0\.\.\.v0\.1\.1 ]] ||
   fail "Expected to find changelog URL for v0.1.0...v0.1.1. result: ${result}"
-
 
 # MARK - Test changelog to a new tag
 
 tag_name="v99999.0.0"
-result="$( "${generate_gh_changelog_sh}" "${tag_name}" )"
+result="$("${generate_gh_changelog_sh}" "${tag_name}")"
 match='[*][*]Full Changelog[*][*].*v9999'
 [[ "${result}" =~ $match ]] || fail "Expected to find changelog URL for ${tag_name}. result: ${result}"

--- a/tests/bzlrelease_tests/tools_tests/generate_git_archive_test.sh
+++ b/tests/bzlrelease_tests/tools_tests/generate_git_archive_test.sh
@@ -2,39 +2,46 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Dependencies
 
 fail_sh_location=cgrindel_bazel_starlib/shlib/lib/fail.sh
-fail_sh="$(rlocation "${fail_sh_location}")" || \
+fail_sh="$(rlocation "${fail_sh_location}")" ||
   (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../shlib/lib/fail.sh
 source "${fail_sh}"
 
 env_sh_location=cgrindel_bazel_starlib/shlib/lib/env.sh
-env_sh="$(rlocation "${env_sh_location}")" || \
+env_sh="$(rlocation "${env_sh_location}")" ||
   (echo >&2 "Failed to locate ${env_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../shlib/lib/env.sh
 source "${env_sh}"
 
 setup_git_repo_sh_location=cgrindel_bazel_starlib/tests/setup_git_repo.sh
-setup_git_repo_sh="$(rlocation "${setup_git_repo_sh_location}")" || \
+setup_git_repo_sh="$(rlocation "${setup_git_repo_sh_location}")" ||
   (echo >&2 "Failed to locate ${setup_git_repo_sh_location}" && exit 1)
 
 generate_git_archive_sh_location=cgrindel_bazel_starlib/bzlrelease/tools/generate_git_archive.sh
-generate_git_archive_sh="$(rlocation "${generate_git_archive_sh_location}")" || \
+generate_git_archive_sh="$(rlocation "${generate_git_archive_sh_location}")" ||
   (echo >&2 "Failed to locate ${generate_git_archive_sh_location}" && exit 1)
 
 generate_sha256_sh_location=cgrindel_bazel_starlib/bzlrelease/tools/generate_sha256.sh
-generate_sha256_sh="$(rlocation "${generate_sha256_sh_location}")" || \
+generate_sha256_sh="$(rlocation "${generate_sha256_sh_location}")" ||
   (echo >&2 "Failed to locate ${generate_sha256_sh_location}" && exit 1)
 
 # MARK - Setup
@@ -42,7 +49,6 @@ generate_sha256_sh="$(rlocation "${generate_sha256_sh_location}")" || \
 # shellcheck source=SCRIPTDIR/../../setup_git_repo.sh
 source "${setup_git_repo_sh}"
 cd "${repo_dir}"
-
 
 # MARK - Test
 
@@ -55,41 +61,41 @@ tag="v0.1.1"
 # Download the Github archive
 github_targz_path="github.tar.gz"
 curl -s -L "https://github.com/cgrindel/bazel-starlib/archive/${tag}.tar.gz" -o "${github_targz_path}"
-expected="$( gunzip < "${github_targz_path}" | "${generate_sha256_sh}" )"
+expected="$(gunzip <"${github_targz_path}" | "${generate_sha256_sh}")"
 
 # Uncompressed, output to stdout
-actual="$( 
-  "${generate_git_archive_sh}" --tag_name "${tag}"  --nocompress | "${generate_sha256_sh}"
+actual="$(
+  "${generate_git_archive_sh}" --tag_name "${tag}" --nocompress | "${generate_sha256_sh}"
 )"
-[[ "${actual}" == "${expected}" ]] || \
-   fail "SHA256 for uncompressed archive did not match. actual: ${actual}, expected: ${expected}"
+[[ "${actual}" == "${expected}" ]] ||
+  fail "SHA256 for uncompressed archive did not match. actual: ${actual}, expected: ${expected}"
 
 # Compressed, output to stdout
-actual="$( 
+actual="$(
   "${generate_git_archive_sh}" --tag_name "${tag}" | gunzip | "${generate_sha256_sh}"
 )"
-[[ "${actual}" == "${expected}" ]] || \
-   fail "SHA256 for compressed archive did not match. actual: ${actual}, expected: ${expected}"
+[[ "${actual}" == "${expected}" ]] ||
+  fail "SHA256 for compressed archive did not match. actual: ${actual}, expected: ${expected}"
 
 # Uncompressed, output to file
 output_path="output.tar"
 "${generate_git_archive_sh}" --tag_name "v0.1.1" --output "${output_path}" --nocompress
 [[ -f "${output_path}" ]] || fail "Expected uncompressed file to exist. ${output_path}"
-actual="$( "${generate_sha256_sh}" --source "${output_path}" )"
-[[ "${actual}" == "${expected}" ]] || \
+actual="$("${generate_sha256_sh}" --source "${output_path}")"
+[[ "${actual}" == "${expected}" ]] ||
   fail "SHA256 for uncompressed archive file did not match. actual: ${actual}, expected: ${expected}"
 
 # Compressed, output to file
 output_path="output.tar.gz"
 "${generate_git_archive_sh}" --tag_name "v0.1.1" --output "${output_path}"
 [[ -f "${output_path}" ]] || fail "Expected uncompressed file to exist. ${output_path}"
-actual="$( gunzip < "${output_path}" | "${generate_sha256_sh}" )"
-[[ "${actual}" == "${expected}" ]] || \
+actual="$(gunzip <"${output_path}" | "${generate_sha256_sh}")"
+[[ "${actual}" == "${expected}" ]] ||
   fail "SHA256 for compressed archive file did not match. actual: ${actual}, expected: ${expected}"
 
 # Non-existent tag
 output_path="non-existent.tar.gz"
 "${generate_git_archive_sh}" --tag_name "v9999.0.0" --output "${output_path}"
 [[ -f "${output_path}" ]] || fail "Expected file to exist when tag does not exist. ${output_path}"
-[[ -s "${output_path}" ]] || \
+[[ -s "${output_path}" ]] ||
   fail "Expected file to not be empty for when tag does not exist. ${output_path}"

--- a/tests/bzlrelease_tests/tools_tests/generate_module_snippet_test.sh
+++ b/tests/bzlrelease_tests/tools_tests/generate_module_snippet_test.sh
@@ -2,32 +2,39 @@
 
 # --- begin runfiles.bash initialization v2 ---
 # Copy-pasted from the Bazel Bash runfiles library v2.
-set -o nounset -o pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+set -o nounset -o pipefail
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
 # shellcheck disable=SC1090
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -o errexit
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -o errexit
 # --- end runfiles.bash initialization v2 ---
 
 # MARK - Locate Deps
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../shlib/lib/assertions.sh
 source "${assertions_sh}"
 
 generate_module_snippet_sh_location=cgrindel_bazel_starlib/bzlrelease/tools/generate_module_snippet.sh
-generate_module_snippet_sh="$(rlocation "${generate_module_snippet_sh_location}")" || \
+generate_module_snippet_sh="$(rlocation "${generate_module_snippet_sh_location}")" ||
   (echo >&2 "Failed to locate ${generate_module_snippet_sh_location}" && exit 1)
 
 # MARK - Test
 
-output="$( "${generate_module_snippet_sh}" --module_name "rules_chicken" --version "1.2.3" )"
-expected="$(cat <<-EOF
+output="$("${generate_module_snippet_sh}" --module_name "rules_chicken" --version "1.2.3")"
+expected="$(
+  cat <<-EOF
 \`\`\`python
 bazel_dep(name = "rules_chicken", version = "1.2.3")
 \`\`\`
@@ -35,8 +42,9 @@ EOF
 )"
 assert_equal "${expected}" "${output}" "module with version"
 
-output="$( "${generate_module_snippet_sh}" --module_name "rules_chicken" --version "v1.2.3" )"
-expected="$(cat <<-EOF
+output="$("${generate_module_snippet_sh}" --module_name "rules_chicken" --version "v1.2.3")"
+expected="$(
+  cat <<-EOF
 \`\`\`python
 bazel_dep(name = "rules_chicken", version = "1.2.3")
 \`\`\`
@@ -44,8 +52,9 @@ EOF
 )"
 assert_equal "${expected}" "${output}" "module with tag"
 
-output="$( "${generate_module_snippet_sh}" --module_name "rules_chicken" --version "v1.2.3" --dev_dependency )"
-expected="$(cat <<-EOF
+output="$("${generate_module_snippet_sh}" --module_name "rules_chicken" --version "v1.2.3" --dev_dependency)"
+expected="$(
+  cat <<-EOF
 \`\`\`python
 bazel_dep(
     name = "rules_chicken",

--- a/tests/bzlrelease_tests/tools_tests/generate_release_notes_test.sh
+++ b/tests/bzlrelease_tests/tools_tests/generate_release_notes_test.sh
@@ -2,35 +2,42 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Dependencies
 
 env_sh_location=cgrindel_bazel_starlib/shlib/lib/env.sh
-env_sh="$(rlocation "${env_sh_location}")" || \
+env_sh="$(rlocation "${env_sh_location}")" ||
   (echo >&2 "Failed to locate ${env_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../shlib/lib/env.sh
 source "${env_sh}"
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../shlib/lib/assertions.sh
 source "${assertions_sh}"
 
 setup_git_repo_sh_location=cgrindel_bazel_starlib/tests/setup_git_repo.sh
-setup_git_repo_sh="$(rlocation "${setup_git_repo_sh_location}")" || \
+setup_git_repo_sh="$(rlocation "${setup_git_repo_sh_location}")" ||
   (echo >&2 "Failed to locate ${setup_git_repo_sh_location}" && exit 1)
 
 generate_release_notes_sh_location=cgrindel_bazel_starlib/bzlrelease/tools/generate_release_notes.sh
-generate_release_notes_sh="$(rlocation "${generate_release_notes_sh_location}")" || \
+generate_release_notes_sh="$(rlocation "${generate_release_notes_sh_location}")" ||
   (echo >&2 "Failed to locate ${generate_release_notes_sh_location}" && exit 1)
 
 # MARK - Setup
@@ -81,7 +88,6 @@ echo "WORKSPACE SNIPPET CONTENT"
 EOF
 chmod +x "${generate_workspace_snippet_sh}"
 
-
 # shellcheck source=SCRIPTDIR/../../setup_git_repo.sh
 source "${setup_git_repo_sh}"
 cd "${repo_dir}"
@@ -92,20 +98,20 @@ cd "${repo_dir}"
 
 tag="v0.1.1"
 
-actual="$( 
+actual="$(
   "${generate_release_notes_sh}" \
     --generate_workspace_snippet "${generate_workspace_snippet_sh}" \
-    "${tag}" 
+    "${tag}"
 )"
 assert_match "## What Has Changed" "${actual}"
 assert_match "## Workspace Snippet" "${actual}"
 assert_match "WORKSPACE SNIPPET CONTENT" "${actual}"
 assert_no_match "## Bazel Module Snippet" "${actual}"
 
-actual="$( 
+actual="$(
   "${generate_release_notes_sh}" \
     --generate_module_snippet "${generate_module_snippet_sh}" \
-    "${tag}" 
+    "${tag}"
 )"
 assert_match "## What Has Changed" "${actual}"
 assert_match "## Bazel Module Snippet" "${actual}"

--- a/tests/bzlrelease_tests/tools_tests/generate_sha256_test.sh
+++ b/tests/bzlrelease_tests/tools_tests/generate_sha256_test.sh
@@ -2,60 +2,67 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Locate Dependencies
 
 fail_sh_location=cgrindel_bazel_starlib/shlib/lib/fail.sh
-fail_sh="$(rlocation "${fail_sh_location}")" || \
+fail_sh="$(rlocation "${fail_sh_location}")" ||
   (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../shlib/lib/fail.sh
 source "${fail_sh}"
 
 generate_sha256_sh_location=cgrindel_bazel_starlib/bzlrelease/tools/generate_sha256.sh
-generate_sha256_sh="$(rlocation "${generate_sha256_sh_location}")" || \
+generate_sha256_sh="$(rlocation "${generate_sha256_sh_location}")" ||
   (echo >&2 "Failed to locate ${generate_sha256_sh_location}" && exit 1)
 
 # MARK - Utilities Check
 
 utilities=(openssl shasum)
 utilities_to_test=()
-for utility in "${utilities[@]}" ; do
-  which "${utility}" > /dev/null && utilities_to_test+=( "${utility}" )
+for utility in "${utilities[@]}"; do
+  which "${utility}" >/dev/null && utilities_to_test+=("${utility}")
 done
 
-[[ ${#utilities_to_test[@]} == 0 ]] && \
+[[ ${#utilities_to_test[@]} == 0 ]] &&
   fail "This platform does not support any of the SHA256 utilities."
 
 # MARK - Setup
 
 source_path="source"
-echo "This file will be hashed." > "${source_path}"
+echo "This file will be hashed." >"${source_path}"
 expected_hash="d85406eb129904c21b9b7c286a0efb775cf6681815035bd82f8ad19285deb250"
 
 # MARK - Tests
 
 err_msg_prefix="Flags test"
 output_path=output_flags
-"${generate_sha256_sh}" --source "${source_path}" --output "${output_path}" || \
+"${generate_sha256_sh}" --source "${source_path}" --output "${output_path}" ||
   fail "${err_msg_prefix} - Execution failed."
-actual_hash="$(< "${output_path}")"
-[[ "${actual_hash}" == "${expected_hash}" ]] || \
+actual_hash="$(<"${output_path}")"
+[[ "${actual_hash}" == "${expected_hash}" ]] ||
   fail "${err_msg_prefix} - Expected actual hash to equal expected. actual: ${actual_hash}, expected: ${expected_hash}"
 
-for utility in "${utilities_to_test[@]}" ; do
+for utility in "${utilities_to_test[@]}"; do
   err_msg_prefix="Utility test for ${utility}"
   output_path="output_${utility}"
-  "${generate_sha256_sh}" --source "${source_path}" --output "${output_path}" --utility "${utility}" || \
+  "${generate_sha256_sh}" --source "${source_path}" --output "${output_path}" --utility "${utility}" ||
     fail "${err_msg_prefix} - Execution failed."
-  actual_hash="$(< "${output_path}")"
-  [[ "${actual_hash}" == "${expected_hash}" ]] || \
+  actual_hash="$(<"${output_path}")"
+  [[ "${actual_hash}" == "${expected_hash}" ]] ||
     fail "${err_msg_prefix} - Expected actual hash to equal expected. actual: ${actual_hash}, expected: ${expected_hash}"
 done

--- a/tests/bzlrelease_tests/tools_tests/generate_workspace_snippet_test.sh
+++ b/tests/bzlrelease_tests/tools_tests/generate_workspace_snippet_test.sh
@@ -2,33 +2,40 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Locate Resources
 
 fail_sh_location=cgrindel_bazel_starlib/shlib/lib/fail.sh
-fail_sh="$(rlocation "${fail_sh_location}")" || \
+fail_sh="$(rlocation "${fail_sh_location}")" ||
   (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../shlib/lib/fail.sh
 source "${fail_sh}"
 
 setup_git_repo_sh_location=cgrindel_bazel_starlib/tests/setup_git_repo.sh
-setup_git_repo_sh="$(rlocation "${setup_git_repo_sh_location}")" || \
+setup_git_repo_sh="$(rlocation "${setup_git_repo_sh_location}")" ||
   (echo >&2 "Failed to locate ${setup_git_repo_sh_location}" && exit 1)
 
 generate_workspace_snippet_sh_location=cgrindel_bazel_starlib/bzlrelease/tools/generate_workspace_snippet.sh
-generate_workspace_snippet_sh="$(rlocation "${generate_workspace_snippet_sh_location}")" || \
+generate_workspace_snippet_sh="$(rlocation "${generate_workspace_snippet_sh_location}")" ||
   (echo >&2 "Failed to locate ${generate_workspace_snippet_sh_location}" && exit 1)
 
 workspace_snippet_tmpl_location=cgrindel_bazel_starlib/tests/bzlrelease_tests/tools_tests/workspace_snippet.tmpl
-workspace_snippet_tmpl="$(rlocation "${workspace_snippet_tmpl_location}")" || \
+workspace_snippet_tmpl="$(rlocation "${workspace_snippet_tmpl_location}")" ||
   (echo >&2 "Failed to locate ${workspace_snippet_tmpl_location}" && exit 1)
 
 # MARK - Setup
@@ -44,12 +51,13 @@ strip_prefix="bazel-starlib-1.2.3"
 # MARK - Test Extracting Info from Git Repository
 
 actual_snippet="$(
-"${generate_workspace_snippet_sh}" \
-  --sha256 "${sha256}" \
-  --tag "${tag}"
+  "${generate_workspace_snippet_sh}" \
+    --sha256 "${sha256}" \
+    --tag "${tag}"
 )"
 
-expected_snippet=$(cat <<-EOF
+expected_snippet=$(
+  cat <<-EOF
 \`\`\`python
 http_archive(
     name = "cgrindel_bazel_starlib",
@@ -62,19 +70,20 @@ http_archive(
 \`\`\`
 EOF
 )
-[[ "${actual_snippet}" == "${expected_snippet}" ]] || \
+[[ "${actual_snippet}" == "${expected_snippet}" ]] ||
   fail $'Snippet with defaults did not match expected.  actual:\n'"${actual_snippet}"$'\nexpected:\n'"${expected_snippet}"
 
 # MARK - Test with custom workspace_name
 
 actual_snippet="$(
-"${generate_workspace_snippet_sh}" \
-  --workspace_name "foo_bar" \
-  --sha256 "${sha256}" \
-  --tag "${tag}"
+  "${generate_workspace_snippet_sh}" \
+    --workspace_name "foo_bar" \
+    --sha256 "${sha256}" \
+    --tag "${tag}"
 )"
 
-expected_snippet=$(cat <<-EOF
+expected_snippet=$(
+  cat <<-EOF
 \`\`\`python
 http_archive(
     name = "foo_bar",
@@ -87,14 +96,15 @@ http_archive(
 \`\`\`
 EOF
 )
-[[ "${actual_snippet}" == "${expected_snippet}" ]] || \
+[[ "${actual_snippet}" == "${expected_snippet}" ]] ||
   fail $'Snippet with custom workspace_name did not match expected.  actual:\n'"${actual_snippet}"$'\nexpected:\n'"${expected_snippet}"
 
 # MARK - Test write to file
 
 output_path="snippet.bzl"
 
-expected_snippet=$(cat <<-EOF
+expected_snippet=$(
+  cat <<-EOF
 \`\`\`python
 http_archive(
     name = "cgrindel_bazel_starlib",
@@ -112,10 +122,9 @@ EOF
   --sha256 "${sha256}" \
   --tag "${tag}" \
   --output "${output_path}"
-actual_snippet="$(< "${output_path}")"
-[[ "${actual_snippet}" == "${expected_snippet}" ]] || \
+actual_snippet="$(<"${output_path}")"
+[[ "${actual_snippet}" == "${expected_snippet}" ]] ||
   fail $'Snippet written to file did not match expected.  actual:\n'"${actual_snippet}"$'\nexpected:\n'"${expected_snippet}"
-
 
 # MARK - Test Without Template
 
@@ -128,17 +137,18 @@ url2='http://mirror.bazel.build/github.com/${owner}/${repo}/releases/download/${
 strip_prefix="rules_fun-1.2.3"
 
 actual_snippet="$(
-"${generate_workspace_snippet_sh}" \
-  --sha256 "${sha256}" \
-  --tag "${tag}" \
-  --no_github_source_archive_url \
-  --url "${url1}" \
-  --url "${url2}" \
-  --owner "${owner}" \
-  --repo "${repo}"
+  "${generate_workspace_snippet_sh}" \
+    --sha256 "${sha256}" \
+    --tag "${tag}" \
+    --no_github_source_archive_url \
+    --url "${url1}" \
+    --url "${url2}" \
+    --owner "${owner}" \
+    --repo "${repo}"
 )"
 
-expected_snippet=$(cat <<-EOF
+expected_snippet=$(
+  cat <<-EOF
 \`\`\`python
 http_archive(
     name = "${owner}_${repo}",
@@ -152,40 +162,37 @@ http_archive(
 \`\`\`
 EOF
 )
-[[ "${actual_snippet}" == "${expected_snippet}" ]] || \
+[[ "${actual_snippet}" == "${expected_snippet}" ]] ||
   fail $'Snippet with specified parameters did not match expected.  actual:\n'"${actual_snippet}"$'\nexpected:\n'"${expected_snippet}"
-
 
 # MARK - Test With Template
 
 actual_snippet="$(
-"${generate_workspace_snippet_sh}" \
-  --sha256 "${sha256}" \
-  --tag "${tag}" \
-  --template "${workspace_snippet_tmpl}"
+  "${generate_workspace_snippet_sh}" \
+    --sha256 "${sha256}" \
+    --tag "${tag}" \
+    --template "${workspace_snippet_tmpl}"
 )"
 
-[[ "${actual_snippet}" =~ load.*http_archive ]] || \
+[[ "${actual_snippet}" =~ load.*http_archive ]] ||
   fail "Did not find load statement from the template."
-[[ "${actual_snippet}" =~ http_archive\( ]] || \
+[[ "${actual_snippet}" =~ http_archive\( ]] ||
   fail "Did not find http_archive statement from the utility."
-
 
 # MARK - Test Arg Checks
 
 err_output="$(
-"${generate_workspace_snippet_sh}" \
-  --sha256 "${sha256}" \
-  2>&1 || true
+  "${generate_workspace_snippet_sh}" \
+    --sha256 "${sha256}" \
+    2>&1 || true
 )"
 [[ "${err_output}" =~ Expected\ a\ tag\ value\. ]] || fail "Missing tag failure."
 
 err_output="$(
-"${generate_workspace_snippet_sh}" \
-  --tag "${tag}" \
-  --sha256 "${sha256}" \
-  --no_github_source_archive_url \
-  2>&1 || true
+  "${generate_workspace_snippet_sh}" \
+    --tag "${tag}" \
+    --sha256 "${sha256}" \
+    --no_github_source_archive_url \
+    2>&1 || true
 )"
 [[ "${err_output}" =~ Expected\ one\ or\ more\ url\ templates\. ]] || fail "Missing url template failure."
-

--- a/tests/bzlrelease_tests/tools_tests/update_readme_test.sh
+++ b/tests/bzlrelease_tests/tools_tests/update_readme_test.sh
@@ -2,27 +2,33 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Locate Deps
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../shlib/lib/assertions.sh
 source "${assertions_sh}"
 
 update_readme_sh_location=cgrindel_bazel_starlib/bzlrelease/tools/update_readme.sh
-update_readme_sh="$(rlocation "${update_readme_sh_location}")" || \
+update_readme_sh="$(rlocation "${update_readme_sh_location}")" ||
   (echo >&2 "Failed to locate ${update_readme_sh_location}" && exit 1)
-
 
 # MARK - Set up
 
@@ -30,7 +36,8 @@ export BUILD_WORKSPACE_DIRECTORY="${PWD}"
 
 tag_name="v99999.0.0"
 
-readme_content="$(cat <<-EOF
+readme_content="$(
+  cat <<-EOF
 Text before workspace snippet
 <!-- BEGIN WORKSPACE SNIPPET -->
 Text should be replaced
@@ -111,15 +118,16 @@ chmod +x "${generate_workspace_snippet_sh}"
 readme_path="${BUILD_WORKSPACE_DIRECTORY}/README.md"
 
 # Write README.md
-echo "${readme_content}" > "${readme_path}"
+echo "${readme_content}" >"${readme_path}"
 
 "${update_readme_sh}" \
   --generate_workspace_snippet "${generate_workspace_snippet_sh}" \
   --generate_module_snippet "${generate_module_snippet_sh}" \
   "${tag_name}"
 
-actual="$(< "${readme_path}")"
-expected="$(cat <<-EOF
+actual="$(<"${readme_path}")"
+expected="$(
+  cat <<-EOF
 Text before workspace snippet
 <!-- BEGIN WORKSPACE SNIPPET -->
 WORKSPACE SNIPPET CONTENT

--- a/tests/bzltidy_tests/tidy_all_test.sh
+++ b/tests/bzltidy_tests/tidy_all_test.sh
@@ -2,33 +2,39 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
 # shellcheck disable=SC1090
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Locate Deps
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../shlib/lib/assertions.sh
 source "${assertions_sh}"
 
 arrays_sh_location=cgrindel_bazel_starlib/shlib/lib/arrays.sh
-arrays_sh="$(rlocation "${arrays_sh_location}")" || \
+arrays_sh="$(rlocation "${arrays_sh_location}")" ||
   (echo >&2 "Failed to locate ${arrays_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../shlib/lib/arrays.sh
 source "${arrays_sh}"
 
-
 create_scratch_dir_sh_location=rules_bazel_integration_test/tools/create_scratch_dir.sh
-create_scratch_dir_sh="$(rlocation "${create_scratch_dir_sh_location}")" || \
+create_scratch_dir_sh="$(rlocation "${create_scratch_dir_sh_location}")" ||
   (echo >&2 "Failed to locate ${create_scratch_dir_sh_location}" && exit 1)
 
 # MARK - Functions
@@ -85,7 +91,7 @@ output_prefix_regex='\[tidy_all\]'
 # Tidy all modified workspaces, but there are none.
 assert_msg="//:tidy_modified, no modifications"
 revert_changes "${scratch_dir}"
-output="$( "${bazel}" run //:tidy_modified )"
+output="$("${bazel}" run //:tidy_modified)"
 tidy_out_files=()
 while IFS=$'\n' read -r line; do tidy_out_files+=("$line"); done < <(
   find_tidy_out_files "${scratch_dir}"
@@ -97,8 +103,8 @@ assert_match "${output_prefix_regex}"\ No\ workspaces\ to\ tidy\. "${output}" "$
 # Tidy all modified workspaces with modification in bar
 assert_msg="//:tidy_modified, modification in bar"
 revert_changes "${scratch_dir}"
-echo "# Modification" >> child_workspaces/bar/BUILD.bazel
-output="$( "${bazel}" run //:tidy_modified )"
+echo "# Modification" >>child_workspaces/bar/BUILD.bazel
+output="$("${bazel}" run //:tidy_modified)"
 tidy_out_files=()
 while IFS=$'\n' read -r line; do tidy_out_files+=("$line"); done < <(
   find_tidy_out_files "${scratch_dir}"
@@ -110,9 +116,9 @@ assert_match "${output_prefix_regex}"\ Running\ //:my_tidy\ in\ .*bar "${output}
 # Tidy all modified workspaces with modification in parent and bar
 assert_msg="//:tidy_modified, modification in parent and bar"
 revert_changes "${scratch_dir}"
-echo "# Modification" >> BUILD.bazel
-echo "# Modification" >> child_workspaces/bar/BUILD.bazel
-output="$( "${bazel}" run //:tidy_modified )"
+echo "# Modification" >>BUILD.bazel
+echo "# Modification" >>child_workspaces/bar/BUILD.bazel
+output="$("${bazel}" run //:tidy_modified)"
 tidy_out_files=()
 while IFS=$'\n' read -r line; do tidy_out_files+=("$line"); done < <(
   find_tidy_out_files "${scratch_dir}"
@@ -127,7 +133,7 @@ assert_match \
 # Tidy all all workspaces.
 assert_msg="//:tidy_all"
 revert_changes "${scratch_dir}"
-output="$( "${bazel}" run //:tidy_all )"
+output="$("${bazel}" run //:tidy_all)"
 tidy_out_files=()
 while IFS=$'\n' read -r line; do tidy_out_files+=("$line"); done < <(
   find_tidy_out_files "${scratch_dir}"

--- a/tests/bzltidy_tests/workspace/child_workspaces/bar/do_bar_tidy.sh
+++ b/tests/bzltidy_tests/workspace/child_workspaces/bar/do_bar_tidy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-cd "${BUILD_WORKSPACE_DIRECTORY}" || \
+cd "${BUILD_WORKSPACE_DIRECTORY}" ||
   (echo >&2 "BUILD_WORKSPACE_DIRECTORY not defined." && exit 1)
 
-echo "bar tidy ran" >> bar.tidy_out
+echo "bar tidy ran" >>bar.tidy_out

--- a/tests/bzltidy_tests/workspace/do_parent_tidy.sh
+++ b/tests/bzltidy_tests/workspace/do_parent_tidy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-cd "${BUILD_WORKSPACE_DIRECTORY}" || \
+cd "${BUILD_WORKSPACE_DIRECTORY}" ||
   (echo >&2 "BUILD_WORKSPACE_DIRECTORY not defined." && exit 1)
 
-echo "parent tidy ran" >> parent.tidy_out
+echo "parent tidy ran" >>parent.tidy_out

--- a/tests/markdown_tests/tools_tests/markdown_toc_tests/generate_toc_test.sh
+++ b/tests/markdown_tests/tools_tests/markdown_toc_tests/generate_toc_test.sh
@@ -2,25 +2,31 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/assertions.sh
 source "${assertions_sh}"
 
 generate_toc_location=cgrindel_bazel_starlib/markdown/tools/markdown_toc/cmd/generate_toc/generate_toc_/generate_toc
-generate_toc="$(rlocation "${generate_toc_location}")" || \
+generate_toc="$(rlocation "${generate_toc_location}")" ||
   (echo >&2 "Failed to locate ${generate_toc_location}" && exit 1)
-
 
 # MARK - Setup
 
@@ -42,21 +48,21 @@ EOF
 # MARK - Test read stdin, write stdout, default start level
 
 msg="read stdin, write stdout, default start level "
-output="$( "${generate_toc}" < "${input_file}" )"
+output="$("${generate_toc}" <"${input_file}")"
 assert_match "Heading 1" "${output}" "${msg}"
 assert_match "Heading 2" "${output}" "${msg}"
 
 # MARK - Test read stdin, write stdout, start level 2
 
 msg="read stdin, write stdout, start level 2"
-output="$( "${generate_toc}" --start-level 2 < "${input_file}" )"
+output="$("${generate_toc}" --start-level 2 <"${input_file}")"
 assert_no_match "Heading 1" "${output}" "${msg}"
 assert_match "Heading 2" "${output}" "${msg}"
 
 # MARK - Test read file, write stdout, default start level
 
 msg="read file, write stdout, default start level "
-output="$( "${generate_toc}" "${input_file}" )"
+output="$("${generate_toc}" "${input_file}")"
 assert_match "Heading 1" "${output}" "${msg}"
 assert_match "Heading 2" "${output}" "${msg}"
 
@@ -65,7 +71,7 @@ assert_match "Heading 2" "${output}" "${msg}"
 msg="read file, write stdout, default start level "
 output_file="output.md"
 "${generate_toc}" --output "${output_file}" "${input_file}"
-output="$( < "${output_file}" )"
+output="$(<"${output_file}")"
 assert_match "Heading 1" "${output}" "${msg}"
 assert_match "Heading 2" "${output}" "${msg}"
 
@@ -73,5 +79,5 @@ assert_match "Heading 2" "${output}" "${msg}"
 
 msg="invalid start level"
 fail_result=false
-"${generate_toc}" --start-level 0 < "${input_file}" || fail_result=true
+"${generate_toc}" --start-level 0 <"${input_file}" || fail_result=true
 assert_equal "true" "${fail_result}" "${msg}"

--- a/tests/markdown_tests/tools_tests/update_markdown_doc_test.sh
+++ b/tests/markdown_tests/tools_tests/update_markdown_doc_test.sh
@@ -2,31 +2,39 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Locate Deps
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../shlib/lib/assertions.sh
 source "${assertions_sh}"
 
 update_markdown_doc_sh_location=cgrindel_bazel_starlib/markdown/tools/update_markdown_doc.sh
-update_markdown_doc_sh="$(rlocation "${update_markdown_doc_sh_location}")" || \
+update_markdown_doc_sh="$(rlocation "${update_markdown_doc_sh_location}")" ||
   (echo >&2 "Failed to locate ${update_markdown_doc_sh_location}" && exit 1)
 
 # MARK - Test Using --marker Flag
 
 markdown_path="original.md"
-markdown_content="$(cat <<-EOF
+markdown_content="$(
+  cat <<-EOF
 Text before snippet
 <!-- FOO BAR: BEGIN -->
 Text should be replaced
@@ -34,15 +42,16 @@ Text should be replaced
 Text after snippet
 EOF
 )"
-echo "${markdown_content}" > "${markdown_path}"
+echo "${markdown_content}" >"${markdown_path}"
 
 update_path="update.md"
-update_content="$(cat <<-EOF
+update_content="$(
+  cat <<-EOF
 Here is some new text.
 This has 2 lines.
 EOF
 )"
-echo "${update_content}" > "${update_path}"
+echo "${update_content}" >"${update_path}"
 
 output_path="output.md"
 "${update_markdown_doc_sh}" \
@@ -50,8 +59,9 @@ output_path="output.md"
   --update "${update_path}" \
   "${markdown_path}" "${output_path}"
 
-output_content="$(< "${output_path}" )"
-expected_content="$(cat <<-'EOF'
+output_content="$(<"${output_path}")"
+expected_content="$(
+  cat <<-'EOF'
 Text before snippet
 <!-- FOO BAR: BEGIN -->
 Here is some new text.
@@ -62,11 +72,11 @@ EOF
 )"
 assert_equal "${expected_content}" "${output_content}" "Content assertion for --marker test."
 
-
 # MARK - Test Using --marker_begin and --marker_end Flags
 
 another_markdown_path="another.md"
-another_markdown_content="$(cat <<-EOF
+another_markdown_content="$(
+  cat <<-EOF
 Text before snippet
 <!-- BEGIN FOO BAR -->
 Text should be replaced
@@ -74,7 +84,7 @@ Text should be replaced
 Text after snippet
 EOF
 )"
-echo "${another_markdown_content}" > "${another_markdown_path}"
+echo "${another_markdown_content}" >"${another_markdown_path}"
 
 another_output_path="another_output.md"
 "${update_markdown_doc_sh}" \
@@ -83,8 +93,9 @@ another_output_path="another_output.md"
   --update "${update_path}" \
   "${another_markdown_path}" "${another_output_path}"
 
-another_output_content="$(< "${another_output_path}" )"
-expected_content="$(cat <<-'EOF'
+another_output_content="$(<"${another_output_path}")"
+expected_content="$(
+  cat <<-'EOF'
 Text before snippet
 <!-- BEGIN FOO BAR -->
 Here is some new text.

--- a/tests/markdown_tests/tools_tests/update_markdown_toc_test.sh
+++ b/tests/markdown_tests/tools_tests/update_markdown_toc_test.sh
@@ -2,31 +2,38 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Locate Deps
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../shlib/lib/assertions.sh
 source "${assertions_sh}"
 
 update_markdown_toc_sh_location=cgrindel_bazel_starlib/markdown/tools/update_markdown_toc.sh
-update_markdown_toc_sh="$(rlocation "${update_markdown_toc_sh_location}")" || \
+update_markdown_toc_sh="$(rlocation "${update_markdown_toc_sh_location}")" ||
   (echo >&2 "Failed to locate ${update_markdown_toc_sh_location}" && exit 1)
-
 
 # MARK - Test with Defaults
 
-markdown_content="$(cat <<-'EOF'
+markdown_content="$(
+  cat <<-'EOF'
 # Document Title
 
 ## Table of Contents
@@ -41,14 +48,15 @@ EOF
 )"
 
 markdown_path="original.md"
-echo "${markdown_content}" > "${markdown_path}"
+echo "${markdown_content}" >"${markdown_path}"
 
 output_path="output.md"
 "${update_markdown_toc_sh}" "${markdown_path}" "${output_path}"
 
-output_content="$( < "${output_path}" )"
+output_content="$(<"${output_path}")"
 
-expected_content="$(cat <<-'EOF'
+expected_content="$(
+  cat <<-'EOF'
 # Document Title
 
 ## Table of Contents
@@ -65,10 +73,10 @@ EOF
 )"
 assert_equal "${expected_content}" "${output_content}" "With defaults"
 
-
 # MARK - Test --no_remove_toc_header_entry
 
-markdown_content="$(cat <<-'EOF'
+markdown_content="$(
+  cat <<-'EOF'
 # Document Title
 
 ## Table of Contents
@@ -83,14 +91,15 @@ EOF
 )"
 
 markdown_path="original.md"
-echo "${markdown_content}" > "${markdown_path}"
+echo "${markdown_content}" >"${markdown_path}"
 
 output_path="output.md"
 "${update_markdown_toc_sh}" --no_remove_toc_header_entry "${markdown_path}" "${output_path}"
 
-output_content="$( < "${output_path}" )"
+output_content="$(<"${output_path}")"
 
-expected_content="$(cat <<-'EOF'
+expected_content="$(
+  cat <<-'EOF'
 # Document Title
 
 ## Table of Contents
@@ -108,10 +117,10 @@ EOF
 )"
 assert_equal "${expected_content}" "${output_content}" "With --no_remove_toc_header_entry"
 
-
 # MARK - Test --toc_header
 
-markdown_content="$(cat <<-'EOF'
+markdown_content="$(
+  cat <<-'EOF'
 # Document Title
 
 ## Contents
@@ -126,14 +135,15 @@ EOF
 )"
 
 markdown_path="original.md"
-echo "${markdown_content}" > "${markdown_path}"
+echo "${markdown_content}" >"${markdown_path}"
 
 output_path="output.md"
 "${update_markdown_toc_sh}" --toc_header "Contents" "${markdown_path}" "${output_path}"
 
-output_content="$( < "${output_path}" )"
+output_content="$(<"${output_path}")"
 
-expected_content="$(cat <<-'EOF'
+expected_content="$(
+  cat <<-'EOF'
 # Document Title
 
 ## Contents

--- a/tests/shlib_tests/lib_tests/arrays_tests/contains_item_sorted_test.sh
+++ b/tests/shlib_tests/lib_tests/arrays_tests/contains_item_sorted_test.sh
@@ -2,33 +2,39 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/assertions.sh
 source "${assertions_sh}"
 
 arrays_sh_location=cgrindel_bazel_starlib/shlib/lib/arrays.sh
-arrays_sh="$(rlocation "${arrays_sh_location}")" || \
+arrays_sh="$(rlocation "${arrays_sh_location}")" ||
   (echo >&2 "Failed to locate ${arrays_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/arrays.sh
 source "${arrays_sh}"
-
 
 # MARK - Even Numbered Array
 
 array=(aa ab ac ba bb bc)
 
-for item in "${array[@]}" ; do
+for item in "${array[@]}"; do
   contains_item_sorted "${item}" "${array[@]}" || fail "Expected '${item}' to be found."
 done
 
@@ -38,23 +44,21 @@ contains_item_sorted "za" "${array[@]}" && fail "Expected 'za' not to be found"
 
 array=(aa ab ac ba bb)
 
-for item in "${array[@]}" ; do
+for item in "${array[@]}"; do
   contains_item_sorted "${item}" "${array[@]}" || fail "Expected '${item}' to be found."
 done
 
 contains_item_sorted "zb" "${array[@]}" && fail "Expected 'zb' not to be found"
 
-
 # MARK - One Item Array
 
 array=(aa)
 
-for item in "${array[@]}" ; do
+for item in "${array[@]}"; do
   contains_item_sorted "${item}" "${array[@]}" || fail "Expected '${item}' to be found."
 done
 
 contains_item_sorted "zc" "${array[@]}" && fail "Expected 'zc' not to be found"
-
 
 # MARK - Empty Array
 

--- a/tests/shlib_tests/lib_tests/arrays_tests/contains_item_test.sh
+++ b/tests/shlib_tests/lib_tests/arrays_tests/contains_item_test.sh
@@ -2,23 +2,30 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/assertions.sh
 source "${assertions_sh}"
 
 arrays_sh_location=cgrindel_bazel_starlib/shlib/lib/arrays.sh
-arrays_sh="$(rlocation "${arrays_sh_location}")" || \
+arrays_sh="$(rlocation "${arrays_sh_location}")" ||
   (echo >&2 "Failed to locate ${arrays_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/arrays.sh
 source "${arrays_sh}"
@@ -33,7 +40,7 @@ contains_item az "${array[@]}" || fail "Expected 'az' to be contained in array."
 contains_item m "${array[@]}" && fail "Expected 'm' not to be contained in array."
 
 # This test will pass the shortcut, but will not find the entry
-contains_item a "${array[@]}" && fail "Expected `a` not to be contained in array."
+contains_item a "${array[@]}" && fail "Expected $(a) not to be contained in array."
 
 # If we made it this far, we want to be sure to exit success
 exit 0

--- a/tests/shlib_tests/lib_tests/arrays_tests/double_quote_items_test.sh
+++ b/tests/shlib_tests/lib_tests/arrays_tests/double_quote_items_test.sh
@@ -2,36 +2,42 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Locate Deps
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/assertions.sh
 source "${assertions_sh}"
 
 arrays_sh_location=cgrindel_bazel_starlib/shlib/lib/arrays.sh
-arrays_sh="$(rlocation "${arrays_sh_location}")" || \
+arrays_sh="$(rlocation "${arrays_sh_location}")" ||
   (echo >&2 "Failed to locate ${arrays_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/arrays.sh
 source "${arrays_sh}"
-
 
 # MARK - Test
 
 args=(a b c)
 actual=()
 while IFS=$'\n' read -r line; do actual+=("$line"); done < <(
-  double_quote_items "${args[@]}" 
+  double_quote_items "${args[@]}"
 )
 assert_equal 3 ${#actual[@]}
 assert_equal "\"a\"" "${actual[0]}"
@@ -42,7 +48,7 @@ assert_equal "\"c\"" "${actual[2]}"
 args=("hello world" "chicken smidgen" "howdy, joe")
 actual=()
 while IFS=$'\n' read -r line; do actual+=("$line"); done < <(
-  double_quote_items "${args[@]}" 
+  double_quote_items "${args[@]}"
 )
 assert_equal 3 ${#actual[@]}
 assert_equal "\"hello world\"" "${actual[0]}"

--- a/tests/shlib_tests/lib_tests/arrays_tests/join_by_test.sh
+++ b/tests/shlib_tests/lib_tests/arrays_tests/join_by_test.sh
@@ -2,23 +2,30 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/assertions.sh
 source "${assertions_sh}"
 
 arrays_sh_location=cgrindel_bazel_starlib/shlib/lib/arrays.sh
-arrays_sh="$(rlocation "${arrays_sh_location}")" || \
+arrays_sh="$(rlocation "${arrays_sh_location}")" ||
   (echo >&2 "Failed to locate ${arrays_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/arrays.sh
 source "${arrays_sh}"

--- a/tests/shlib_tests/lib_tests/arrays_tests/print_by_line_test.sh
+++ b/tests/shlib_tests/lib_tests/arrays_tests/print_by_line_test.sh
@@ -2,23 +2,30 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/assertions.sh
 source "${assertions_sh}"
 
 arrays_sh_location=cgrindel_bazel_starlib/shlib/lib/arrays.sh
-arrays_sh="$(rlocation "${arrays_sh_location}")" || \
+arrays_sh="$(rlocation "${arrays_sh_location}")" ||
   (echo >&2 "Failed to locate ${arrays_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/arrays.sh
 source "${arrays_sh}"

--- a/tests/shlib_tests/lib_tests/assertions_tests/assert_equal_test.sh
+++ b/tests/shlib_tests/lib_tests/assertions_tests/assert_equal_test.sh
@@ -5,12 +5,12 @@
 set -uo pipefail
 set +e
 f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null \
-  || source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null \
-  || source "$0.runfiles/$f" 2>/dev/null \
-  || source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null \
-  || source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null \
-  || {
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
     echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
     exit 1
   }
@@ -19,14 +19,14 @@ set -e
 # --- end runfiles.bash initialization v3 ---
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" \
-  || (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
+  (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/assertions.sh
 source "${assertions_sh}"
 
 assert_fail_sh_location=cgrindel_bazel_starlib/tests/shlib_tests/lib_tests/assertions_tests/assert_fail.sh
-assert_fail_sh="$(rlocation "${assert_fail_sh_location}")" \
-  || (echo >&2 "Failed to locate ${assert_fail_sh_location}" && exit 1)
+assert_fail_sh="$(rlocation "${assert_fail_sh_location}")" ||
+  (echo >&2 "Failed to locate ${assert_fail_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/assert_fail.sh
 source "${assert_fail_sh}"
 

--- a/tests/shlib_tests/lib_tests/assertions_tests/assert_fail.sh
+++ b/tests/shlib_tests/lib_tests/assertions_tests/assert_fail.sh
@@ -4,14 +4,14 @@ FAIL_ERR_MSGS=()
 
 fail() {
   local err_msg="${1:-Unspecified error occurred.}"
-  FAIL_ERR_MSGS+=( "${err_msg}" )
+  FAIL_ERR_MSGS+=("${err_msg}")
 }
 
 reset_fail_err_msgs() {
   FAIL_ERR_MSGS=()
 }
 
-new_fail(){
+new_fail() {
   if [[ $# -eq 0 ]]; then
     echo >&2 "Unspecified error occurred."
   else
@@ -27,6 +27,6 @@ assert_fail() {
   [[ "${FAIL_ERR_MSGS[0]}" =~ ${pattern} ]] || new_fail "Unexpected failure. Found '${FAIL_ERR_MSGS[0]}'. pattern: ${pattern}"
 }
 
-assert_no_fail(){
+assert_no_fail() {
   [[ ${#FAIL_ERR_MSGS[@]} == 0 ]] || new_fail "Expected no failures. Found ${#FAIL_ERR_MSGS[@]}." "${FAIL_ERR_MSGS[@]}"
 }

--- a/tests/shlib_tests/lib_tests/assertions_tests/assert_match_test.sh
+++ b/tests/shlib_tests/lib_tests/assertions_tests/assert_match_test.sh
@@ -2,23 +2,30 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/assertions.sh
 source "${assertions_sh}"
 
 assert_fail_sh_location=cgrindel_bazel_starlib/tests/shlib_tests/lib_tests/assertions_tests/assert_fail.sh
-assert_fail_sh="$(rlocation "${assert_fail_sh_location}")" || \
+assert_fail_sh="$(rlocation "${assert_fail_sh_location}")" ||
   (echo >&2 "Failed to locate ${assert_fail_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/assert_fail.sh
 source "${assert_fail_sh}"

--- a/tests/shlib_tests/lib_tests/assertions_tests/assert_no_match_test.sh
+++ b/tests/shlib_tests/lib_tests/assertions_tests/assert_no_match_test.sh
@@ -2,23 +2,30 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/assertions.sh
 source "${assertions_sh}"
 
 assert_fail_sh_location=cgrindel_bazel_starlib/tests/shlib_tests/lib_tests/assertions_tests/assert_fail.sh
-assert_fail_sh="$(rlocation "${assert_fail_sh_location}")" || \
+assert_fail_sh="$(rlocation "${assert_fail_sh_location}")" ||
   (echo >&2 "Failed to locate ${assert_fail_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/assert_fail.sh
 source "${assert_fail_sh}"

--- a/tests/shlib_tests/lib_tests/fail_tests/fail_test.sh
+++ b/tests/shlib_tests/lib_tests/fail_tests/fail_test.sh
@@ -5,15 +5,15 @@
 set -o nounset -o pipefail
 f=bazel_tools/tools/bash/runfiles/runfiles.bash
 # shellcheck disable=SC1090
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null \
-  || source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" \
-    | cut -f2- -d' ')" 2>/dev/null \
-  || source "$0.runfiles/$f" 2>/dev/null \
-  || source "$(grep -sm1 "^$f " "$0.runfiles_manifest" \
-    | cut -f2- -d' ')" 2>/dev/null \
-  || source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" \
-    | cut -f2- -d' ')" 2>/dev/null \
-  || {
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" |
+    cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" |
+    cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" |
+    cut -f2- -d' ')" 2>/dev/null ||
+  {
     echo >&2 "ERROR: cannot find $f"
     exit 1
   }
@@ -24,14 +24,14 @@ set -o errexit
 # MARK - Locate Deps
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" \
-  || (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
+  (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/assertions.sh
 source "${assertions_sh}"
 
 fail_sh_location=cgrindel_bazel_starlib/shlib/lib/fail.sh
-fail_sh="$(rlocation "${fail_sh_location}")" \
-  || (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
+fail_sh="$(rlocation "${fail_sh_location}")" ||
+  (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/fail.sh
 source "${fail_sh}"
 

--- a/tests/shlib_tests/lib_tests/fail_tests/show_usage_test.sh
+++ b/tests/shlib_tests/lib_tests/fail_tests/show_usage_test.sh
@@ -5,15 +5,15 @@
 set -o nounset -o pipefail
 f=bazel_tools/tools/bash/runfiles/runfiles.bash
 # shellcheck disable=SC1090
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null \
-  || source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" \
-    | cut -f2- -d' ')" 2>/dev/null \
-  || source "$0.runfiles/$f" 2>/dev/null \
-  || source "$(grep -sm1 "^$f " "$0.runfiles_manifest" \
-    | cut -f2- -d' ')" 2>/dev/null \
-  || source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" \
-    | cut -f2- -d' ')" 2>/dev/null \
-  || {
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" |
+    cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" |
+    cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" |
+    cut -f2- -d' ')" 2>/dev/null ||
+  {
     echo >&2 "ERROR: cannot find $f"
     exit 1
   }
@@ -24,14 +24,14 @@ set -o errexit
 # MARK - Locate Deps
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" \
-  || (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
+  (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/assertions.sh
 source "${assertions_sh}"
 
 fail_sh_location=cgrindel_bazel_starlib/shlib/lib/fail.sh
-fail_sh="$(rlocation "${fail_sh_location}")" \
-  || (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
+fail_sh="$(rlocation "${fail_sh_location}")" ||
+  (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/fail.sh
 source "${fail_sh}"
 

--- a/tests/shlib_tests/lib_tests/fail_tests/usage_error_test.sh
+++ b/tests/shlib_tests/lib_tests/fail_tests/usage_error_test.sh
@@ -5,15 +5,15 @@
 set -o nounset -o pipefail
 f=bazel_tools/tools/bash/runfiles/runfiles.bash
 # shellcheck disable=SC1090
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null \
-  || source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" \
-    | cut -f2- -d' ')" 2>/dev/null \
-  || source "$0.runfiles/$f" 2>/dev/null \
-  || source "$(grep -sm1 "^$f " "$0.runfiles_manifest" \
-    | cut -f2- -d' ')" 2>/dev/null \
-  || source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" \
-    | cut -f2- -d' ')" 2>/dev/null \
-  || {
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" |
+    cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" |
+    cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" |
+    cut -f2- -d' ')" 2>/dev/null ||
+  {
     echo >&2 "ERROR: cannot find $f"
     exit 1
   }
@@ -24,14 +24,14 @@ set -o errexit
 # MARK - Locate Deps
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" \
-  || (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
+  (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/assertions.sh
 source "${assertions_sh}"
 
 fail_sh_location=cgrindel_bazel_starlib/shlib/lib/fail.sh
-fail_sh="$(rlocation "${fail_sh_location}")" \
-  || (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
+fail_sh="$(rlocation "${fail_sh_location}")" ||
+  (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/fail.sh
 source "${fail_sh}"
 

--- a/tests/shlib_tests/lib_tests/fail_tests/warn_test.sh
+++ b/tests/shlib_tests/lib_tests/fail_tests/warn_test.sh
@@ -5,15 +5,15 @@
 set -o nounset -o pipefail
 f=bazel_tools/tools/bash/runfiles/runfiles.bash
 # shellcheck disable=SC1090
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null \
-  || source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" \
-    | cut -f2- -d' ')" 2>/dev/null \
-  || source "$0.runfiles/$f" 2>/dev/null \
-  || source "$(grep -sm1 "^$f " "$0.runfiles_manifest" \
-    | cut -f2- -d' ')" 2>/dev/null \
-  || source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" \
-    | cut -f2- -d' ')" 2>/dev/null \
-  || {
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" |
+    cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" |
+    cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" |
+    cut -f2- -d' ')" 2>/dev/null ||
+  {
     echo >&2 "ERROR: cannot find $f"
     exit 1
   }
@@ -24,14 +24,14 @@ set -o errexit
 # MARK - Locate Deps
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" \
-  || (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
+  (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/assertions.sh
 source "${assertions_sh}"
 
 fail_sh_location=cgrindel_bazel_starlib/shlib/lib/fail.sh
-fail_sh="$(rlocation "${fail_sh_location}")" \
-  || (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
+fail_sh="$(rlocation "${fail_sh_location}")" ||
+  (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/fail.sh
 source "${fail_sh}"
 

--- a/tests/shlib_tests/lib_tests/files_tests/upsearch_test.sh
+++ b/tests/shlib_tests/lib_tests/files_tests/upsearch_test.sh
@@ -2,23 +2,30 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/assertions.sh
 source "${assertions_sh}"
 
 files_sh_location=cgrindel_bazel_starlib/shlib/lib/files.sh
-files_sh="$(rlocation "${files_sh_location}")" || \
+files_sh="$(rlocation "${files_sh_location}")" ||
   (echo >&2 "Failed to locate ${files_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/files.sh
 source "${files_sh}"

--- a/tests/shlib_tests/lib_tests/git_tests/git_integration_test.sh
+++ b/tests/shlib_tests/lib_tests/git_tests/git_integration_test.sh
@@ -2,47 +2,54 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Locate Dependencies
 
 fail_sh_location=cgrindel_bazel_starlib/shlib/lib/fail.sh
-fail_sh="$(rlocation "${fail_sh_location}")" || \
+fail_sh="$(rlocation "${fail_sh_location}")" ||
   (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/fail.sh
 source "${fail_sh}"
 
 env_sh_location=cgrindel_bazel_starlib/shlib/lib/env.sh
-env_sh="$(rlocation "${env_sh_location}")" || \
+env_sh="$(rlocation "${env_sh_location}")" ||
   (echo >&2 "Failed to locate ${env_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/env.sh
 source "${env_sh}"
 
 setup_git_repo_sh_location=cgrindel_bazel_starlib/tests/setup_git_repo.sh
-setup_git_repo_sh="$(rlocation "${setup_git_repo_sh_location}")" || \
+setup_git_repo_sh="$(rlocation "${setup_git_repo_sh_location}")" ||
   (echo >&2 "Failed to locate ${setup_git_repo_sh_location}" && exit 1)
 
 git_sh_location=cgrindel_bazel_starlib/shlib/lib/git.sh
-git_sh="$(rlocation "${git_sh_location}")" || \
+git_sh="$(rlocation "${git_sh_location}")" ||
   (echo >&2 "Failed to locate ${git_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/git.sh
 source "${git_sh}"
 
 arrays_sh_location=cgrindel_bazel_starlib/shlib/lib/arrays.sh
-arrays_sh="$(rlocation "${arrays_sh_location}")" || \
+arrays_sh="$(rlocation "${arrays_sh_location}")" ||
   (echo >&2 "Failed to locate ${arrays_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/arrays.sh
 source "${arrays_sh}"
 
 git_exe_location=cgrindel_bazel_starlib/tools/git/git.exe
-git="$(rlocation "${git_exe_location}")" || \
+git="$(rlocation "${git_exe_location}")" ||
   (echo >&2 "Failed to locate ${git_exe_location}" && exit 1)
 
 # MARK - Setup
@@ -89,7 +96,7 @@ contains_item "3.2.1" "${release_tags[@]}" || fail "Expected tag '3.2.1' to be f
 git_tag_exists "v9999.0.0" && fail "Did not expect v9999.0.0 to exist."
 git_tag_exists "v0.1.1" || fail "Did expect v0.1.1 to exist."
 
-commit="$( get_git_commit_hash "v0.1.1" )"
+commit="$(get_git_commit_hash "v0.1.1")"
 expected_commit="fc5ed94542dc764ba17670803ca06eddafc5beb1"
-[[ "${commit}" == "${expected_commit}" ]] || \
+[[ "${commit}" == "${expected_commit}" ]] ||
   fail "Unexpected commit hash. actual: ${commit}, expected:${expected_commit}"

--- a/tests/shlib_tests/lib_tests/github_tests/get_gh_api_base_url_test.sh
+++ b/tests/shlib_tests/lib_tests/github_tests/get_gh_api_base_url_test.sh
@@ -2,29 +2,35 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Locate Dependencies
 
 fail_sh_location=cgrindel_bazel_starlib/shlib/lib/fail.sh
-fail_sh="$(rlocation "${fail_sh_location}")" || \
+fail_sh="$(rlocation "${fail_sh_location}")" ||
   (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/fail.sh
 source "${fail_sh}"
 
 github_sh_location=cgrindel_bazel_starlib/shlib/lib/github.sh
-github_sh="$(rlocation "${github_sh_location}")" || \
+github_sh="$(rlocation "${github_sh_location}")" ||
   (echo >&2 "Failed to locate ${github_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/github.sh
 source "${github_sh}"
-
 
 # MARK - Test
 
@@ -36,9 +42,8 @@ urls+=(https://github.com/cgrindel/bazel-starlib)
 urls+=(https://api.github.com/repos/cgrindel/bazel-starlib)
 
 expected="https://api.github.com/repos/cgrindel/bazel-starlib"
-for url in "${urls[@]}" ; do
-  actual="$( get_gh_api_base_url "${url}" )"
-  [[ "${actual}" == "${expected}" ]] || \
+for url in "${urls[@]}"; do
+  actual="$(get_gh_api_base_url "${url}")"
+  [[ "${actual}" == "${expected}" ]] ||
     fail "Expected base API URL not found. url: ${url}, expected: ${expected}, actual: ${actual}"
 done
-

--- a/tests/shlib_tests/lib_tests/github_tests/get_gh_auth_status_test.sh
+++ b/tests/shlib_tests/lib_tests/github_tests/get_gh_auth_status_test.sh
@@ -2,37 +2,43 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Locate Dependencies
 
 fail_sh_location=cgrindel_bazel_starlib/shlib/lib/fail.sh
-fail_sh="$(rlocation "${fail_sh_location}")" || \
+fail_sh="$(rlocation "${fail_sh_location}")" ||
   (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/fail.sh
 source "${fail_sh}"
 
 env_sh_location=cgrindel_bazel_starlib/shlib/lib/env.sh
-env_sh="$(rlocation "${env_sh_location}")" || \
+env_sh="$(rlocation "${env_sh_location}")" ||
   (echo >&2 "Failed to locate ${env_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/env.sh
 source "${env_sh}"
 
 github_sh_location=cgrindel_bazel_starlib/shlib/lib/github.sh
-github_sh="$(rlocation "${github_sh_location}")" || \
+github_sh="$(rlocation "${github_sh_location}")" ||
   (echo >&2 "Failed to locate ${github_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/github.sh
 source "${github_sh}"
 
-
 # MARK - Test
 
-result="$( get_gh_auth_status )"
+result="$(get_gh_auth_status)"
 [[ "${result}" =~ "Logged in to " ]] || fail "Expected auth status to indicate a user is logged in."

--- a/tests/shlib_tests/lib_tests/github_tests/get_gh_auth_token_test.sh
+++ b/tests/shlib_tests/lib_tests/github_tests/get_gh_auth_token_test.sh
@@ -2,27 +2,33 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 fail_sh_location=cgrindel_bazel_starlib/shlib/lib/fail.sh
-fail_sh="$(rlocation "${fail_sh_location}")" || \
+fail_sh="$(rlocation "${fail_sh_location}")" ||
   (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/fail.sh
 source "${fail_sh}"
 
 github_sh_location=cgrindel_bazel_starlib/shlib/lib/github.sh
-github_sh="$(rlocation "${github_sh_location}")" || \
+github_sh="$(rlocation "${github_sh_location}")" ||
   (echo >&2 "Failed to locate ${github_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/github.sh
 source "${github_sh}"
-
 
 # MARK - Test
 
@@ -34,6 +40,6 @@ github.com
 "
 
 expected="1234567899b95cd24c3e91d210388a28bf560b73"
-actual="$( get_gh_auth_token "${auth_status}" )"
-[[ "${actual}" == "${expected}" ]] || \
+actual="$(get_gh_auth_token "${auth_status}")"
+[[ "${actual}" == "${expected}" ]] ||
   fail "Expected auth token not found. actual: ${actual}, expected: ${expected}"

--- a/tests/shlib_tests/lib_tests/github_tests/get_gh_changelog_organized_test.sh
+++ b/tests/shlib_tests/lib_tests/github_tests/get_gh_changelog_organized_test.sh
@@ -6,12 +6,12 @@ set -uo pipefail
 set +e
 f=bazel_tools/tools/bash/runfiles/runfiles.bash
 # shellcheck disable=SC1090
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null \
-  || source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null \
-  || source "$0.runfiles/$f" 2>/dev/null \
-  || source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null \
-  || source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null \
-  || {
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
     echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
     exit 1
   }
@@ -22,26 +22,26 @@ set -e
 # MARK - Locate Dependencies
 
 fail_sh_location=cgrindel_bazel_starlib/shlib/lib/fail.sh
-fail_sh="$(rlocation "${fail_sh_location}")" \
-  || (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
+fail_sh="$(rlocation "${fail_sh_location}")" ||
+  (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/fail.sh
 source "${fail_sh}"
 
 env_sh_location=cgrindel_bazel_starlib/shlib/lib/env.sh
-env_sh="$(rlocation "${env_sh_location}")" \
-  || (echo >&2 "Failed to locate ${env_sh_location}" && exit 1)
+env_sh="$(rlocation "${env_sh_location}")" ||
+  (echo >&2 "Failed to locate ${env_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/env.sh
 source "${env_sh}"
 
 github_sh_location=cgrindel_bazel_starlib/shlib/lib/github.sh
-github_sh="$(rlocation "${github_sh_location}")" \
-  || (echo >&2 "Failed to locate ${github_sh_location}" && exit 1)
+github_sh="$(rlocation "${github_sh_location}")" ||
+  (echo >&2 "Failed to locate ${github_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/github.sh
 source "${github_sh}"
 
 setup_git_repo_sh_location=cgrindel_bazel_starlib/tests/setup_git_repo.sh
-setup_git_repo_sh="$(rlocation "${setup_git_repo_sh_location}")" \
-  || (echo >&2 "Failed to locate ${setup_git_repo_sh_location}" && exit 1)
+setup_git_repo_sh="$(rlocation "${setup_git_repo_sh_location}")" ||
+  (echo >&2 "Failed to locate ${setup_git_repo_sh_location}" && exit 1)
 
 # MARK - Setup
 
@@ -58,8 +58,8 @@ result="$(
     --tag_name "${tag_name}" \
     --previous_tag_name "${prev_tag_name}"
 )"
-[[ "${result}" =~ \*\*Full\ Changelog\*\*:\ https://github\.com/cgrindel/bazel-starlib/compare/v0\.24\.0\.\.\.v0\.25\.1 ]] \
-  || fail "Expected to find changelog URL for v0.24.0...v0.25.1. result: ${result}"
+[[ "${result}" =~ \*\*Full\ Changelog\*\*:\ https://github\.com/cgrindel/bazel-starlib/compare/v0\.24\.0\.\.\.v0\.25\.1 ]] ||
+  fail "Expected to find changelog URL for v0.24.0...v0.25.1. result: ${result}"
 
 [[ "${result}" =~ "## What's Changed" ]] || fail "No What's Changed"
 

--- a/tests/shlib_tests/lib_tests/github_tests/get_gh_changelog_test.sh
+++ b/tests/shlib_tests/lib_tests/github_tests/get_gh_changelog_test.sh
@@ -2,39 +2,45 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Locate Dependencies
 
 fail_sh_location=cgrindel_bazel_starlib/shlib/lib/fail.sh
-fail_sh="$(rlocation "${fail_sh_location}")" || \
+fail_sh="$(rlocation "${fail_sh_location}")" ||
   (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/fail.sh
 source "${fail_sh}"
 
 env_sh_location=cgrindel_bazel_starlib/shlib/lib/env.sh
-env_sh="$(rlocation "${env_sh_location}")" || \
+env_sh="$(rlocation "${env_sh_location}")" ||
   (echo >&2 "Failed to locate ${env_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/env.sh
 source "${env_sh}"
 
 github_sh_location=cgrindel_bazel_starlib/shlib/lib/github.sh
-github_sh="$(rlocation "${github_sh_location}")" || \
+github_sh="$(rlocation "${github_sh_location}")" ||
   (echo >&2 "Failed to locate ${github_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/github.sh
 source "${github_sh}"
 
 setup_git_repo_sh_location=cgrindel_bazel_starlib/tests/setup_git_repo.sh
-setup_git_repo_sh="$(rlocation "${setup_git_repo_sh_location}")" || \
+setup_git_repo_sh="$(rlocation "${setup_git_repo_sh_location}")" ||
   (echo >&2 "Failed to locate ${setup_git_repo_sh_location}" && exit 1)
-
 
 # MARK - Setup
 
@@ -46,7 +52,6 @@ cd "${repo_dir}"
 
 tag_name="v0.1.1"
 prev_tag_name="v0.1.0"
-result="$( get_gh_changelog --tag_name  "${tag_name}" --previous_tag_name "${prev_tag_name}" )"
-[[ "${result}" =~ \*\*Full\ Changelog\*\*:\ https://github\.com/cgrindel/bazel-starlib/compare/v0\.1\.0\.\.\.v0\.1\.1 ]] || \
+result="$(get_gh_changelog --tag_name "${tag_name}" --previous_tag_name "${prev_tag_name}")"
+[[ "${result}" =~ \*\*Full\ Changelog\*\*:\ https://github\.com/cgrindel/bazel-starlib/compare/v0\.1\.0\.\.\.v0\.1\.1 ]] ||
   fail "Expected to find changelog URL for v0.1.0...v0.1.1. result: ${result}"
-

--- a/tests/shlib_tests/lib_tests/github_tests/get_gh_repo_name_test.sh
+++ b/tests/shlib_tests/lib_tests/github_tests/get_gh_repo_name_test.sh
@@ -2,29 +2,35 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Locate Dependencies
 
 fail_sh_location=cgrindel_bazel_starlib/shlib/lib/fail.sh
-fail_sh="$(rlocation "${fail_sh_location}")" || \
+fail_sh="$(rlocation "${fail_sh_location}")" ||
   (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/fail.sh
 source "${fail_sh}"
 
 github_sh_location=cgrindel_bazel_starlib/shlib/lib/github.sh
-github_sh="$(rlocation "${github_sh_location}")" || \
+github_sh="$(rlocation "${github_sh_location}")" ||
   (echo >&2 "Failed to locate ${github_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/github.sh
 source "${github_sh}"
-
 
 # MARK - Test
 
@@ -36,9 +42,9 @@ urls+=(https://github.com/chicken-smidgen/bazel-starlib)
 urls+=(https://api.github.com/repos/chicken-smidgen/bazel-starlib)
 
 expected=bazel-starlib
-for (( i = 0; i < ${#urls[@]}; i++ )); do
+for ((i = 0; i < ${#urls[@]}; i++)); do
   url="${urls[$i]}"
-  actual="$( get_gh_repo_name "${url}" )"
-  [[ "${actual}" == "${expected}" ]] || \
+  actual="$(get_gh_repo_name "${url}")"
+  [[ "${actual}" == "${expected}" ]] ||
     fail "Expected name not found. url: ${url}, expected: ${expected}, actual: ${actual}"
 done

--- a/tests/shlib_tests/lib_tests/github_tests/get_gh_repo_owner_test.sh
+++ b/tests/shlib_tests/lib_tests/github_tests/get_gh_repo_owner_test.sh
@@ -2,29 +2,35 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Locate Dependencies
 
 fail_sh_location=cgrindel_bazel_starlib/shlib/lib/fail.sh
-fail_sh="$(rlocation "${fail_sh_location}")" || \
+fail_sh="$(rlocation "${fail_sh_location}")" ||
   (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/fail.sh
 source "${fail_sh}"
 
 github_sh_location=cgrindel_bazel_starlib/shlib/lib/github.sh
-github_sh="$(rlocation "${github_sh_location}")" || \
+github_sh="$(rlocation "${github_sh_location}")" ||
   (echo >&2 "Failed to locate ${github_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/github.sh
 source "${github_sh}"
-
 
 # MARK - Test
 
@@ -42,10 +48,10 @@ expected_owners+=(chicken-smidgen)
 expected_owners+=(chicken-smidgen)
 expected_owners+=(chicken-smidgen)
 
-for (( i = 0; i < ${#urls[@]}; i++ )); do
+for ((i = 0; i < ${#urls[@]}; i++)); do
   url="${urls[$i]}"
   expected="${expected_owners[$i]}"
-  actual="$( get_gh_repo_owner "${url}" )"
-  [[ "${actual}" == "${expected}" ]] || \
+  actual="$(get_gh_repo_owner "${url}")"
+  [[ "${actual}" == "${expected}" ]] ||
     fail "Expected owner not found. url: ${url}, expected: ${expected}, actual: ${actual}"
 done

--- a/tests/shlib_tests/lib_tests/github_tests/get_gh_username_test.sh
+++ b/tests/shlib_tests/lib_tests/github_tests/get_gh_username_test.sh
@@ -2,29 +2,35 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Locate Dependencies
 
 fail_sh_location=cgrindel_bazel_starlib/shlib/lib/fail.sh
-fail_sh="$(rlocation "${fail_sh_location}")" || \
+fail_sh="$(rlocation "${fail_sh_location}")" ||
   (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/fail.sh
 source "${fail_sh}"
 
 github_sh_location=cgrindel_bazel_starlib/shlib/lib/github.sh
-github_sh="$(rlocation "${github_sh_location}")" || \
+github_sh="$(rlocation "${github_sh_location}")" ||
   (echo >&2 "Failed to locate ${github_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/github.sh
 source "${github_sh}"
-
 
 # MARK - Test
 
@@ -38,6 +44,6 @@ github.com
 "
 
 expected="cgrindel"
-actual="$( get_gh_username "${auth_status}" )"
-[[ "${actual}" == "${expected}" ]] || \
+actual="$(get_gh_username "${auth_status}")"
+[[ "${actual}" == "${expected}" ]] ||
   fail "Expected username not found. actual: ${actual}, expected: ${expected}"

--- a/tests/shlib_tests/lib_tests/github_tests/is_github_repo_url_test.sh
+++ b/tests/shlib_tests/lib_tests/github_tests/is_github_repo_url_test.sh
@@ -2,29 +2,35 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Locate Dependencies
 
 fail_sh_location=cgrindel_bazel_starlib/shlib/lib/fail.sh
-fail_sh="$(rlocation "${fail_sh_location}")" || \
+fail_sh="$(rlocation "${fail_sh_location}")" ||
   (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/fail.sh
 source "${fail_sh}"
 
 github_sh_location=cgrindel_bazel_starlib/shlib/lib/github.sh
-github_sh="$(rlocation "${github_sh_location}")" || \
+github_sh="$(rlocation "${github_sh_location}")" ||
   (echo >&2 "Failed to locate ${github_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/github.sh
 source "${github_sh}"
-
 
 # MARK - Test
 
@@ -33,7 +39,7 @@ good_urls+=(git@github.com:cgrindel/bazel-starlib.git)
 good_urls+=(https://github.com/cgrindel/bazel-starlib.git)
 good_urls+=(https://github.com/cgrindel/bazel-starlib)
 
-for url in "${good_urls[@]}" ; do
+for url in "${good_urls[@]}"; do
   is_github_repo_url "${url}" || fail "Expected '${url}' to be a Github URL."
 done
 
@@ -41,7 +47,7 @@ bad_urls=()
 bad_urls+=(git@example.org:cgrindel/bazel-starlib.git)
 bad_urls+=(https://example.org/cgrindel/bazel-starlib.git)
 
-for url in "${bad_urls[@]}" ; do
+for url in "${bad_urls[@]}"; do
   is_github_repo_url "${url}" && fail "Expected '${url}' to not be a Github URL."
 done
 

--- a/tests/shlib_tests/lib_tests/messages_tests/exit_with_msg_test.sh
+++ b/tests/shlib_tests/lib_tests/messages_tests/exit_with_msg_test.sh
@@ -2,23 +2,30 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/assertions.sh
 source "${assertions_sh}"
 
 messages_sh_location=cgrindel_bazel_starlib/shlib/lib/messages.sh
-messages_sh="$(rlocation "${messages_sh_location}")" || \
+messages_sh="$(rlocation "${messages_sh_location}")" ||
   (echo >&2 "Failed to locate ${messages_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/messages.sh
 source "${messages_sh}"
@@ -31,7 +38,7 @@ exit_code=$?
 assert_equal "Unspecified error occurred." "${msg}"
 assert_equal 1 ${exit_code}
 
-msg=$(exit_with_msg --no_exit "My custom message"  2>&1)
+msg=$(exit_with_msg --no_exit "My custom message" 2>&1)
 exit_code=$?
 assert_equal "My custom message" "${msg}"
 assert_equal 1 ${exit_code}
@@ -41,7 +48,7 @@ exit_code=$?
 assert_equal "Unspecified error occurred." "${msg}"
 assert_equal 123 ${exit_code}
 
-msg=$(exit_with_msg --no_exit --exit_code 123 "My custom message"  2>&1)
+msg=$(exit_with_msg --no_exit --exit_code 123 "My custom message" 2>&1)
 exit_code=$?
 assert_equal "My custom message" "${msg}"
 assert_equal 123 ${exit_code}
@@ -50,4 +57,3 @@ msg=$(exit_with_msg --no_exit "First msg" "Second msg" 2>&1)
 exit_code=$?
 assert_equal "First msg Second msg" "${msg}"
 assert_equal 1 ${exit_code}
-

--- a/tests/shlib_tests/lib_tests/paths_tests/normalize_path_test.sh
+++ b/tests/shlib_tests/lib_tests/paths_tests/normalize_path_test.sh
@@ -2,23 +2,30 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/assertions.sh
 source "${assertions_sh}"
 
 paths_sh_location=cgrindel_bazel_starlib/shlib/lib/paths.sh
-paths_sh="$(rlocation "${paths_sh_location}")" || \
+paths_sh="$(rlocation "${paths_sh_location}")" ||
   (echo >&2 "Failed to locate ${paths_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/paths.sh
 source "${paths_sh}"

--- a/tests/shlib_tests/rules_tests/execute_binary_tests/execute_binary_no_args_test.sh
+++ b/tests/shlib_tests/rules_tests/execute_binary_tests/execute_binary_no_args_test.sh
@@ -2,23 +2,30 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/assertions.sh
 source "${assertions_sh}"
 
 my_bin_no_args_sh_location=cgrindel_bazel_starlib/tests/shlib_tests/rules_tests/execute_binary_tests/my_bin_no_args.sh
-my_bin="$(rlocation "${my_bin_no_args_sh_location}")" || \
+my_bin="$(rlocation "${my_bin_no_args_sh_location}")" ||
   (echo >&2 "Failed to locate ${my_bin_no_args_sh_location}" && exit 1)
 
 output=$("${my_bin}")

--- a/tests/shlib_tests/rules_tests/execute_binary_tests/execute_binary_with_args_test.sh
+++ b/tests/shlib_tests/rules_tests/execute_binary_tests/execute_binary_with_args_test.sh
@@ -2,23 +2,30 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/assertions.sh
 source "${assertions_sh}"
 
 my_bin_with_args_sh_location=cgrindel_bazel_starlib/tests/shlib_tests/rules_tests/execute_binary_tests/my_bin_with_args.sh
-my_bin="$(rlocation "${my_bin_with_args_sh_location}")" || \
+my_bin="$(rlocation "${my_bin_with_args_sh_location}")" ||
   (echo >&2 "Failed to locate ${my_bin_with_args_sh_location}" && exit 1)
 
 # MARK - Additional Assertions
@@ -50,10 +57,8 @@ ${output}
 "
 assert_embedded_args "${output}"
 
-
 [[ "${output}" =~ Data:\ This\ is\ a\ data\ file\. ]] || fail "Did not see data file output."
 [[ "${output}" =~ Input:\ This\ is\ an\ input\ file\. ]] || fail "Did not see input file output."
-
 
 # MARK - Test that additional arguments are passed along properly
 

--- a/tests/shlib_tests/rules_tests/execute_binary_tests/find_workspace.sh
+++ b/tests/shlib_tests/rules_tests/execute_binary_tests/find_workspace.sh
@@ -3,4 +3,7 @@
 # This utility expects to be run at the root of a Bazel workspace. It fails if
 # it is not.
 
-[[ -f "WORKSPACE" ]] || (echo >&2 "WORKSPACE not found." ; exit 1)
+[[ -f "WORKSPACE" ]] || (
+  echo >&2 "WORKSPACE not found."
+  exit 1
+)

--- a/tests/shlib_tests/rules_tests/execute_binary_tests/find_workspace_eb_test.sh
+++ b/tests/shlib_tests/rules_tests/execute_binary_tests/find_workspace_eb_test.sh
@@ -2,26 +2,33 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Locate Deps
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/assertions.sh
 source "${assertions_sh}"
 
 # tests/shlib_tests/rules_tests/execute_binary_tests
 find_workspace_eb_location=cgrindel_bazel_starlib/tests/shlib_tests/rules_tests/execute_binary_tests/find_workspace_eb.sh
-find_workspace_eb="$(rlocation "${find_workspace_eb_location}")" || \
+find_workspace_eb="$(rlocation "${find_workspace_eb_location}")" ||
   (echo >&2 "Failed to locate ${find_workspace_eb_location}" && exit 1)
 
 # MARK - Test

--- a/tests/shlib_tests/rules_tests/execute_binary_tests/my_bin.sh
+++ b/tests/shlib_tests/rules_tests/execute_binary_tests/my_bin.sh
@@ -2,20 +2,26 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Args Count
 
-
 echo "Args Count: ${#}"
-for (( i = 1; i <= ${#}; i++ )); do
+for ((i = 1; i <= ${#}; i++)); do
   echo "  ${i}: ${!i}"
 done
 
@@ -26,26 +32,26 @@ check_data_file=false
 args=()
 while (("$#")); do
   case "${1}" in
-    "--check_data_file")
-      check_data_file=true
-      shift 1
-      ;;
-    "--input")
-      input_file="${2}"
-      shift 2
-      ;;
-    *)
-      args+=("${1}")
-      shift 1
-      ;;
+  "--check_data_file")
+    check_data_file=true
+    shift 1
+    ;;
+  "--input")
+    input_file="${2}"
+    shift 2
+    ;;
+  *)
+    args+=("${1}")
+    shift 1
+    ;;
   esac
 done
 
 if [[ "${check_data_file}" == true ]]; then
   data_txt_location=cgrindel_bazel_starlib/tests/shlib_tests/rules_tests/execute_binary_tests/data.txt
-  data_txt="$(rlocation "${data_txt_location}")" || \
+  data_txt="$(rlocation "${data_txt_location}")" ||
     (echo >&2 "Failed to locate ${data_txt_location}" && exit 1)
-  echo "Data: $(< "${data_txt}")"
+  echo "Data: $(<"${data_txt}")"
 fi
 
-[[ -z "${input_file:-}" ]] || echo "Input: $(< "${input_file}")"
+[[ -z "${input_file:-}" ]] || echo "Input: $(<"${input_file}")"

--- a/tests/shlib_tests/rules_tests/execute_binary_tests/process_file.sh
+++ b/tests/shlib_tests/rules_tests/execute_binary_tests/process_file.sh
@@ -2,40 +2,46 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Locate Deps
 
 data_file_txt_location=cgrindel_bazel_starlib/tests/shlib_tests/rules_tests/execute_binary_tests/data.txt
-data_file_txt="$(rlocation "${data_file_txt_location}")" || \
+data_file_txt="$(rlocation "${data_file_txt_location}")" ||
   (echo >&2 "Failed to locate ${data_file_txt_location}" && exit 1)
 
 args=()
 while (("$#")); do
   case "${1}" in
-    "--file")
-      arg_file="${2}"
-      shift 2
-      ;;
-    *)
-      args+=("${1}")
-      shift 1
-      ;;
+  "--file")
+    arg_file="${2}"
+    shift 2
+    ;;
+  *)
+    args+=("${1}")
+    shift 1
+    ;;
   esac
 done
 
-
-data="$(< "${data_file_txt}")"
+data="$(<"${data_file_txt}")"
 echo "Data: ${data}"
 
 if [[ -n "${arg_file:-}" ]]; then
-  arg_file_data="$(< "${arg_file}")"
+  arg_file_data="$(<"${arg_file}")"
   echo "Arg File: ${arg_file_data}"
 fi

--- a/tests/shlib_tests/rules_tests/execute_binary_tests/process_file_consumer.sh
+++ b/tests/shlib_tests/rules_tests/execute_binary_tests/process_file_consumer.sh
@@ -2,41 +2,46 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Locate Deps
 
 fail_sh_location=cgrindel_bazel_starlib/shlib/lib/fail.sh
-fail_sh="$(rlocation "${fail_sh_location}")" || \
+fail_sh="$(rlocation "${fail_sh_location}")" ||
   (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/fail.sh
 source "${fail_sh}"
-
 
 # MARK - Process Args
 
 args=()
 while (("$#")); do
   case "${1}" in
-    "--process_file")
-      process_file="${2}"
-      shift 2
-      ;;
-    *)
-      args+=("${1}")
-      shift 1
-      ;;
+  "--process_file")
+    process_file="${2}"
+    shift 2
+    ;;
+  *)
+    args+=("${1}")
+    shift 1
+    ;;
   esac
 done
 
 [[ -z "${process_file:-}" ]] && fail "Expected a process_file executable"
 
 "${process_file}"
-

--- a/tests/shlib_tests/rules_tests/execute_binary_tests/process_file_consumer_eb_test.sh
+++ b/tests/shlib_tests/rules_tests/execute_binary_tests/process_file_consumer_eb_test.sh
@@ -2,31 +2,37 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"; exit 1; }; f=; set -e
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: ${BASH_SOURCE[0]} cannot find $f"
+    exit 1
+  }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 # MARK - Locate Deps
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 # shellcheck source=SCRIPTDIR/../../../../shlib/lib/assertions.sh
 source "${assertions_sh}"
 
 process_file_consumer_eb_sh_location=cgrindel_bazel_starlib/tests/shlib_tests/rules_tests/execute_binary_tests/process_file_consumer_eb.sh
-process_file_consumer_eb_sh="$(rlocation "${process_file_consumer_eb_sh_location}")" || \
+process_file_consumer_eb_sh="$(rlocation "${process_file_consumer_eb_sh_location}")" ||
   (echo >&2 "Failed to locate ${process_file_consumer_eb_sh_location}" && exit 1)
-
 
 # MARK - Test
 
-output="$( "${process_file_consumer_eb_sh}" )"
+output="$("${process_file_consumer_eb_sh}")"
 
 # Look for output from process_file.sh
 assert_match "Data: This is a data file." "${output}"

--- a/tests/tools_tests/git_tests/git_binary_test.sh
+++ b/tests/tools_tests/git_tests/git_binary_test.sh
@@ -2,25 +2,31 @@
 
 # --- begin runfiles.bash initialization v2 ---
 # Copy-pasted from the Bazel Bash runfiles library v2.
-set -o nounset -o pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+set -o nounset -o pipefail
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
 # shellcheck disable=SC1090
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -o errexit
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: cannot find $f"
+    exit 1
+  }
+f=
+set -o errexit
 # --- end runfiles.bash initialization v2 ---
 
 # MARK - Locate Deps
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 source "${assertions_sh}"
 
 git_exe_location=cgrindel_bazel_starlib/tools/git/git.exe
-git_exe="$(rlocation "${git_exe_location}")" || \
+git_exe="$(rlocation "${git_exe_location}")" ||
   (echo >&2 "Failed to locate ${git_exe_location}" && exit 1)
 
 # MARK - Test

--- a/tests/tools_tests/git_tests/git_vars_test.sh
+++ b/tests/tools_tests/git_tests/git_vars_test.sh
@@ -2,25 +2,31 @@
 
 # --- begin runfiles.bash initialization v2 ---
 # Copy-pasted from the Bazel Bash runfiles library v2.
-set -o nounset -o pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+set -o nounset -o pipefail
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
 # shellcheck disable=SC1090
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -o errexit
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$0.runfiles/$f" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+  {
+    echo >&2 "ERROR: cannot find $f"
+    exit 1
+  }
+f=
+set -o errexit
 # --- end runfiles.bash initialization v2 ---
 
 # MARK - Locate Deps
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
-assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+assertions_sh="$(rlocation "${assertions_sh_location}")" ||
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 source "${assertions_sh}"
 
 # MARK - Test
 
-if [[  -z "${GIT:-}"  ]]; then
+if [[ -z "${GIT:-}" ]]; then
   fail "GIT env var was not set."
 fi

--- a/tools/format/BUILD.bazel
+++ b/tools/format/BUILD.bazel
@@ -6,6 +6,6 @@ bzlformat_pkg(name = "bzlformat")
 format_multirun(
     name = "format",
     shell = "@aspect_rules_lint//format:shfmt",
-    # starlark = "@buildifier_prebuilt//:buildifier",
+    starlark = "@buildifier_prebuilt//:buildifier",
     visibility = ["//:__subpackages__"],
 )

--- a/tools/format/BUILD.bazel
+++ b/tools/format/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@aspect_rules_lint//format:defs.bzl", "format_multirun")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
+
+bzlformat_pkg(name = "bzlformat")
+
+format_multirun(
+    name = "format",
+    visibility = ["//:__subpackages__"],
+)

--- a/tools/format/BUILD.bazel
+++ b/tools/format/BUILD.bazel
@@ -5,5 +5,7 @@ bzlformat_pkg(name = "bzlformat")
 
 format_multirun(
     name = "format",
+    shell = "@aspect_rules_lint//format:shfmt",
+    # starlark = "@buildifier_prebuilt//:buildifier",
     visibility = ["//:__subpackages__"],
 )

--- a/updatesrc/private/update_all.sh
+++ b/updatesrc/private/update_all.sh
@@ -5,7 +5,7 @@
 
 set -o errexit -o nounset -o pipefail
 
-# Use the Bazel binary specified by the integration test. Otherise, fall back 
+# Use the Bazel binary specified by the integration test. Otherise, fall back
 # to bazel.
 bazel="${BIT_BAZEL_BINARY:-bazel}"
 
@@ -28,18 +28,18 @@ targets_to_run_before=()
 targets_to_run_after=()
 while (("$#")); do
   case "${1}" in
-    "--run_before")
-      targets_to_run_before+=( "$2" )
-      shift 2
-      ;;
-    "--run_after")
-      targets_to_run_after+=( "$2" )
-      shift 2
-      ;;
-    *)
-      args+=("${1}")
-      shift 1
-      ;;
+  "--run_before")
+    targets_to_run_before+=("$2")
+    shift 2
+    ;;
+  "--run_after")
+    targets_to_run_after+=("$2")
+    shift 2
+    ;;
+  *)
+    args+=("${1}")
+    shift 1
+    ;;
   esac
 done
 
@@ -68,8 +68,8 @@ update_targets=()
 while IFS=$'\n' read -r line; do update_targets+=("$line"); done < <(
   "${bazel}" cquery "${bazel_query}" \
     --output=starlark \
-    --starlark:file="${starlark_file}" \
-    | sort
+    --starlark:file="${starlark_file}" |
+    sort
 )
 if [[ ${#update_targets[@]} -gt 0 ]]; then
   run_bazel_targets "${update_targets[@]}"


### PR DESCRIPTION
Closes #539.

- Add `rules_lint`.
- Define `//tools/format` to run `shfmt` for shell files and `buildifier` for Starlark.
- Add alias `//:format` that references `//tools/format`.
- Ran `//:format` on the codebase.
