### PR TITLE
deps: migrate away from aspect-bazel-lib

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -36,7 +36,7 @@ bazel_dep(
 bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "rules_shell", version = "0.5.0")
 bazel_dep(name = "rules_multitool", version = "1.0.0")
-bazel_dep(name = "aspect_bazel_lib", version = "2.19.4")
+bazel_dep(name = "tar.bzl", version = "0.7.0")
 
 multitool = use_extension(
     "@rules_multitool//multitool:extension.bzl",

--- a/tools/tar/tar_toolchains.bzl
+++ b/tools/tar/tar_toolchains.bzl
@@ -1,5 +1,5 @@
 """Implementation of 'tar_toolchains' module."""
 
 tar_toolchains = struct(
-    type = "@aspect_bazel_lib//lib:tar_toolchain_type",
+    type = "@tar.bzl//tar/toolchain:type",
 )


### PR DESCRIPTION
The tar toolchain now lives in tar.bzl.
See: https://github.com/bazel-contrib/tar.bzl/pull/37.

This is a prerequisite to work on Bazel 9 since this version of `aspect_bazel_lib` still depends on `local_config_platform`, which is no longer available:


```
ERROR: /home/malte/github.com/cgrindel/bazel-starlib/release/BUILD.bazel:52:16: While resolving toolchains for target //release:archive (bbcbb1c): invalid registered toolchain '@bsd_tar_toolchains//:all': while parsing '@bsd_tar_toolchains//:all': error loading package '@@aspect_bazel_lib++toolchains+bsd_tar_toolchains//': Unable to find package for @@[unknown repo 'local_config_platform' requested from @@aspect_bazel_lib++toolchains+bsd_tar_toolchains]//:constraints.bzl: The repository '@@[unknown repo 'local_config_platform' requested from @@aspect_bazel_lib++toolchains+bsd_tar_toolchains]' could not be resolved: No repository visible as '@local_config_platform' from repository '@@aspect_bazel_lib++toolchains+bsd_tar_toolchains'.
```